### PR TITLE
Fix misuse of modes for SemiSet

### DIFF
--- a/src/Helpers/BigOp.v
+++ b/src/Helpers/BigOp.v
@@ -65,6 +65,8 @@ Proof.
   lia.
 Qed.
 
+Hint Mode SemiSet ! ! - - - - : typeclass_instances.
+
 Theorem heap_array_to_list {Σ} {A} l0 (vs: list A) (P: loc -> A -> iProp Σ) :
   ([∗ map] l↦v ∈ heap_array l0 vs, P l v) ⊣⊢
   ([∗ list] i↦v ∈ vs, P (l0 +ₗ i) v).


### PR DESCRIPTION
A wrong  instance involving `option unit` was found otherwise at ` intros ?%elem_of_singleton.`
It seems the SemiSet (in stdpp?) modes are not set correctly, as this declaration is necessary for an unambiguous typeclass resolution in the proof script below. I'd be happy if you could merge this fix here and later submit it to upstream so as to not delay https://github.com/coq/coq/pull/10858 any further. The fix should be backwards compatible of course.