### PR TITLE
|={E1,E2}_k=>^n notation makes no sense with different masks

### DIFF
--- a/src/program_logic/crash_adequacy.v
+++ b/src/program_logic/crash_adequacy.v
@@ -70,7 +70,7 @@ Qed.
 Lemma wptp_steps s k n e1 t1 κs κs' t2 σ1 σ2 Φ Φc :
   nsteps n (e1 :: t1, σ1) κs (t2, σ2) →
   state_interp σ1 (κs ++ κs') (length t1) -∗ WPC e1 @ s; k; ⊤; ⊤ {{ Φ }} {{ Φc }} -∗ wptp s k t1 -∗ NC -∗
-  |={⊤,⊤}_(3 * (S (S k)))=>^n (∃ e2 t2',
+  |={⊤}_(3 * (S (S k)))=>^n (∃ e2 t2',
     ⌜t2 = e2 :: t2'⌝ ∗
     state_interp σ2 κs' (pred (length t2)) ∗
     WPC e2 @ s; k; ⊤; ⊤ {{ Φ }} {{ Φc }} ∗ wptp s k t2' ∗
@@ -110,7 +110,7 @@ Lemma wptp_strong_adequacy Φ Φc k κs' s n e1 t1 κs t2 σ1 σ2 :
   WPC e1 @ s; k; ⊤; ⊤ {{ Φ }} {{ Φc }} -∗
   wptp s k t1 -∗
   NC -∗
-  |={⊤,⊤}_(3 * (S (S k)))=>^(S n) (∃ e2 t2',
+  |={⊤}_(3 * (S (S k)))=>^(S n) (∃ e2 t2',
     ⌜ t2 = e2 :: t2' ⌝ ∗
     ⌜ ∀ e2, s = NotStuck → e2 ∈ t2 → (is_Some (to_val e2) ∨ reducible e2 σ2) ⌝ ∗
     state_interp σ2 κs' (length t2') ∗
@@ -150,7 +150,7 @@ Lemma wptp_strong_crash_adequacy Φ Φc κs' s k n e1 t1 κs t2 σ1 σ2 :
   state_interp σ1 (κs ++ κs') (length t1) -∗
   WPC e1 @ s; k; ⊤; ⊤ {{ Φ }} {{ Φc }} -∗
   wptp s k t1 -∗
-  NC -∗ |={⊤,⊤}_(3 * S (S k))=>^(S n) |={⊤,⊤}_(S k)=> |={⊤, ∅}_(S k)=> (∃ e2 t2',
+  NC -∗ |={⊤}_(3 * S (S k))=>^(S n) |={⊤,⊤}_(S k)=> |={⊤, ∅}_(S k)=> (∃ e2 t2',
     ⌜ t2 = e2 :: t2' ⌝ ∗
     Φc ∗ state_interp σ2 κs' (length t2') ∗ C).
 Proof.

--- a/src/program_logic/recovery_adequacy.v
+++ b/src/program_logic/recovery_adequacy.v
@@ -26,14 +26,14 @@ Fixpoint step_fupdN_fresh k (ns: list nat) Hi0 (Hc0: crashG Σ) t0
   match ns with
   | [] => P Hi0 Hc0 t0
   | (n :: ns) =>
-    (|={⊤, ⊤}_k=>^(S (S n)) |={⊤, ∅}_k=> ▷
+    (|={⊤}_k=>^(S (S n)) |={⊤, ∅}_k=> ▷
      ∀ Hi' Hc', NC ={⊤}=∗ (∃ t' : pbundleG T Σ, step_fupdN_fresh k ns Hi' Hc' t' P))%I
   end.
 
 Lemma step_fupdN_fresh_snoc k (ns: list nat) n Hi0 Hc0 t0 Q:
   step_fupdN_fresh k (ns ++ [n]) Hi0 Hc0 t0 Q ≡
   step_fupdN_fresh k (ns) Hi0 Hc0 t0
-    (λ Hi Hc' _, |={⊤, ⊤}_k=>^(S (S n)) |={⊤, ∅}_k=> ▷ ∀ Hi' Hc', NC ={⊤}=∗ ∃ t', Q Hi' Hc' t')%I.
+    (λ Hi Hc' _, |={⊤}_k=>^(S (S n)) |={⊤, ∅}_k=> ▷ ∀ Hi' Hc', NC ={⊤}=∗ ∃ t', Q Hi' Hc' t')%I.
 Proof.
   apply (anti_symm (⊢)%I).
   - revert Hi0 Hc0 t0 Q.
@@ -63,8 +63,8 @@ Proof.
 Qed.
 
 Lemma step_fupdN_fresh_pattern_wand {H: invG Σ} k n (Q Q': iProp Σ):
-  (|={⊤, ⊤}_k=>^(S n) |={⊤, ∅}_k=> ▷ Q) -∗ (Q -∗ Q') -∗
-  (|={⊤, ⊤}_k=>^(S n) |={⊤, ∅}_k=> ▷ Q').
+  (|={⊤}_k=>^(S n) |={⊤, ∅}_k=> ▷ Q) -∗ (Q -∗ Q') -∗
+  (|={⊤}_k=>^(S n) |={⊤, ∅}_k=> ▷ Q').
 Proof.
   iIntros "H Hwand". simpl.
   iApply (step_fupdN_wand with "H").
@@ -90,7 +90,7 @@ Proof.
 Qed.
 
 Lemma step_fupdN_fresh_pattern_plain' {H: invG Σ} k n (Q: iProp Σ) `{!Plain Q}:
-  (|={⊤, ⊤}_k=>^(S n) |={⊤, ∅}_k=> ▷ Q) -∗
+  (|={⊤}_k=>^(S n) |={⊤, ∅}_k=> ▷ Q) -∗
   (|={⊤}=> ▷^(S (S n) * (S (S k))) Q).
 Proof.
   iIntros "H".
@@ -126,7 +126,7 @@ Fixpoint fresh_later_count k (ns: list nat) :=
 
 Lemma step_fupdN_fresh_plain `{!invPreG Σ} `{!crashPreG Σ} P `{!Plain P} k ns n:
   (∀ Hinv' Hc', NC -∗ |={⊤}=> ∃ t, step_fupdN_fresh k ns Hinv' Hc' t
-                  (λ _ _ _, |={⊤, ⊤}_k=>^(S n) |={⊤, ∅}=> P)) -∗
+                  (λ _ _ _, |={⊤}_k=>^(S n) |={⊤, ∅}=> P)) -∗
   ▷^(fresh_later_count k ns + S (S k + S n * (S (S k)))) P.
 Proof.
   iIntros "H".
@@ -164,7 +164,7 @@ Qed.
 (* XXX this probably needs to be tweaked. *)
 Lemma step_fupdN_fresh_soundness `{!invPreG Σ} `{!crashPreG Σ} (φ : Prop) k ns n:
   (∀ (Hinv : invG Σ) (Hc: crashG Σ), NC -∗ (|={⊤}=> (∃ t0, step_fupdN_fresh k ns Hinv Hc t0
-                             (λ _ _ _, |={⊤, ⊤}_k=>^(S (S n)) |={⊤, ∅}=> ▷ ⌜φ⌝)))%I) →
+                             (λ _ _ _, |={⊤}_k=>^(S (S n)) |={⊤, ∅}=> ▷ ⌜φ⌝)))%I) →
   φ.
 Proof.
   intros Hiter.
@@ -186,7 +186,7 @@ Lemma wptp_recv_strong_normal_adequacy Φ Φinv Φr κs' s k Hi Hc t n ns r1 e1 
   wpr s k Hi Hc t ⊤ e1 r1 Φ Φinv Φr -∗
   wptp s k t1 -∗ NC -∗ step_fupdN_fresh (3 * (S (S k))) ns Hi Hc t (λ Hi' Hc' t',
     ⌜ Hi' = Hi ∧ Hc' = Hc ∧ t' = t ⌝ ∗
-    (|={⊤, ⊤}_(3 * (S (S k)))=>^(S n) ∃ e2 t2',
+    (|={⊤}_(3 * (S (S k)))=>^(S n) ∃ e2 t2',
     ⌜ t2 = e2 :: t2' ⌝ ∗
     ⌜ ∀ e2, s = NotStuck → e2 ∈ t2 → (is_Some (to_val e2) ∨ reducible e2 σ2) ⌝ ∗
     state_interp σ2 κs' (length t2') ∗
@@ -214,7 +214,7 @@ Lemma wptp_recv_strong_crash_adequacy Φ Φinv Φinv' Φr κs' s k Hi Hc t ns n 
   wpr s k Hi Hc t ⊤ e1 r1 Φ Φinv Φr -∗
   □ (∀ Hi' t', Φinv Hi' t' -∗ □ Φinv' Hi' t') -∗
   wptp s k t1 -∗ NC -∗ step_fupdN_fresh (3 * (S (S k))) ns Hi Hc t (λ Hi' Hc' t',
-    (|={⊤, ⊤}_(3 * (S (S k)))=>^(S (S n)) ∃ e2 t2',
+    (|={⊤}_(3 * (S (S k)))=>^(S (S n)) ∃ e2 t2',
     ⌜ t2 = e2 :: t2' ⌝ ∗
     ⌜ ∀ e2, s = NotStuck → e2 ∈ t2 → (is_Some (to_val e2) ∨ reducible e2 σ2) ⌝ ∗
     state_interp σ2 κs' (length t2') ∗
@@ -284,7 +284,7 @@ Lemma wptp_recv_strong_adequacy Φ Φinv Φinv' Φr κs' s k Hi Hc t ns n r1 e1 
   wpr s k Hi Hc t ⊤ e1 r1 Φ Φinv Φr -∗
   □ (∀ Hi' t', Φinv Hi' t' -∗ □ Φinv' Hi' t') -∗
   wptp s k t1 -∗ NC -∗ step_fupdN_fresh (3 * (S (S k))) ns Hi Hc t (λ Hi' Hc' t',
-    (|={⊤, ⊤}_(3 * (S (S k)))=>^(S (S n)) ∃ e2 t2',
+    (|={⊤}_(3 * (S (S k)))=>^(S (S n)) ∃ e2 t2',
     ⌜ t2 = e2 :: t2' ⌝ ∗
     ⌜ ∀ e2, s = NotStuck → e2 ∈ t2 → (is_Some (to_val e2) ∨ reducible e2 σ2) ⌝ ∗
     state_interp σ2 κs' (length t2') ∗

--- a/src/program_logic/step_fupd_extra.v
+++ b/src/program_logic/step_fupd_extra.v
@@ -10,10 +10,10 @@ Notation "|={ E1 , E2 }_ k => P" :=
        format "|={ E1 , E2 }_ k =>  P").
 
 
-Notation "|={ E1 , E2 }_ k =>^ n P" :=
-    (Nat.iter n (λ Q, (|={E1, ∅}=> |={∅, ∅}▷=>^k |={∅, E2}=> Q)) P)%I
-      (at level 99, E1, E2 at level 50, k, n at level 9, P at level 200,
-       format "|={ E1 , E2 }_ k =>^ n  P").
+Notation "|={ E }_ k =>^ n P" :=
+    (Nat.iter n (λ Q, (|={E%I, ∅}=> |={∅, ∅}▷=>^k |={∅, E}=> Q)) P)%I
+      (at level 99, E at level 50, k, n at level 9, P at level 200,
+       format "|={ E }_ k =>^ n  P").
 
 
 Section step_fupdN.
@@ -137,9 +137,9 @@ Lemma step_fupdN_innerN_wand E1 E2 k1 k2 n1 n2 (P Q: PROP):
   E2 ⊆ E1 →
   k2 ≤ k1 →
   n2 ≤ n1 →
-  (|={E2,E2}_k2=>^n2 P) -∗
+  (|={E2}_k2=>^n2 P) -∗
   (P -∗ Q) -∗
-  (|={E1,E1}_k1=>^n1 Q).
+  (|={E1}_k1=>^n1 Q).
 Proof using HAff.
   iIntros (?? Hle) "HP HPQ".
   iInduction Hle as [] "IH".
@@ -172,10 +172,10 @@ Proof using HAff.
   by iApply "HPQ".
 Qed.
 
-Lemma step_fupdN_innerN_wand' E1 E2 k n (P Q: PROP):
-  (|={E1,E2}_k=>^n P) -∗
+Lemma step_fupdN_innerN_wand' E k n (P Q: PROP):
+  (|={E}_k=>^n P) -∗
   (P -∗ Q) -∗
-  |={E1,E2}_k=>^n Q.
+  |={E}_k=>^n Q.
 Proof using HAff.
   iIntros "HP HPQ". iInduction n as [| n] "IH".
   - rewrite //=. by iApply "HPQ".
@@ -183,9 +183,9 @@ Proof using HAff.
     iIntros; by iApply ("IH" with "[$] [$]").
 Qed.
 
-Lemma step_fupdN_innerN_S_fupd E1 E2 k n (P: PROP):
-  (|={E1,E2}_k=>^(S n) |={E2}=> P) -∗
-  (|={E1,E2}_k=>^(S n) P).
+Lemma step_fupdN_innerN_S_fupd E k n (P: PROP):
+  (|={E}_k=>^(S n) |={E}=> P) -∗
+  (|={E}_k=>^(S n) P).
 Proof using HAff.
   rewrite !Nat_iter_S_r.
   iIntros "H". iApply (step_fupdN_innerN_wand' with "H").
@@ -247,7 +247,7 @@ Qed.
 Lemma step_fupdN_innerN_plain `{BP: BiPlainly PROP} `{@BiFUpdPlainly PROP H BP}
       (k n: nat) (P: PROP) :
   Plain P →
-  ⊢ (|={⊤, ⊤}_k=>^n P) -∗
+  ⊢ (|={⊤}_k=>^n P) -∗
   |={⊤}=> ▷^(n * (S k)) P.
 Proof using HAff.
   iIntros (HPlain).


### PR DESCRIPTION
|={E1,E2}_k=>^n notation makes no sense with different masks, so force them to be the same.

I'm still new here so I figured I'd better make this a PR. ;)
@jtassarotti @tchajed do you get notifications for PRs?