### PR TITLE
inode, alloc: consistently keep P below one level of later

### DIFF
--- a/src/goose_lang/lib/lock/crash_lock.v
+++ b/src/goose_lang/lib/lock/crash_lock.v
@@ -73,7 +73,7 @@ Section proof.
   Lemma alloc_crash_lock k k' E Φ Φc e γ lk (R Rcrash : iProp Σ):
     (k' < k)%nat →
     □ (R -∗ Rcrash) ∗
-    R ∗
+    ▷ R ∗
     is_free_lock γ lk ∗
     (is_crash_lock (LVL k') γ #lk R Rcrash -∗
           WPC e @ (LVL k); ⊤; E {{ Φ }} {{ Rcrash -∗ Φc }}) -∗
@@ -109,8 +109,8 @@ Section proof.
     language.to_val e = None →
     crash_locked (LVL k') Γ lk R Rcrash -∗
     Φc ∧ (R -∗
-         WPC e @ LVL k; (E1 ∖ ↑Ncrash); ∅ {{ λ v, (crash_locked (LVL k') Γ lk R Rcrash -∗ (Φc ∧ Φ v)) ∗ R }}
-                                         {{ Φc ∗ Rcrash }}) -∗
+         WPC e @ LVL k; (E1 ∖ ↑Ncrash); ∅ {{ λ v, (crash_locked (LVL k') Γ lk R Rcrash -∗ (Φc ∧ Φ v)) ∗ ▷ R }}
+                                         {{ Φc ∗ ▷ Rcrash }}) -∗
     WPC e @  (LVL (S (S k))); E1; E2 {{ Φ }} {{ Φc }}.
   Proof.
     iIntros (???) "Hcrash_locked H".
@@ -150,7 +150,7 @@ Section proof.
     (S k < k')%nat →
     to_val e = None →
     is_crash_lock (LVL k') γ lk R Rcrash ∗
-    (Φc ∧ (R -∗ WPC e @ (LVL k); (⊤ ∖ ↑Ncrash); ∅ {{ λ v, (Φc ∧ Φ #()) ∗ R }} {{ Φc ∗ Rcrash }})) -∗
+    (Φc ∧ (R -∗ WPC e @ (LVL k); (⊤ ∖ ↑Ncrash); ∅ {{ λ v, (Φc ∧ Φ #()) ∗ ▷ R }} {{ Φc ∗ ▷ Rcrash }})) -∗
     WPC (with_lock lk e) @ (LVL (S (S k))) ; ⊤; E {{ Φ }} {{ Φc }}.
   Proof.
     iIntros (??) "(#Hcrash&Hwp)".

--- a/src/goose_lang/lib/lock/lock.v
+++ b/src/goose_lang/lib/lock/lock.v
@@ -76,7 +76,7 @@ Section proof.
     val_ty.
   Qed.
 
-  Theorem alloc_lock E γ l R : is_free_lock γ l -∗ R ={E}=∗ is_lock γ #l R.
+  Theorem alloc_lock E γ l R : is_free_lock γ l -∗ ▷ R ={E}=∗ is_lock γ #l R.
   Proof.
     iIntros "(Hγ&Hl) HR".
     iMod (inv_alloc N _ (lock_inv γ l R) with "[Hl HR Hγ]") as "#?".
@@ -97,7 +97,7 @@ Section proof.
   Qed.
 
   Lemma newlock_spec E (R : iProp Σ):
-    {{{ R }}} lock.new #() @ E {{{ lk γ, RET lk; is_lock γ lk R }}}.
+    {{{ ▷ R }}} lock.new #() @ E {{{ lk γ, RET lk; is_lock γ lk R }}}.
   Proof using ext_tys.
     iIntros (Φ) "HR HΦ". rewrite -wp_fupd /lock.new /=.
     wp_lam. wp_apply wp_alloc_untyped; first by auto.
@@ -138,7 +138,7 @@ Section proof.
 
   Lemma release_spec' E γ lk R :
     ↑N ⊆ E →
-    {{{ is_lock γ lk R ∗ locked γ ∗ R }}} lock.release lk @ E {{{ RET #(); True }}}.
+    {{{ is_lock γ lk R ∗ locked γ ∗ ▷ R }}} lock.release lk @ E {{{ RET #(); True }}}.
   Proof.
     iIntros (? Φ) "(Hlock & Hlocked & HR) HΦ".
     iDestruct "Hlock" as (l ->) "#Hinv".
@@ -157,7 +157,7 @@ Section proof.
   Qed.
 
   Lemma release_spec γ lk R :
-    {{{ is_lock γ lk R ∗ locked γ ∗ R }}} lock.release lk {{{ RET #(); True }}}.
+    {{{ is_lock γ lk R ∗ locked γ ∗ ▷ R }}} lock.release lk {{{ RET #(); True }}}.
   Proof. eapply release_spec'; auto. Qed.
 
   (** cond var proofs *)

--- a/src/program_logic/na_crash_inv.v
+++ b/src/program_logic/na_crash_inv.v
@@ -62,14 +62,15 @@ Proof. crash_unseal. iMod (staged_inv_init) as (Γ) "H". iExists Γ. iFrame "H".
 Lemma na_crash_inv_alloc Γ N k E P Q:
   ↑N ⊆ E →
   na_crash_inv Γ N k -∗
-  ▷ Q -∗ □ (Q -∗ P) ={E}=∗
+  ▷ Q -∗ ▷ □ (Q -∗ P) ={E}=∗
   ∃ i, na_crash_bundle Γ N k Q {[i]} ∗ na_crash_val Γ P {[i]} ∗ na_crash_pending Γ N k P.
 Proof.
   crash_unseal.
   iIntros (?) "#Hinv HQ #HQP".
   iMod (staged_inv_alloc Γ N k E (⊤ ∖ ↑N) P Q True%I with "[HQ]") as (i') "(Hbundle&#Hval&Hpend)".
   { auto. }
-  { iFrame "#". iFrame. iAlways; iIntros; eauto. rewrite right_id. iApply "HQP"; eauto. }
+  { iFrame "#". iFrame. iAlways; iIntros; eauto. iSplitL; last done.
+    iApply "HQP"; eauto. }
   iModIntro. iExists i'. iFrame "#".
   iSplitL "Hbundle".
   - iExists _. iFrame.
@@ -99,8 +100,8 @@ Lemma wpc_na_crash_inv_open_modify Γ Qnew s k k' E1 E2 e Φ Φc Q P bset N :
   na_crash_bundle Γ N (LVL k') Q bset -∗
   na_crash_val Γ P bset -∗
   (Φc ∧ (Q -∗ WPC e @ NotStuck; (LVL k); (E1 ∖ ↑N); ∅
-                    {{λ v, Qnew v ∗ □ (Qnew v -∗ P)  ∗ (na_crash_bundle Γ N (LVL k') (Qnew v) bset -∗ (Φc ∧ Φ v))}}
-                    {{ Φc ∗ P }})) -∗
+                    {{λ v, ▷ Qnew v ∗ ▷ □ (Qnew v -∗ P)  ∗ (na_crash_bundle Γ N (LVL k') (Qnew v) bset -∗ (Φc ∧ Φ v))}}
+                    {{ Φc ∗ ▷ P }})) -∗
   WPC e @ s; LVL (S (S k)); E1; E2 {{ Φ }} {{ Φc }}.
 Proof.
   crash_unseal.
@@ -127,8 +128,8 @@ Lemma wpc_na_crash_inv_open Γ s k k' E1 E2 e Φ Φc Q P bset N:
   na_crash_bundle Γ N (LVL k') Q bset -∗
   na_crash_val Γ P bset -∗
   (Φc ∧ (Q -∗ WPC e @ NotStuck; (LVL k); (E1 ∖ ↑N); ∅
-                    {{λ v, Q ∗ □ (Q -∗ P) ∗ (na_crash_bundle Γ N (LVL k') Q bset -∗ (Φc ∧ Φ v))}}
-                    {{ Φc ∗ P }})) -∗
+                    {{λ v, ▷ Q ∗ ▷ □ (Q -∗ P) ∗ (na_crash_bundle Γ N (LVL k') Q bset -∗ (Φc ∧ Φ v))}}
+                    {{ Φc ∗ ▷ P }})) -∗
   WPC e @ s; LVL (S (S k)); E1; E2 {{ Φ }} {{ Φc }}.
 Proof.
   iIntros (???) "H1 H2 Hwp". iApply (wpc_na_crash_inv_open_modify with "[$] [$]"); auto.
@@ -203,7 +204,7 @@ Proof.
   iApply ("H" with "[HQ]").
   iDestruct "HQ" as "[(HQ&Hclo)|(?&HC&Hclo)]".
   - iLeft. iFrame. iIntros (Q') "(HQ'&#Hwand')". iMod ("Hclo" $! Q' True%I false with "[HQ']") as "H".
-    { iFrame. iAlways. iIntros. rewrite right_id. by iApply "Hwand'". }
+    { iFrame. iAlways. iIntros. iSplitL; last done. by iApply "Hwand'". }
     iModIntro. iExists _. iFrame "H Hinv Hwand'".
   - iRight. iFrame. iMod "Hclo". iModIntro. iExists _. iFrame. iFrame "#".
 Qed.

--- a/src/program_logic/staged_invariant.v
+++ b/src/program_logic/staged_invariant.v
@@ -58,15 +58,15 @@ Definition bunch_wf k E E' (Ps Pr Qc: nat → iProp Σ) i bunch :=
      own γ (● Excl' (b, (γprop_stored, γprop_remainder))) ∗
      saved_prop_own γprop_stored (Ps i) ∗
      saved_prop_own γprop_remainder (Pr i) ∗
-     □ (C -∗ (Ps i) -∗ if b then |={E, E'}_k=> ([∗ set] j∈bunch, (Qc j)) ∗ (Pr i)
-                            else ([∗ set] j∈bunch, (Qc j)) ∗ (Pr i)))%I.
+     □ (C -∗ Ps i -∗ if b then |={E, E'}_k=> ([∗ set] j∈bunch, ▷ Qc j) ∗ (▷ Pr i)
+                            else ([∗ set] j∈bunch, ▷ Qc j) ∗ (▷ Pr i)))%I.
 
 Definition bunches_wf k E E' σ (Ps Pr Qc: nat → iProp Σ) :=
   ([∗ map] i↦bunch ∈ σ, bunch_wf k E E' Ps Pr Qc i bunch)%I.
 
 Definition bunch_live (Ps: nat → iProp Σ) i := Ps i.
 Definition bunch_crashed (Pr Qc: nat → iProp Σ) i bunch :=
-  (C ∗ Pr i ∗ ([∗ set] j ∈ bunch, Qc j ∨ (∃ γ, meta (hG := sghG) j pN γ ∗ staged_done γ)))%I.
+  (C ∗ ▷ Pr i ∗ ([∗ set] j ∈ bunch, ▷ Qc j ∨ (∃ γ, meta (hG := sghG) j pN γ ∗ staged_done γ)))%I.
 
 (*
 Definition inv_crashed (σ: gmap nat (gset nat)) (Pr Qc: nat → iProp Σ) :=
@@ -104,7 +104,7 @@ Definition staged_bundle (Q Q': iProp Σ) b (bundle: gset nat) : iProp Σ :=
       mapsto (hG := sphG) i 1 bundle ∗
       meta (hG := sphG) i bN γ ∗
       own γ (◯ Excl' (b, (γprop, γprop'))) ∗
-      ▷▷ (□ (Qalt -∗ Q)) ∗ ▷▷ (□ (Qalt' -∗ Q')) ∗
+      ▷ (□ (▷ Qalt -∗ ▷ Q)) ∗ ▷ (□ (▷ Qalt' -∗ ▷ Q')) ∗
       saved_prop_own γprop Qalt ∗
       saved_prop_own γprop' Qalt').
 
@@ -115,7 +115,7 @@ Definition staged_crash (i: nat) (P: iProp Σ) : iProp Σ :=
 
 Definition staged_crash (P: iProp Σ) s : iProp Σ :=
   (∃ Ps, ([∗ set] i ∈ s, ∃ γ, meta (hG := sghG) i cN γ ∗ saved_prop_own γ (Ps i)) ∗
-         □ (P -∗ ([∗ set] i ∈ s, Ps i))).
+         □ (▷ P -∗ ([∗ set] i ∈ s, ▷ Ps i))).
 
 Definition staged_crash_pending (P: iProp Σ) i : iProp Σ :=
   (mapsto (hG := sghG) i 1 ()) ∗
@@ -127,8 +127,8 @@ Definition bunch_wf_later k E E' (Ps Pr Qc: nat → iProp Σ) i bunch :=
      own γ (● Excl' (b, (γprop_stored, γprop_remainder))) ∗
      ▷ saved_prop_own γprop_stored (Ps i) ∗
      ▷ saved_prop_own γprop_remainder (Pr i) ∗
-     ▷ □ (C -∗ (Ps i) -∗ if b then |={E, E'}_k=> ([∗ set] j∈bunch, (Qc j)) ∗ (Pr i)
-                         else ([∗ set] j ∈ bunch, Qc j) ∗ (Pr i)))%I.
+     ▷ □ (C -∗ Ps i -∗ if b then |={E, E'}_k=> ([∗ set] j∈bunch, ▷ Qc j) ∗ (▷ Pr i)
+                         else ([∗ set] j ∈ bunch, ▷ Qc j) ∗ (▷ Pr i)))%I.
 
 Definition bunches_wf_later k E E' σ (Ps Pr Qc: nat → iProp Σ) :=
   ([∗ map] i↦bunch ∈ σ, bunch_wf_later k E E' Ps Pr Qc i bunch)%I.
@@ -154,8 +154,8 @@ Lemma bunches_wf_pers_lookup k E E' σ Ps Pr Qc i s γ (b: bool) γprop_stored �
   bunches_wf k E E' σ Ps Pr Qc -∗
      saved_prop_own γprop_stored (Ps i) ∗
      saved_prop_own γprop_remainder (Pr i) ∗
-     □ (C -∗ (Ps i) -∗ if b then |={E, E'}_k=> ([∗ set] j∈s, (Qc j)) ∗ (Pr i)
-                            else ([∗ set] j∈s, (Qc j)) ∗ (Pr i))%I.
+     □ (C -∗ Ps i -∗ if b then |={E, E'}_k=> ([∗ set] j∈s, ▷ Qc j) ∗ (▷ Pr i)
+                            else ([∗ set] j∈s, ▷ Qc j) ∗ (▷ Pr i))%I.
 Proof.
   iIntros (?) "#Hm Hown Hbunch".
   rewrite /bunches_wf.
@@ -173,8 +173,8 @@ Lemma bunches_wf_later_pers_lookup k E E' σ Ps Pr Qc i s γ (b: bool) γprop_st
   ▷ bunches_wf k E E' σ Ps Pr Qc -∗
      ▷ (saved_prop_own γprop_stored (Ps i) ∗
         saved_prop_own γprop_remainder (Pr i) ∗
-        □ (C -∗ (Ps i) -∗ if b then |={E, E'}_k=> ([∗ set] j∈s, (Qc j)) ∗ (Pr i)
-                            else ([∗ set] j∈s, (Qc j)) ∗ (Pr i)))%I.
+        □ (C -∗ Ps i -∗ if b then |={E, E'}_k=> ([∗ set] j∈s, ▷ Qc j) ∗ (▷ Pr i)
+                            else ([∗ set] j∈s, ▷ Qc j) ∗ (▷ Pr i)))%I.
 Proof.
   iIntros. iNext. iApply (bunches_wf_pers_lookup with "[$] [$] [$]"); eauto.
 Qed.
@@ -185,8 +185,8 @@ Lemma bunches_wf_later_pers_lookup_weak k E E' σ Ps Pr Qc i s:
      ▷ ∃ (b: bool) γprop_stored γprop_remainder,
          (saved_prop_own γprop_stored (Ps i) ∗
         saved_prop_own γprop_remainder (Pr i) ∗
-        □ (C -∗ (Ps i) -∗ if b then |={E, E'}_k=> ([∗ set] j∈s, (Qc j)) ∗ (Pr i)
-                            else ([∗ set] j∈s, (Qc j)) ∗ (Pr i)))%I.
+        □ (C -∗ Ps i -∗ if b then |={E, E'}_k=> ([∗ set] j∈s, ▷ Qc j) ∗ (▷ Pr i)
+                            else ([∗ set] j∈s, ▷ Qc j) ∗ (▷ Pr i)))%I.
 Proof.
   iIntros (?) "Hbunch". iNext.
   rewrite /bunches_wf.
@@ -247,7 +247,7 @@ Qed.
 Lemma staged_inv_alloc N k E E' P Q Qr:
   ↑N ⊆ E →
   staged_inv N k E' E' ∗
-  ▷ Q ∗ □ (C -∗ Q -∗ P ∗ Qr) ={E}=∗
+  ▷ Q ∗ □ (C -∗ ▷ Q -∗ ▷ P ∗ ▷ Qr) ={E}=∗
   ∃ i, staged_bundle Q Qr false {[i]} ∗ staged_crash P {[i]} ∗ staged_crash_pending P i.
 Proof.
   iIntros (?) "(Hinv&HQ&#HQP)".
@@ -299,7 +299,8 @@ Proof.
         iFrame "#".
         iAlways. iIntros.
         rewrite big_opS_singleton.
-        rewrite decide_True //. by iApply "HQP".
+        rewrite decide_True //.
+        by iApply "HQP".
       }
       iApply (big_sepM_mono with "Hbunch_wf").
       { iIntros (k' [] ?) "H".
@@ -348,8 +349,8 @@ Proof.
   iSplitL "Hbundle H2".
   { iExists _, _, _, _, Q, Qr. iFrame. iFrame "#".
     iSplitL.
-    - iIntros "!> !> !> $".
-    - iIntros "!> !> !> $".
+    - iIntros "!> !> $".
+    - iIntros "!> !> $".
   }
   iSplitL "".
   { iExists _. rewrite ?big_sepS_singleton. iFrame "#".
@@ -373,10 +374,10 @@ Proof.
   iDestruct "H" as (i γ γprop γprop' Qalt Qalt') "(Hbundle&Hmeta&Hown&#Hequiv1&#Hequiv2&Hsaved1&Hsaved2)".
   iExists i, γ, γprop, γprop', Qalt, Qalt'; iFrame.
   iSplitL "Hequiv1".
-  - iIntros "!> !> !> H".
+  - iIntros "!> !> H".
     iDestruct ("Hequiv1" with "H") as "H".
     iApply "HQ12"; auto.
-  - iIntros "!> !> !> H".
+  - iIntros "!> !> H".
     iDestruct ("Hequiv2" with "H") as "H".
     iApply "HQ12'"; auto.
 Qed.
@@ -463,7 +464,7 @@ Lemma staged_inv_weak_open E N k E1 P i:
   E1 ⊆ E ∖ ↑N →
   staged_inv N k E1 E1 ∗
   staged_crash_pending P i ∗
-  C -∗ |={E,E}_(S (S k))=> P.
+  C -∗ |={E,E}_(S (S k))=> ▷ P.
 Proof.
   iIntros (??) "(#Hinv&(Hpts&Hpending&Hsaved)&#HC)".
   iInv "Hinv" as "H" "Hclo".
@@ -484,7 +485,9 @@ Proof.
   iDestruct (later_or with "Hstatus") as "Hstatus".
   iMod (fupd_intro_mask' _ E1) as "Hclo_E"; first auto.
   iMod (fupd_intro_mask' _ (∅)) as "Hclo_E1"; first by set_solver.
-  iModIntro. rewrite Nat_iter_S. iModIntro. iNext. rewrite Nat_iter_S. do 2 iModIntro. iNext.
+  iModIntro. rewrite Nat_iter_S. iModIntro. iNext.
+  iEval (rewrite (lock bunch_crashed)) in "Hstatus". (* protect against ▷-stripping *)
+  rewrite Nat_iter_S. do 2 iModIntro. iNext. rewrite -lock.
   iDestruct "Hstatus" as "[Hlive|(_&Hcrashed)]".
   - rewrite /bunch_live.
     iSpecialize ("Hwand" with "[$] [$]").
@@ -547,7 +550,7 @@ Proof.
       iMod (pending_upd_done with "[$]") as "Hdone".
      iSpecialize ("Hstatus_rest" with "[HQsr HPcs Hdone]").
      {
-       iRight. iNext. rewrite /bunch_crashed. iFrame. iFrame "#".
+       iRight. rewrite /bunch_crashed. iFrame. iFrame "#".
        iApply big_sepS_delete; first eassumption.
        iSplitL "Hdone".
        {
@@ -592,12 +595,12 @@ Proof.
 
   iMod (bunches_wf_to_later with "Hbunch_wf") as "Hbunch_wf".
 
-  set (Qs' := (λ k, if decide (k = bid1) then (Qs bid1 ∗ Qs bid2)%I else
-                    if decide (k = bid2) then True%I else
-                    Qs k)).
-  set (Qsr' := (λ k, if decide (k = bid1) then (Qsr bid1 ∗ Qsr bid2)%I else
-                    if decide (k = bid2) then True%I else
-                    Qsr k)).
+  set (Qs' := (λ k, if decide (k = bid1) then (Qs bid1 ∗ Qs bid2) else
+                    if decide (k = bid2) then True else
+                    Qs k)%I).
+  set (Qsr' := (λ k, if decide (k = bid1) then (Qsr bid1 ∗ Qsr bid2) else
+                    if decide (k = bid2) then True else
+                    Qsr k)%I).
   iAssert (|==> bunches_wf_later k E' E' (<[bid2:=∅]> (<[bid1:=s1 ∪ s2]> σ)) Qs' Qsr' Pc ∗
                 ▷ saved_prop_own γprop1 (Qs bid1) ∗
                 ▷ saved_prop_own γprop1' (Qsr bid1) ∗
@@ -605,8 +608,8 @@ Proof.
                 ▷ saved_prop_own γprop2' (Qsr bid2) ∗
                 own γ1 (◯ Excl' (false, (γprop1_new, γprop1'_new))) ∗
                 own γ2 (◯ Excl' (false, (γprop2_new, γprop2'_new))) ∗
-                ▷ □ (C -∗ Qs bid1 -∗ ([∗ set] j ∈ s1, Pc j) ∗ Qsr bid1) ∗
-                ▷ □ (C -∗ Qs bid2 -∗ ([∗ set] j ∈ s2, Pc j) ∗ Qsr bid2))%I with "[Hbunch_wf Hown1 Hown2]"
+                ▷ □ (C -∗ Qs bid1 -∗ ([∗ set] j ∈ s1, ▷ Pc j) ∗ ▷ Qsr bid1) ∗
+                ▷ □ (C -∗ Qs bid2 -∗ ([∗ set] j ∈ s2, ▷ Pc j) ∗ ▷ Qsr bid2))%I with "[Hbunch_wf Hown1 Hown2]"
          as ">(Hbunches&#Hsaved1'&#Hsavedr1'&#Hsaved2'&#Hsavedr2'&Hown1&Hown2&#Hwand1&#Hwand2)".
   { rewrite /bunches_wf_later big_sepM_insert_delete.
     iDestruct (big_sepM_delete with "Hbunch_wf") as "(Hbid2_bunch&Hbunch_wf)"; first eapply Hin2.
@@ -614,7 +617,7 @@ Proof.
                   ▷ saved_prop_own γprop2 (Qs bid2) ∗
                   ▷ saved_prop_own γprop2' (Qsr bid2) ∗
                   own γ2 (◯ Excl' (false, (γprop2_new, γprop2'_new))) ∗
-                  ▷ □ (C -∗ Qs bid2 -∗ ([∗ set] j ∈ s2, Pc j) ∗ Qsr bid2))%I
+                  ▷ □ (C -∗ Qs bid2 -∗ ([∗ set] j ∈ s2, ▷ Pc j) ∗ ▷ Qsr bid2))%I
       with "[Hbid2_bunch Hown2]" as ">($&$&$&$&#Hwand2)".
     {
       iDestruct "Hbid2_bunch" as (????) "(Hm2&Hown_auth2&Hs2&Hsr2&#Hwand2)".
@@ -636,7 +639,7 @@ Proof.
                   ▷ saved_prop_own γprop1 (Qs bid1) ∗
                   ▷ saved_prop_own γprop1' (Qsr bid1) ∗
                   own γ1 (◯ Excl' (false ,(γprop1_new, γprop1'_new))) ∗
-                  ▷ □ (C -∗ Qs bid1 -∗ ([∗ set] j ∈ s1, Pc j) ∗ Qsr bid1))%I
+                  ▷ □ (C -∗ Qs bid1 -∗ ([∗ set] j ∈ s1, ▷ Pc j) ∗ ▷ Qsr bid1))%I
       with "[Hbid1_bunch Hown1]" as ">(?&$&$&$&Hwand1)".
     {
       iDestruct "Hbid1_bunch" as (????) "(Hm1&Hown_auth1&Hs1&Hsr1&#Hwand1)".
@@ -697,7 +700,7 @@ Proof.
           iSplitL "".
           { iRight. rewrite big_sepS_empty. iFrame "#". eauto. }
           iRight. iFrame. iFrame "#". iApply big_sepS_union; first by auto.
-          iFrame. iApply (big_sepS_mono with "Hb1cr"); eauto.
+          iFrame. iApply (big_sepS_mono with "Hb1cr"). eauto.
         }
       }
       iDestruct "Hb2" as "[Hb2l|(_&HQr2&Hb2cr)]".
@@ -737,16 +740,17 @@ Proof.
   iDestruct (saved_prop_agree with "Hsaved2 Hsaved2'") as "Hequiv2'".
   iDestruct (saved_prop_agree with "Hsavedr1 Hsavedr1'") as "Hequivr1'".
   iDestruct (saved_prop_agree with "Hsavedr2 Hsavedr2'") as "Hequivr2'".
-  iNext.
   iSplitL; iModIntro.
-  - iRewrite -"Hequiv1'". iRewrite -"Hequiv2'".
-    iIntros "[H1 H2]".
-    iDestruct ("Hequiv1" with "H1") as "$".
-    iDestruct ("Hequiv2" with "H2") as "$".
-  - iRewrite -"Hequivr1'". iRewrite -"Hequivr2'".
-    iIntros "[H1 H2]".
-    iDestruct ("Hequiv1_alt" with "H1") as "$".
-    iDestruct ("Hequiv2_alt" with "H2") as "$".
+  - iIntros "[H1 H2]".
+    iDestruct ("Hequiv1" with "[H1]") as "$".
+    { iNext. iRewrite "Hequiv1'". done. }
+    iDestruct ("Hequiv2" with "[H2]") as "$".
+    { iNext. iRewrite "Hequiv2'". done. }
+  - iIntros "[H1 H2]".
+    iDestruct ("Hequiv1_alt" with "[H1]") as "$".
+    { iNext. iRewrite "Hequivr1'". done. }
+    iDestruct ("Hequiv2_alt" with "[H2]") as "$".
+    { iNext. iRewrite "Hequivr2'". done. }
 Qed.
 
 Lemma staged_inv_open E N k E1 E2 P Q Qr b s:
@@ -755,8 +759,8 @@ Lemma staged_inv_open E N k E1 E2 P Q Qr b s:
   staged_inv N k E1 E2 ∗
   staged_bundle Q Qr b s ∗
   staged_crash P s ={E,E∖↑N}=∗
-  (▷ ▷ Q ∗ ▷ (∀ Q' Qr' b', ▷ Q' ∗ □ (C -∗ Q' -∗ if (b': bool) then |={E1, E2}_k=> P ∗ Qr' else
-                                                P ∗ Qr')
+  (▷ ▷ Q ∗ ▷ (∀ Q' Qr' b', ▷ Q' ∗ □ (C -∗ Q' -∗ if (b': bool) then |={E1, E2}_k=> ▷ P ∗ ▷ Qr' else
+                                                ▷ P ∗ ▷ Qr')
                          ={E∖↑N,E}=∗ staged_bundle Q' Qr' b' s)) ∨
   (▷ ▷ Qr ∗ C ∗ |={E∖↑N, E}=> staged_bundle Q True b s).
 Proof.
@@ -779,7 +783,7 @@ Proof.
   - iLeft.
     iModIntro. iSplitL "Hlive".
     { iNext. iDestruct (saved_prop_agree with "Hsaved HQs") as "Hequiv'".
-      iNext. iApply "Hequiv". iRewrite "Hequiv'". auto. }
+      iApply "Hequiv". iNext. iRewrite "Hequiv'". auto. }
     iNext.
     iIntros (Q' Qr' b') "(HQs'&#Hwand')".
     iMod (saved_prop_alloc Q') as (γprop_new) "#Hsaved_new".
@@ -809,8 +813,12 @@ Proof.
           iSpecialize ("Hwand'" with "[$] [$]").
           destruct b'.
           * iApply (step_fupdN_inner_wand' with "Hwand'"); auto.
-            iIntros "(?&$)". iRewrite -"Hequiv_crash". by iApply "Hcrash_wand".
-          * iDestruct ("Hwand'") as "(?&$)". iRewrite -"Hequiv_crash". by iApply "Hcrash_wand".
+            iIntros "(?&$)".
+            iApply big_sepS_later. iRewrite -"Hequiv_crash". iApply big_sepS_later.
+            by iApply "Hcrash_wand".
+          * iDestruct ("Hwand'") as "(?&$)".
+            iApply big_sepS_later. iRewrite -"Hequiv_crash". iApply big_sepS_later.
+            by iApply "Hcrash_wand".
         }
         iFrame "#".
         iModIntro. iApply (big_sepM_mono with "Hbunch_wf").
@@ -827,14 +835,16 @@ Proof.
       iApply (big_sepM_mono with "Hstatus_rest").
       { iIntros (k0 ? Hlookup_delete).
         apply lookup_delete_Some in Hlookup_delete as (?&?).
-        rewrite /Qs'/Qsr'/bunch_crashed. rewrite ?decide_False //. }
+        rewrite /Qs'/Qsr'/bunch_crashed. rewrite ?decide_False //.
+        apply or_mono_r. apply sep_mono_r. apply sep_mono; first by auto.
+        apply big_sepS_mono=>??. apply or_mono_l. auto. }
     }
     iModIntro. iExists _, _, _, _, _, _. iFrame. iFrame "#".
-    iSplitL; iIntros "!> !> !> $".
+    iSplitL; iIntros "!> !> $".
   - iRight.
     iModIntro. iDestruct "Hcrashed" as "(HQsr&Hcrashed)". iSplitL "HQsr".
     { iNext. iDestruct (saved_prop_agree with "Hsavedr HQr") as "Hequiv'".
-      iNext. iApply "Hequiv_alt". iRewrite "Hequiv'". auto. }
+      iApply "Hequiv_alt". iNext. iRewrite "Hequiv'". auto. }
     iFrame "HC".
     iMod (saved_prop_alloc True%I) as (γprop'_new) "#Hsaved'_new".
     iMod (bunches_wf_to_later with "Hbunch_wf") as "Hbunch_wf".
@@ -862,8 +872,8 @@ Proof.
           iSpecialize ("Hwand_old" with "[$] [$]").
           destruct b.
           * iApply (step_fupdN_inner_wand' with "Hwand_old"); auto.
-            iIntros "(?&?)". rewrite right_id. eauto.
-          * iDestruct ("Hwand_old") as "(?&?)". rewrite right_id //.
+            iIntros "(?&?)". iSplitL; eauto.
+          * iDestruct ("Hwand_old") as "(?&?)". iSplitL; eauto.
         }
         iFrame "#".
         iModIntro. iApply (big_sepM_mono with "Hbunch_wf").
@@ -893,8 +903,8 @@ Lemma staged_inv_NC_open E N k E1 E2 P Q Qr b s:
   staged_inv N k E1 E2 ∗
   staged_bundle Q Qr b s ∗
   staged_crash P s ={E,E∖↑N}=∗
-  (▷ ▷ Q ∗ ▷ (∀ Q' Qr' b', ▷ Q' ∗ □ (C -∗ Q' -∗ if (b': bool) then |={E1, E2}_k=> P ∗ Qr' else
-                                                P ∗ Qr')
+  (▷ ▷ Q ∗ ▷ (∀ Q' Qr' b', ▷ Q' ∗ □ (C -∗ Q' -∗ if (b': bool) then |={E1, E2}_k=> ▷ P ∗ ▷ Qr' else
+                                                ▷ P ∗ ▷ Qr')
                          ={E∖↑N,E}=∗ staged_bundle Q' Qr' b' s)).
 Proof.
   iIntros (??) "(HNC&Hinv&Hval)".

--- a/src/program_logic/staged_wpc.v
+++ b/src/program_logic/staged_wpc.v
@@ -58,7 +58,7 @@ Lemma wpc_staged_inv_open_aux' Γ s k k' k'' E1 E1' E2 e Φ Φc P Q N bset :
   (2 * (S k)) ≤ k' →
   staged_inv Γ N k' (E1' ∖ ↑N) (E1' ∖ ↑N) ∗
   NC ∗
-  staged_bundle Γ (WPC e @ k''; E1 ∖ ↑N; ∅ {{ v, Q v ∗ □ (Q v -∗ P) ∗ (staged_bundle Γ (Q v) True false bset -∗ Φc ∧ Φ v)}}{{Φc ∗ P}}) Φc true bset ∗
+  staged_bundle Γ (WPC e @ k''; E1 ∖ ↑N; ∅ {{ v, ▷ Q v ∗ ▷ □ (Q v -∗ P) ∗ (staged_bundle Γ (Q v) True false bset -∗ Φc ∧ Φ v)}}{{Φc ∗ ▷ P}}) Φc true bset ∗
   staged_crash Γ P bset
   ⊢ |={E1,E1}_(S (2 * S (S k)))=>
      WPC e @ s; 2 * S (S k); E1; E2 {{ v, Φ v }} {{Φc}} ∗ NC.
@@ -90,7 +90,7 @@ Proof.
       iDestruct "H" as "(H&_)".
       iMod ("H" with "[$]") as "((HQ&#HQP&HΦ)&HNC)".
       iMod ("Hclo'" $! _ True%I false with "[HQ]").
-      { iSplitL. iApply "HQ". iAlways.
+      { iSplitL. iApply "HQ". iIntros "!>".
         iIntros. iSplitL; last eauto. iApply "HQP"; eauto.
       }
       iModIntro. iSplitR "HNC"; last by iFrame.
@@ -124,7 +124,7 @@ Proof.
   iMod "Hclo" as "_".
   iSpecialize ("Hclo'" $! _ Φc true with "[H]").
   { iSplitL "H".
-    -  iApply "H".
+    - iNext. iApply "H".
     - iAlways. iIntros "HC H".
     iPoseProof (wpc_crash with "H") as "H".
     iSpecialize ("H" with "[$]").
@@ -274,7 +274,7 @@ Lemma wpc_staged_inv_open' Γ s k k' k'' E1 E1' E2 e Φ Φc Q Qrest Qnew P N b b
   to_val e = None →
   staged_inv Γ N k' (E1' ∖ ↑N) (E1' ∖ ↑N) ∗
   staged_bundle Γ Q Qrest b bset ∗
-  (Φc ∧ (Q -∗ WPC e @ NotStuck; k''; (E1 ∖ ↑N); ∅ {{λ v, Qnew v ∗ □ (Qnew v -∗ P) ∗ (staged_bundle Γ (Qnew v) True false bset -∗  (Φc ∧ Φ v))}} {{ Φc ∗ P }})) ∗
+  (Φc ∧ (Q -∗ WPC e @ NotStuck; k''; (E1 ∖ ↑N); ∅ {{λ v, ▷ Qnew v ∗ ▷ □ (Qnew v -∗ P) ∗ (staged_bundle Γ (Qnew v) True false bset -∗  (Φc ∧ Φ v))}} {{ Φc ∗ ▷ P }})) ∗
   staged_crash Γ P bset
   ⊢
   WPC e @ s; (2 * (S (S (S k)))); E1; E2 {{ Φ }} {{ Φc }}.
@@ -341,7 +341,7 @@ Proof.
   iDestruct "H" as "(Hσ&H&Hefs&HNC)".
   iSpecialize ("Hclo" $!
                       (WPC e2 @ k''; E1 ∖ ↑N;∅
-                        {{ v, Qnew v ∗ □ (Qnew v -∗ P) ∗ (staged_bundle Γ (Qnew v) True false bset -∗ Φc ∧ Φ v) }}{{Φc ∗ P}})%I
+                        {{ v, ▷ Qnew v ∗ ▷□ (Qnew v -∗ P) ∗ (staged_bundle Γ (Qnew v) True false bset -∗ Φc ∧ Φ v) }}{{Φc ∗ ▷ P}})%I
                Φc true with "[H]").
   { iSplitL "H".
     - iNext. iFrame.
@@ -413,7 +413,7 @@ Lemma wpc_staged_inv_open'' Γ s k k' k'' E1 E1' E2 e Φ Φc Q Qrest Qnew P N b 
   staged_inv Γ N k' (E1' ∖ ↑N) (E1' ∖ ↑N) ∗
   staged_bundle Γ Q Qrest b bset ∗
   staged_crash Γ P bset ∗
-  (Φc ∧ (Q -∗ WPC e @ NotStuck; k''; (E1 ∖ ↑N); ∅ {{λ v, Qnew v ∗ □ (Qnew v -∗ P) ∗ (staged_bundle Γ (Qnew v) True false bset -∗  (Φc ∧ Φ v))}} {{ Φc ∗ P }})) ⊢
+  (Φc ∧ (Q -∗ WPC e @ NotStuck; k''; (E1 ∖ ↑N); ∅ {{λ v, ▷ Qnew v ∗ ▷ □ (Qnew v -∗ P) ∗ (staged_bundle Γ (Qnew v) True false bset -∗  (Φc ∧ Φ v))}} {{ Φc ∗ ▷ P }})) ⊢
   WPC e @ s; (4 * k); E1; E2 {{ Φ }} {{ Φc }}.
 Proof.
   iIntros (??????) "(?&?&?&?)".
@@ -475,7 +475,7 @@ Lemma wpc_staged_inv_open Γ s k k' E1 E1' E2 e Φ Φc Q Qrest Qnew P N b bset :
   staged_inv Γ N (LVL k') (E1' ∖ ↑N) (E1' ∖ ↑N) ∗
   staged_bundle Γ Q Qrest b bset ∗
   staged_crash Γ P bset ∗
-  (Φc ∧ ((Q) -∗ WPC e @ NotStuck; (LVL k); (E1 ∖ ↑N); ∅ {{λ v, Qnew v ∗ □ (Qnew v -∗ P) ∗ (staged_bundle Γ (Qnew v) True false bset -∗  (Φc ∧ Φ v))}} {{ Φc ∗ P }})) ⊢
+  (Φc ∧ ((Q) -∗ WPC e @ NotStuck; (LVL k); (E1 ∖ ↑N); ∅ {{λ v, ▷ Qnew v ∗ ▷ □ (Qnew v -∗ P) ∗ (staged_bundle Γ (Qnew v) True false bset -∗  (Φc ∧ Φ v))}} {{ Φc ∗ ▷ P }})) ⊢
   WPC e @ s; LVL (S (S k)); E1; E2 {{ Φ }} {{ Φc }}.
 Proof.
   rewrite /LVL. iIntros (????) "(?&?&?)".

--- a/src/program_proof/append_log_hocap.v
+++ b/src/program_proof/append_log_hocap.v
@@ -95,7 +95,7 @@ Proof.
     { rewrite /log_init/log_crash_cond/log_crash_cond'.
       iFrame "HP".
       iNext. iFrame => //=. }
-    { iAlways. iIntros "H". iExists _. iFrame. }
+    { iIntros "!> !> H". iExists _. iFrame. }
     iMod (ghost_var_alloc (UnInit : log_stateO)) as (γ2) "(Hauth&Hfrag)".
     iMod (inv_alloc N _ (log_inv_inner _ γ2) with "[Hfull Hauth Hfrag]") as "#?".
     { iIntros "!>". rewrite /log_inv_inner. iExists _; repeat iFrame. iExists _, _. iFrame "#". iFrame. }
@@ -115,7 +115,7 @@ Proof.
     { rewrite /log_init/log_crash_cond/log_crash_cond'.
       iFrame "HP".
       iNext. iFrame => //=. }
-    { iAlways. iIntros "H". iExists _. iFrame. }
+    { iIntros "!> !> H". iExists _. iFrame. }
     iMod (ghost_var_alloc (Closed vs : log_stateO)) as (γ2) "(Hauth&Hfrag)".
     iMod (inv_alloc N _ (log_inv_inner _ γ2) with "[Hfull Hauth Hfrag]") as "#?".
     { iIntros "!>". rewrite /log_inv_inner. iExists _; repeat iFrame. iExists _, _. iFrame "#". iFrame. }
@@ -323,7 +323,7 @@ Proof using PStartedOpening_Timeless.
       { iExists _. iFrame. eauto. }
       iModIntro.
       iSplitR; first eauto.
-      { iAlways. iIntros "H". iDestruct "H" as (bs) "(?&?)". iExists _. iFrame.
+      { iIntros "!> !> H". iDestruct "H" as (bs) "(?&?)". iExists _. iFrame.
         simpl. by iApply ptsto_log_crashed. }
       iIntros "Hfull". iSplit.
       ** iApply "HΦ". by iApply Hwand.
@@ -442,7 +442,7 @@ Proof using PStartedIniting_Timeless SIZE_nonzero.
       { iExists _. iFrame. eauto. }
       iModIntro.
       iSplitR; first eauto.
-      { iAlways. iIntros "H". iDestruct "H" as (bs) "(?&?)". iExists _. iFrame.
+      { iIntros "!> !> H". iDestruct "H" as (bs) "(?&?)". iExists _. iFrame.
         simpl. by iApply ptsto_log_crashed. }
       iIntros "Hfull". iSplit.
       ** iApply "HΦ". by iApply Hwand.

--- a/src/program_proof/examples/alloc_crash_proof.v
+++ b/src/program_proof/examples/alloc_crash_proof.v
@@ -219,7 +219,7 @@ Proof.
     iMod (na_crash_inv_alloc _ _ _ _ (block_cinv γ k) (Ψ k) with "[$] [$] []") as
         (i) "(Hbund&Hval&Hpend)".
     { auto. }
-    { iAlways. iIntros "H". iLeft. eauto. }
+    { iIntros "!> !> H". iLeft. eauto. }
     iModIntro. iFrame. rewrite /free_block_pending.
     iSplitL "Hpend".
     { iExists _. iFrame. }
@@ -230,7 +230,7 @@ Proof.
     iMod (na_crash_inv_alloc _ _ _ _ (block_cinv γ k) (mapsto k 1 block_used) with "[$] [$] []") as
         (i) "(Hbund&Hval&Hpend)".
     { auto. }
-    { iAlways. iIntros "H". iRight. eauto. }
+    { iIntros "!> !> H". iRight. eauto. }
     iModIntro. iFrame.
     iExists _. iFrame.
 Qed.
@@ -241,7 +241,7 @@ Lemma allocator_crash_obligation e (Φ: val → iProp Σ) Φc E2 E2' n n' σ:
   ↑N ⊆ E2' ∖ E2 →
   alloc_post_crash σ →
   ([∗ set] k ∈ alloc.unused σ, Ψ k) -∗
-  P σ -∗
+  ▷ P σ -∗
   (∀ γ, is_allocator_pre γ n' (alloc.domain σ) (alloc.free σ) -∗
         WPC e @ NotStuck; LVL n; ⊤; E2 {{ Φ }} {{ alloc_crash_cond -∗ Φc }}) -∗
   WPC e @ NotStuck; (LVL ((S n) + set_size (alloc.domain σ))); ⊤; E2' {{ Φ }} {{ Φc }}%I.
@@ -388,7 +388,7 @@ Theorem wpc_Reserve (Q: option u64 → iProp Σ) (Qc: iProp Σ) l dset γ n n' E
            | Some a => a ∈ alloc.free σ ∧ σ' = <[a := block_reserved]> σ
            | None => σ' = σ ∧ alloc.free σ = ∅
            end⌝ -∗
-          P σ ={E1 ∖ ↑N}=∗ P σ' ∗ Q ma) ∧
+          ▷ P σ ={E1 ∖ ↑N}=∗ ▷ P σ' ∗ Q ma) ∧
       Qc
   }}}
     Allocator__Reserve #l  @ NotStuck; n; E1; E2
@@ -549,7 +549,7 @@ Lemma prepare_reserved_block_reuse R' E R n n' γ e a Φ Φc:
                                            (R' v) ∗
                                            reserved_block_in_prep γ n' a ∗
                                            □ (R' v -∗ block_cinv γ a) }}
-                                   {{ Φc ∗ block_cinv γ a }}) -∗
+                                   {{ Φc ∗ ▷ block_cinv γ a }}) -∗
   WPC e @  (LVL (S (S n))); ⊤; E {{ Φ }} {{ Φc }}.
 Proof.
   iIntros (??) "Hreserved H".
@@ -580,7 +580,7 @@ Lemma prepare_reserved_block E1 E2 R n n' γ e a Φ Φc:
   (R -∗
    reserved_block_in_prep γ n' a -∗
    WPC e @ LVL n; (E1 ∖ ↑Ncrash); ∅ {{ λ v, (Φc ∧ Φ v) ∗ block_cinv γ a }}
-                                   {{ Φc ∗ block_cinv γ a }}) -∗
+                                   {{ Φc ∗ ▷ block_cinv γ a }}) -∗
   WPC e @  (LVL (S (S n))); E1; E2 {{ Φ }} {{ Φc }}.
 Proof.
   iIntros (???) "Hreserved H".
@@ -700,7 +700,7 @@ Theorem wp_Free (Q: iProp Σ) E l d γ n' (a: u64) :
   ↑N ⊆ E →
   ↑nroot.@"readonly" ⊆ E →
   {{{ is_allocator l d γ n' ∗ reserved_block γ n' a (Ψ a) ∗
-     (∀ σ, ⌜ σ !! a = Some block_reserved ⌝ -∗ P σ ={E ∖↑N}=∗ P (<[ a := block_free ]> σ) ∗ Q)
+     (∀ σ, ⌜ σ !! a = Some block_reserved ⌝ -∗ ▷ P σ ={E ∖↑N}=∗ ▷ P (<[ a := block_free ]> σ) ∗ Q)
   }}}
     Allocator__Free #l #a @ E
   {{{ RET #(); Q }}}.

--- a/src/program_proof/examples/alloc_proof.v
+++ b/src/program_proof/examples/alloc_proof.v
@@ -86,7 +86,7 @@ Theorem wp_newAllocator mref (start sz: u64) used :
   {{{ is_addrset mref used ∗
       let σ0 := {| alloc.domain := rangeSet (int.val start) (int.val sz);
                    alloc.used := used |} in
-      ⌜alloc.wf σ0⌝ ∗ allocator_durable σ0 ∗ P σ0 }}}
+      ⌜alloc.wf σ0⌝ ∗ allocator_durable σ0 ∗ ▷ P σ0 }}}
     New #start #sz #mref
   {{{ l γ, RET #l; is_allocator l γ }}}.
 Proof using allocG0.
@@ -148,7 +148,7 @@ Theorem wp_Reserve (Q: option u64 → iProp Σ) l γ :
            | None => σ' = σ
            end⌝ -∗
            ⌜alloc.wf σ⌝ -∗
-          P σ ={⊤}=∗ P σ' ∗ Q ma)
+          ▷ P σ ={⊤}=∗ ▷ P σ' ∗ Q ma)
   }}}
     Allocator__Reserve #l
   {{{ a (ok: bool), RET (#a, #ok);
@@ -202,7 +202,7 @@ Proof.
     wp_pures.
     iApply "HΦ"; iFrame.
   - wp_apply (release_spec with "[-HΦ HQ $His_lock $His_locked]").
-    { iExists _; iFrame "∗ %".
+    { iExists _; iFrame "∗ %". iNext.
       iExactEq "Hfreemap"; rewrite /named.
       f_equal.
       set_solver. }
@@ -260,7 +260,7 @@ Theorem wp_Free (Q: iProp Σ) l γ (a: u64) :
      (∀ σ σ',
           ⌜σ' = set alloc.used (λ used, used ∖ {[a]}) σ⌝ -∗
           ⌜alloc.wf σ⌝ -∗
-          P σ ={⊤}=∗ P σ' ∗ Q)
+          ▷ P σ ={⊤}=∗ ▷ P σ' ∗ Q)
   }}}
     Allocator__Free #l #a
   {{{ RET #(); Q }}}.
@@ -301,7 +301,7 @@ Proof.
     rewrite big_sepS_union; last first.
     { apply disjoint_singleton_r; auto. }
     rewrite big_opS_singleton.
-    iFrame "Hb Hblocks".
+    iFrame "Hb Hblocks". iNext.
     iExactEq "Hallocated".
     rewrite /named.
     f_equal.


### PR DESCRIPTION
Basically, things that are stored in an invariant/lock should consistently just have a later in front of them when being talked about outside the invariant/lock. The crash_lock spec is even a bit stronger than that, by providing `R` (and not just `\later R`) after "acquire" -- it has the luxury of taking a step and it exposes that to its clients.

Unfortunately this makes caching work a bit less good in some places as laters occur and then go away after the next step.

I have no idea what I did to the layers below crash_inv; that is all solely based on pushing things through until Coq stops complaining...