### PR TITLE
Remove later in definition of na_crash_inv

### DIFF
--- a/src/program_logic/na_crash_inv.v
+++ b/src/program_logic/na_crash_inv.v
@@ -21,7 +21,7 @@ Implicit Types e : expr Λ.
 
 Definition na_crash_inv_def N k Q P :=
   (∃ Γ Qr bset, staged_inv Γ N k (⊤ ∖ ↑N) (⊤ ∖ ↑N) ∗ staged_bundle Γ Q Qr false bset ∗
-                staged_crash Γ P bset ∗ ▷ □ (Q -∗ P))%I.
+                staged_crash Γ P bset ∗ □ (Q -∗ P))%I.
 Definition na_crash_inv_aux : seal (@na_crash_inv_def). by eexists. Qed.
 Definition na_crash_inv := (na_crash_inv_aux).(unseal).
 Definition na_crash_inv_eq := (na_crash_inv_aux).(seal_eq).
@@ -33,7 +33,7 @@ Ltac crash_unseal :=
 
 Lemma na_crash_inv_alloc N k E P Q:
   ↑N ⊆ E →
-  ▷ Q -∗ ▷ □ (Q -∗ P) ={E}=∗ na_crash_inv N (LVL k) Q P ∗ |C={⊤, ∅}_(LVL (S k))=> P.
+  ▷ Q -∗ □ (Q -∗ P) ={E}=∗ na_crash_inv N (LVL k) Q P ∗ |C={⊤, ∅}_(LVL (S k))=> P.
 Proof.
   crash_unseal.
   iIntros (?) "HQ #HQP".
@@ -50,12 +50,12 @@ Qed.
 
 Lemma na_crash_inv_status_wand N k Q P:
   na_crash_inv N k Q P -∗
-  ▷ □ (Q -∗ P).
+  □ (Q -∗ P).
 Proof. crash_unseal. iDestruct 1 as (???) "(?&?&?&$)". Qed.
 
 Lemma na_crash_inv_weaken N k Q Q' P :
   □(Q -∗ Q') -∗
-  ▷ □(Q' -∗ P) -∗
+  □(Q' -∗ P) -∗
   na_crash_inv N k Q P -∗
   na_crash_inv N k Q' P.
 Proof.
@@ -65,7 +65,7 @@ Proof.
   iExists _, Qr, _. iFrame.
   iSplitL "Hbundle".
   iApply (staged_bundle_weaken_1 with "HQ' Hbundle").
-  iNext. iAlways. iIntros. by iApply "HQ'P".
+  iAlways. iIntros. by iApply "HQ'P".
 Qed.
 
 Lemma wpc_na_crash_inv_open_modify Qnew s k k' E1 E2 e Φ Φc Q P N :
@@ -74,7 +74,7 @@ Lemma wpc_na_crash_inv_open_modify Qnew s k k' E1 E2 e Φ Φc Q P N :
   to_val e = None →
   na_crash_inv N (LVL k') Q P -∗
   (Φc ∧ (Q -∗ WPC e @ NotStuck; (LVL k); (E1 ∖ ↑N); ∅
-                    {{λ v, ▷ Qnew v ∗ ▷ □ (Qnew v -∗ P)  ∗ (na_crash_inv N (LVL k') (Qnew v) P -∗ (Φc ∧ Φ v))}}
+                    {{λ v, ▷ Qnew v ∗ □ (Qnew v -∗ P)  ∗ (na_crash_inv N (LVL k') (Qnew v) P -∗ (Φc ∧ Φ v))}}
                     {{ Φc ∗ ▷ P }})) -∗
   WPC e @ s; LVL (S k); E1; E2 {{ Φ }} {{ Φc }}.
 Proof.

--- a/src/program_proof/append_log_hocap.v
+++ b/src/program_proof/append_log_hocap.v
@@ -89,7 +89,7 @@ Proof.
   - iMod (na_crash_inv_alloc N2 kinv ⊤ (log_crash_cond) (log_crash_cond' (UnInit))  with "[$] []") as
      "(Hfull&Hpending)".
     { set_solver +. }
-    { iIntros "!> !> H". iExists _. iFrame. }
+    { iIntros "!> H". iExists _. iFrame. }
     iMod (ghost_var_alloc (UnInit : log_stateO)) as (γ2) "(Hauth&Hfrag)".
     iMod (inv_alloc N _ (log_inv_inner _ γ2) with "[Hfull Hauth Hfrag]") as "#?".
     { iIntros "!>". rewrite /log_inv_inner. iExists _; repeat iFrame. }
@@ -111,7 +111,7 @@ Proof.
     iMod (na_crash_inv_alloc N2 kinv ⊤ (log_crash_cond) (log_crash_cond' (Closed vs))  with "[$] []") as
      "(Hfull&Hpending)".
     { set_solver +. }
-    { iIntros "!> !> H". iExists _. iFrame. }
+    { iIntros "!> H". iExists _. iFrame. }
     iMod (ghost_var_alloc (Closed vs : log_stateO)) as (γ2) "(Hauth&Hfrag)".
     iMod (inv_alloc N _ (log_inv_inner _ γ2) with "[Hfull Hauth Hfrag]") as "#?".
     { iIntros "!>". rewrite /log_inv_inner. iExists _; repeat iFrame. }
@@ -324,7 +324,7 @@ Proof using PStartedOpening_Timeless.
       { iExists _. iFrame. eauto. }
       iModIntro.
       iSplitR; first eauto.
-      { iIntros "!> !> H". iDestruct "H" as (bs) "(?&?)". iExists _. iFrame.
+      { iIntros "!> H". iDestruct "H" as (bs) "(?&?)". iExists _. iFrame.
         simpl. by iApply ptsto_log_crashed. }
       iIntros "Hfull". iSplit.
       ** iApply "HΦ". by iApply Hwand.
@@ -442,7 +442,7 @@ Proof using PStartedIniting_Timeless SIZE_nonzero.
       { iExists _. iFrame. eauto. }
       iModIntro.
       iSplitR; first eauto.
-      { iIntros "!> !> H". iDestruct "H" as (bs) "(?&?)". iExists _. iFrame.
+      { iIntros "!> H". iDestruct "H" as (bs) "(?&?)". iExists _. iFrame.
         simpl. by iApply ptsto_log_crashed. }
       iIntros "Hfull". iSplit.
       ** iApply "HΦ". by iApply Hwand.

--- a/src/program_proof/examples/alloc_crash_proof.v
+++ b/src/program_proof/examples/alloc_crash_proof.v
@@ -400,7 +400,7 @@ Qed.
 
 Theorem reserved_block_weaken γ n k R R' :
   □(R -∗ R') -∗
-  ▷ □(R' -∗ block_cinv γ k) -∗
+  □(R' -∗ block_cinv γ k) -∗
   reserved_block γ n k R -∗
   reserved_block γ n k R'.
 Proof.
@@ -438,14 +438,14 @@ Proof.
     iMod (na_crash_inv_alloc Ncrash _ _ (block_cinv γ k) (Ψ k) with "[$] []") as
         "(Hbund&Hpend)".
     { auto. }
-    { iIntros "!> !> H". iLeft. eauto. }
+    { iIntros "!> H". iLeft. eauto. }
     iModIntro. iFrame.
   - exfalso. eapply alloc_post_crash_lookup_not_reserved; eauto.
   - (* TODO: should they all be in the same na_crash_inv? *)
     iMod (na_crash_inv_alloc Ncrash _ _ (block_cinv γ k) (mapsto k 1 block_used) with "[$] []") as
         "(Hbund&Hpend)".
     { auto. }
-    { iIntros "!> !> H". iRight. eauto. }
+    { iIntros "!> H". iRight. eauto. }
     iModIntro. iFrame.
 Qed.
 

--- a/src/program_proof/examples/inode_proof.v
+++ b/src/program_proof/examples/inode_proof.v
@@ -755,7 +755,7 @@ Proof.
       { iSplitL "Hreserved".
         { iApply (reserved_block_weaken with "[] [] Hreserved").
           { rewrite /Ψ. eauto. }
-          { rewrite /Ψ/block_cinv. iNext. eauto. }
+          { rewrite /Ψ/block_cinv. eauto. }
         }
         iIntros (σ' Hreserved) "HP".
         iMod ("Hfree_fupd" with "[//] HP") as "$".


### PR DESCRIPTION
This is an incomparable definition; it's weaker in that allocating a crash invariant now requires proving persistently(Q -* P) now instead of later, but it's stronger in that a crash invariant now implies persistently(Q -* P) now.

Note that if the guarantee P is timeless the later in the definition doesn't matter.