### PR TITLE
Adapt to a more-principled name generation in the "%" introduction pattern

### DIFF
--- a/src/algebra/fmcounter.v
+++ b/src/algebra/fmcounter.v
@@ -23,8 +23,8 @@ Definition fmcounter_lb γ (n: nat) := own γ (◯ (MaxNat n)).
 Instance inj_MaxNat_equiv : Inj eq equiv MaxNat.
 Proof.
   intros n1 n2.
-  intros ?%leibniz_equiv.
-  inversion H1; auto.
+  intros H0%leibniz_equiv.
+  inversion H0; auto.
 Qed.
 
 Lemma fmcounter_agree_1 γ q1 q2 n1 n2:

--- a/src/goose_lang/lib/struct/struct.v
+++ b/src/goose_lang/lib/struct/struct.v
@@ -241,8 +241,8 @@ Lemma NoDup_app_singleton A l (x:A) :
 Proof.
   intros Hnodup%NoDup_app.
   destruct Hnodup as (_&Hnotin&_).
-  intros ?%Hnotin.
-  apply H0.
+  intros H%Hnotin.
+  apply H.
   constructor.
 Qed.
 


### PR DESCRIPTION
Hi, this PR adapts to Coq PR coq/coq#13512 which makes the naming in the presence of the `%` introduction pattern compatible with name mangling. As a result, an `H0` is now named `H` in perennial's file ` src/goose_lang/lib/struct/struct.v`.

We fix the corresponding proof in a backward-compatible by not letting Coq generate the name. If you agree with the fix, it can be merged as soon as now.