### PR TITLE
Backward compatible fix

### DIFF
--- a/src/program_proof/examples/inode_proof.v
+++ b/src/program_proof/examples/inode_proof.v
@@ -507,7 +507,7 @@ Proof.
   iNext. iIntros (σ mb) "[%Hσ HP]". iMod ("Hfupd" with "[$HP //]") as "[HP HQ]".
   iModIntro. iFrame "HP". iSplit.
   { eauto. }
-  iIntros (s) "Hblock". iExists _, _; iSplit; first done. iFrame. iApply "Hblock".
+  iIntros (s) "Hblock". iExists _, _; iSplit; first done. iFrame; iApply "Hblock".
 Qed.
 
 Theorem wpc_Inode__Size {k} {l k' P addr}:


### PR DESCRIPTION
Due do coq/coq#14392, only heads of applications should not be evars for ! to match a term during typeclass resolution. This makes the iris automation more powerful, resulting in a breakage in the script.