### PR TITLE
For Coq PR #14392

### DIFF
--- a/src/program_proof/examples/dir_proof.v
+++ b/src/program_proof/examples/dir_proof.v
@@ -930,7 +930,7 @@ Section goose.
     iSplit.
     { eauto. }
     iIntros (s) "Hpost".
-    iExists _, _; iSplit; first eauto; iFrame. eauto.
+    iExists _, _; iSplit; first eauto; iFrame; eauto.
   Qed.
 
   Theorem wpc_Dir__Size {k} (Q: u64 → iProp Σ) l sz k' (idx: u64):

--- a/src/program_proof/examples/inode_proof.v
+++ b/src/program_proof/examples/inode_proof.v
@@ -507,7 +507,7 @@ Proof.
   iNext. iIntros (σ mb) "[%Hσ HP]". iMod ("Hfupd" with "[$HP //]") as "[HP HQ]".
   iModIntro. iFrame "HP". iSplit.
   { eauto. }
-  iIntros (s) "Hblock". iExists _, _; iSplit; first done. iFrame. iApply "Hblock".
+  iIntros (s) "Hblock". iExists _, _; iSplit; first done. iFrame; iApply "Hblock".
 Qed.
 
 Theorem wpc_Inode__Size {k} {l k' P addr}:


### PR DESCRIPTION
Second commit adds a similar fix needed for `dir_proof`.