### PR TITLE
Revert a57832ec6f4a43c184151f4a962b296d0e1cc982 and remove `-noglob`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ QUICK_CHECK_FILES := $(shell find 'src/program_proof/examples' -name "*.v")
 
 # extract any global arguments for Coq from _CoqProject
 COQPROJECT_ARGS := $(shell sed -E -e '/^\#/d' -e 's/-arg ([^ ]*)/\1/g' _CoqProject)
-COQ_ARGS := -noglob
+COQ_ARGS :=
 
 # user configurable
 Q:=@


### PR DESCRIPTION
Without .glob files, it's extremely hard to support automatic minimization of build failures in perennial caused by changes in Coq's PRs.  In particular, there's no general way to both reuse the artifacts from Coq's CI and also determine the correct invocation of coqc to regenerate a .glob file for a given .v file.  I could support this build mode by blowing away any .vo files from Coq's CI which don't have corresponding .glob files and then modifying the coqc wrapper to discard `-noglob`...   However, I don't see a real reason to skip building .glob files here.