### PR TITLE
Adapt to coq/coq#13837 ("apply with" does not rename arguments)

### DIFF
--- a/src/goose_lang/interpreter/interpreter.v
+++ b/src/goose_lang/interpreter/interpreter.v
@@ -166,7 +166,7 @@ Proof.
     rewrite H20 in prim_step_e_e''.
     pose proof (fill_step _ _ _ _ _ _ _ _ prim_step_e_e'') as prim_step_ic.
     eapply language.nsteps_l; [|exact nstep_ic_rest].
-    eapply step_atomic with (t3 := []) (t4 := []); [| |exact prim_step_ic]; eauto.
+    eapply @step_atomic with (t1 := []) (t2 := []); [| |exact prim_step_ic]; eauto.
     simpl. subst. done.
   }
 Qed.


### PR DESCRIPTION
Should be backwards compatible.