### PR TITLE
adjust for opaque pointer type

### DIFF
--- a/external/Goose/github_com/mit_pdos/go_journal/alloc.v
+++ b/external/Goose/github_com/mit_pdos/go_journal/alloc.v
@@ -7,7 +7,7 @@ Local Coercion Var' s: expr := Var s.
 (* Allocator uses a bit map to allocate and free numbers. Bit 0
    corresponds to number 0, bit 1 to 1, and so on. *)
 Definition Alloc := struct.decl [
-  "mu" :: lockRefT;
+  "mu" :: ptrT;
   "next" :: uint64T;
   "bitmap" :: slice.T byteT
 ].

--- a/external/Goose/github_com/mit_pdos/go_journal/buf.v
+++ b/external/Goose/github_com/mit_pdos/go_journal/buf.v
@@ -124,13 +124,13 @@ Definition Buf__BnumPut: val :=
 (* bufmap.go *)
 
 Definition BufMap := struct.decl [
-  "addrs" :: mapT (struct.ptrT Buf)
+  "addrs" :: mapT ptrT
 ].
 
 Definition MkBufMap: val :=
   rec: "MkBufMap" <> :=
     let: "a" := struct.new BufMap [
-      "addrs" ::= NewMap (struct.ptrT Buf) #()
+      "addrs" ::= NewMap ptrT #()
     ] in
     "a".
 
@@ -160,9 +160,9 @@ Definition BufMap__Ndirty: val :=
 
 Definition BufMap__DirtyBufs: val :=
   rec: "BufMap__DirtyBufs" "bmap" :=
-    let: "bufs" := ref (zero_val (slice.T (refT (struct.t Buf)))) in
+    let: "bufs" := ref (zero_val (slice.T ptrT)) in
     MapIter (struct.loadF BufMap "addrs" "bmap") (λ: <> "buf",
       (if: struct.loadF Buf "dirty" "buf"
-      then "bufs" <-[slice.T (refT (struct.t Buf))] SliceAppend (refT (struct.t Buf)) (![slice.T (refT (struct.t Buf))] "bufs") "buf"
+      then "bufs" <-[slice.T ptrT] SliceAppend ptrT (![slice.T ptrT] "bufs") "buf"
       else #()));;
-    ![slice.T (refT (struct.t Buf))] "bufs".
+    ![slice.T ptrT] "bufs".

--- a/external/Goose/github_com/mit_pdos/go_journal/jrnl.v
+++ b/external/Goose/github_com/mit_pdos/go_journal/jrnl.v
@@ -49,8 +49,8 @@ Definition LogBytes : expr := #4096 * #511.
    Call CommitWait to persist the operation's writes.
    To abort the operation simply stop using it. *)
 Definition Op := struct.decl [
-  "log" :: struct.ptrT obj.Log;
-  "bufs" :: struct.ptrT buf.BufMap
+  "log" :: ptrT;
+  "bufs" :: ptrT
 ].
 
 (* Begin starts a local journal operation with no writes from a global object
@@ -78,19 +78,19 @@ Definition Op__ReadBuf: val :=
 (* OverWrite writes an object to addr *)
 Definition Op__OverWrite: val :=
   rec: "Op__OverWrite" "op" "addr" "sz" "data" :=
-    let: "b" := ref_to (refT (struct.t buf.Buf)) (buf.BufMap__Lookup (struct.loadF Op "bufs" "op") "addr") in
-    (if: (![refT (struct.t buf.Buf)] "b" = #null)
+    let: "b" := ref_to ptrT (buf.BufMap__Lookup (struct.loadF Op "bufs" "op") "addr") in
+    (if: (![ptrT] "b" = #null)
     then
-      "b" <-[refT (struct.t buf.Buf)] buf.MkBuf "addr" "sz" "data";;
-      buf.Buf__SetDirty (![refT (struct.t buf.Buf)] "b");;
-      buf.BufMap__Insert (struct.loadF Op "bufs" "op") (![refT (struct.t buf.Buf)] "b");;
+      "b" <-[ptrT] buf.MkBuf "addr" "sz" "data";;
+      buf.Buf__SetDirty (![ptrT] "b");;
+      buf.BufMap__Insert (struct.loadF Op "bufs" "op") (![ptrT] "b");;
       #()
     else
-      (if: "sz" ≠ struct.loadF buf.Buf "Sz" (![refT (struct.t buf.Buf)] "b")
+      (if: "sz" ≠ struct.loadF buf.Buf "Sz" (![ptrT] "b")
       then Panic "overwrite"
       else #());;
-      struct.storeF buf.Buf "Data" (![refT (struct.t buf.Buf)] "b") "data";;
-      buf.Buf__SetDirty (![refT (struct.t buf.Buf)] "b");;
+      struct.storeF buf.Buf "Data" (![ptrT] "b") "data";;
+      buf.Buf__SetDirty (![ptrT] "b");;
       #()).
 
 (* NDirty reports an upper bound on the size of this transaction when committed.

--- a/external/Goose/github_com/mit_pdos/go_journal/jrnl_replication.v
+++ b/external/Goose/github_com/mit_pdos/go_journal/jrnl_replication.v
@@ -9,8 +9,8 @@ From Goose Require github_com.mit_pdos.go_journal.obj.
 From Goose Require github_com.mit_pdos.go_journal.util.
 
 Definition RepBlock := struct.decl [
-  "txn" :: struct.ptrT obj.Log;
-  "m" :: lockRefT;
+  "txn" :: ptrT;
+  "m" :: ptrT;
   "a0" :: struct.t addr.Addr;
   "a1" :: struct.t addr.Addr
 ].

--- a/external/Goose/github_com/mit_pdos/go_journal/obj.v
+++ b/external/Goose/github_com/mit_pdos/go_journal/obj.v
@@ -16,8 +16,8 @@ From Goose Require github_com.mit_pdos.go_journal.wal.
 
    There is only one Log object. *)
 Definition Log := struct.decl [
-  "mu" :: lockRefT;
-  "log" :: struct.ptrT wal.Walog;
+  "mu" :: ptrT;
+  "log" :: ptrT;
   "pos" :: wal.LogPosition
 ].
 
@@ -45,7 +45,7 @@ Definition Log__Load: val :=
 Definition Log__installBufsMap: val :=
   rec: "Log__installBufsMap" "l" "bufs" :=
     let: "blks" := NewMap (slice.T byteT) #() in
-    ForSlice (refT (struct.t buf.Buf)) <> "b" "bufs"
+    ForSlice ptrT <> "b" "bufs"
       (if: (struct.loadF buf.Buf "Sz" "b" = common.NBITBLOCK)
       then MapInsert "blks" (struct.get addr.Addr "Blkno" (struct.loadF buf.Buf "Addr" "b")) (struct.loadF buf.Buf "Data" "b")
       else

--- a/external/Goose/github_com/mit_pdos/go_journal/txn.v
+++ b/external/Goose/github_com/mit_pdos/go_journal/txn.v
@@ -15,13 +15,13 @@ From Goose Require github_com.mit_pdos.go_journal.util.
    transactions. Lock ordering is still up to the caller to avoid deadlocks. *)
 
 Definition Log := struct.decl [
-  "log" :: struct.ptrT obj.Log;
-  "locks" :: struct.ptrT lockmap.LockMap
+  "log" :: ptrT;
+  "locks" :: ptrT
 ].
 
 Definition Txn := struct.decl [
-  "buftxn" :: struct.ptrT jrnl.Op;
-  "locks" :: struct.ptrT lockmap.LockMap;
+  "buftxn" :: ptrT;
+  "locks" :: ptrT;
   "acquired" :: mapT boolT
 ].
 

--- a/external/Goose/github_com/mit_pdos/go_journal/wal.v
+++ b/external/Goose/github_com/mit_pdos/go_journal/wal.v
@@ -273,7 +273,7 @@ Definition sliding__clearMutable: val :=
 (* 0waldefs.go *)
 
 Definition WalogState := struct.decl [
-  "memLog" :: struct.ptrT sliding;
+  "memLog" :: ptrT;
   "diskEnd" :: LogPosition;
   "shutdown" :: boolT;
   "nthread" :: uint64T
@@ -284,13 +284,13 @@ Definition WalogState__memEnd: val :=
     sliding__end (struct.loadF WalogState "memLog" "st").
 
 Definition Walog := struct.decl [
-  "memLock" :: lockRefT;
+  "memLock" :: ptrT;
   "d" :: disk.Disk;
-  "circ" :: struct.ptrT circularAppender;
-  "st" :: struct.ptrT WalogState;
-  "condLogger" :: condvarRefT;
-  "condInstall" :: condvarRefT;
-  "condShut" :: condvarRefT
+  "circ" :: ptrT;
+  "st" :: ptrT;
+  "condLogger" :: ptrT;
+  "condInstall" :: ptrT;
+  "condShut" :: ptrT
 ].
 
 Definition Walog__LogSz: val :=

--- a/external/Goose/github_com/mit_pdos/go_nfsd/kvs.v
+++ b/external/Goose/github_com/mit_pdos/go_nfsd/kvs.v
@@ -12,7 +12,7 @@ Definition DISKNAME : expr := #(str"goose_kvs.img").
 
 Definition KVS := struct.decl [
   "sz" :: uint64T;
-  "log" :: struct.ptrT obj.Log
+  "log" :: ptrT
 ].
 
 Definition KVPair := struct.decl [

--- a/external/Goose/github_com/mit_pdos/go_nfsd/nfstypes.v
+++ b/external/Goose/github_com/mit_pdos/go_nfsd/nfstypes.v
@@ -646,11 +646,11 @@ Definition Entry3 := struct.decl [
   "Fileid" :: Fileid3;
   "Name" :: Filename3;
   "Cookie" :: Cookie3;
-  "Nextentry" :: refT anyT
+  "Nextentry" :: ptrT
 ].
 
 Definition Dirlist3 := struct.decl [
-  "Entries" :: struct.ptrT Entry3;
+  "Entries" :: ptrT;
   "Eof" :: boolT
 ].
 
@@ -684,11 +684,11 @@ Definition Entryplus3 := struct.decl [
   "Cookie" :: Cookie3;
   "Name_attributes" :: struct.t Post_op_attr;
   "Name_handle" :: struct.t Post_op_fh3;
-  "Nextentry" :: refT anyT
+  "Nextentry" :: ptrT
 ].
 
 Definition Dirlistplus3 := struct.decl [
-  "Entries" :: struct.ptrT Entryplus3;
+  "Entries" :: ptrT;
   "Eof" :: boolT
 ].
 
@@ -877,26 +877,26 @@ Definition Mountres3 := struct.decl [
 Definition Mount3 := struct.decl [
   "Ml_hostname" :: Name3;
   "Ml_directory" :: Dirpath3;
-  "Ml_next" :: refT anyT
+  "Ml_next" :: ptrT
 ].
 
 Definition Mountopt3 := struct.decl [
-  "P" :: struct.ptrT Mount3
+  "P" :: ptrT
 ].
 
 Definition Groups3 := struct.decl [
   "Gr_name" :: Name3;
-  "Gr_next" :: refT anyT
+  "Gr_next" :: ptrT
 ].
 
 Definition Exports3 := struct.decl [
   "Ex_dir" :: Dirpath3;
-  "Ex_groups" :: struct.ptrT Groups3;
-  "Ex_next" :: refT anyT
+  "Ex_groups" :: ptrT;
+  "Ex_next" :: ptrT
 ].
 
 Definition Exportsopt3 := struct.decl [
-  "P" :: struct.ptrT Exports3
+  "P" :: ptrT
 ].
 
 End code.

--- a/external/Goose/github_com/mit_pdos/go_nfsd/simple.v
+++ b/external/Goose/github_com/mit_pdos/go_nfsd/simple.v
@@ -194,8 +194,8 @@ Definition inodeInit: val :=
 (* mkfs.go *)
 
 Definition Nfs := struct.decl [
-  "t" :: struct.ptrT obj.Log;
-  "l" :: struct.ptrT lockmap.LockMap
+  "t" :: ptrT;
+  "l" :: ptrT
 ].
 
 Definition Mkfs: val :=

--- a/external/Goose/github_com/mit_pdos/gokv/bank.v
+++ b/external/Goose/github_com/mit_pdos/gokv/bank.v
@@ -10,8 +10,8 @@ From Goose Require github_com.mit_pdos.gokv.memkv.
 Definition BAL_TOTAL : expr := #1000.
 
 Definition BankClerk := struct.decl [
-  "lck" :: struct.ptrT lockservice.LockClerk;
-  "kvck" :: struct.ptrT memkv.SeqKVClerk;
+  "lck" :: ptrT;
+  "kvck" :: ptrT;
   "acc1" :: uint64T;
   "acc2" :: uint64T
 ].

--- a/external/Goose/github_com/mit_pdos/gokv/lockservice.v
+++ b/external/Goose/github_com/mit_pdos/gokv/lockservice.v
@@ -6,7 +6,7 @@ From Goose Require github_com.mit_pdos.gokv.connman.
 From Goose Require github_com.mit_pdos.gokv.memkv.
 
 Definition LockClerk := struct.decl [
-  "kv" :: struct.ptrT memkv.KVClerk
+  "kv" :: ptrT
 ].
 
 Definition LockClerk__Lock: val :=

--- a/external/Goose/github_com/mit_pdos/gokv/paxi/single.v
+++ b/external/Goose/github_com/mit_pdos/gokv/paxi/single.v
@@ -7,7 +7,7 @@ From Goose Require github_com.mit_pdos.gokv.urpc.rpc.
 (* clerk.go *)
 
 Definition Clerk := struct.decl [
-  "cl" :: struct.ptrT rpc.RPCClient
+  "cl" :: ptrT
 ].
 
 Definition MakeClerk: val :=
@@ -36,12 +36,12 @@ Definition PROPOSE : expr := #2.
 
 (* This isn't quite paxos *)
 Definition Replica := struct.decl [
-  "mu" :: lockRefT;
+  "mu" :: ptrT;
   "promisedPN" :: uint64T;
   "acceptedPN" :: uint64T;
   "acceptedVal" :: ValType;
   "committedVal" :: ValType;
-  "peers" :: slice.T (struct.ptrT Clerk)
+  "peers" :: slice.T ptrT
 ].
 
 Definition PrepareReply := struct.decl [
@@ -96,7 +96,7 @@ Definition Replica__TryDecide: val :=
     let: "highestVal" := ref (zero_val uint64T) in
     "highestVal" <-[uint64T] "v";;
     let: "mu" := lock.new #() in
-    ForSlice (refT (struct.t Clerk)) <> "peer" (struct.loadF Replica "peers" "r")
+    ForSlice ptrT <> "peer" (struct.loadF Replica "peers" "r")
       (let: "local_peer" := "peer" in
       Fork (let: "reply_ptr" := struct.alloc PrepareReply (zero_val (struct.t PrepareReply)) in
             Clerk__Prepare "local_peer" "pn" "reply_ptr";;
@@ -120,7 +120,7 @@ Definition Replica__TryDecide: val :=
       let: "mu2" := lock.new #() in
       let: "numAccepted" := ref (zero_val uint64T) in
       "numAccepted" <-[uint64T] #0;;
-      ForSlice (refT (struct.t Clerk)) <> "peer" (struct.loadF Replica "peers" "r")
+      ForSlice ptrT <> "peer" (struct.loadF Replica "peers" "r")
         (let: "local_peer" := "peer" in
         Fork (let: "r" := Clerk__Propose "local_peer" "pn" "proposeVal" in
               (if: "r"

--- a/external/Goose/github_com/mit_pdos/gokv/urpc/rpc.v
+++ b/external/Goose/github_com/mit_pdos/gokv/urpc/rpc.v
@@ -8,7 +8,7 @@ From Goose Require github_com.tchajed.marshal.
 Definition HostName: ty := uint64T.
 
 Definition RPCServer := struct.decl [
-  "handlers" :: mapT ((slice.T byteT -> refT (slice.T byteT) -> unitT)%ht)
+  "handlers" :: mapT ((slice.T byteT -> ptrT -> unitT)%ht)
 ].
 
 Definition RPCServer__rpcHandle: val :=
@@ -65,16 +65,16 @@ Definition callbackStateDone : expr := #1.
 Definition callbackStateAborted : expr := #2.
 
 Definition callback := struct.decl [
-  "reply" :: refT (slice.T byteT);
-  "state" :: refT uint64T;
-  "cond" :: condvarRefT
+  "reply" :: ptrT;
+  "state" :: ptrT;
+  "cond" :: ptrT
 ].
 
 Definition RPCClient := struct.decl [
-  "mu" :: lockRefT;
+  "mu" :: ptrT;
   "conn" :: grove_ffi.Connection;
   "seq" :: uint64T;
-  "pending" :: mapT (struct.ptrT callback)
+  "pending" :: mapT ptrT
 ].
 
 Definition RPCClient__replyThread: val :=
@@ -118,7 +118,7 @@ Definition MakeRPCClient: val :=
       "conn" ::= struct.get grove_ffi.ConnectRet "Connection" "a";
       "mu" ::= lock.new #();
       "seq" ::= #1;
-      "pending" ::= NewMap (struct.ptrT callback) #()
+      "pending" ::= NewMap ptrT #()
     ] in
     Fork (RPCClient__replyThread "cl");;
     "cl".

--- a/external/Goose/github_com/tchajed/goose/internal/examples/append_log.v
+++ b/external/Goose/github_com/tchajed/goose/internal/examples/append_log.v
@@ -11,7 +11,7 @@ From Goose Require github_com.tchajed.marshal.
    the number of valid blocks in the log. *)
 
 Definition Log := struct.decl [
-  "m" :: lockRefT;
+  "m" :: ptrT;
   "sz" :: uint64T;
   "diskSz" :: uint64T
 ].

--- a/external/Goose/github_com/tchajed/goose/internal/examples/logging2.v
+++ b/external/Goose/github_com/tchajed/goose/internal/examples/logging2.v
@@ -13,13 +13,13 @@ Definition LOGMAXBLK : expr := #510.
 Definition LOGEND : expr := LOGMAXBLK + LOGSTART.
 
 Definition Log := struct.decl [
-  "logLock" :: lockRefT;
-  "memLock" :: lockRefT;
+  "logLock" :: ptrT;
+  "memLock" :: ptrT;
   "logSz" :: uint64T;
-  "memLog" :: refT (slice.T disk.blockT);
-  "memLen" :: refT uint64T;
-  "memTxnNxt" :: refT uint64T;
-  "logTxnNxt" :: refT uint64T
+  "memLog" :: ptrT;
+  "memLen" :: ptrT;
+  "memTxnNxt" :: ptrT;
+  "logTxnNxt" :: ptrT
 ].
 
 Definition Log__writeHdr: val :=
@@ -154,7 +154,7 @@ Definition Log__Logger: val :=
 (* txn.go *)
 
 Definition Txn := struct.decl [
-  "log" :: struct.ptrT Log;
+  "log" :: ptrT;
   "blks" :: mapT disk.blockT
 ].
 

--- a/external/Goose/github_com/tchajed/goose/internal/examples/rfc1813.v
+++ b/external/Goose/github_com/tchajed/goose/internal/examples/rfc1813.v
@@ -646,11 +646,11 @@ Definition Entry3 := struct.decl [
   "Fileid" :: Fileid3;
   "Name" :: Filename3;
   "Cookie" :: Cookie3;
-  "Nextentry" :: refT anyT
+  "Nextentry" :: ptrT
 ].
 
 Definition Dirlist3 := struct.decl [
-  "Entries" :: struct.ptrT Entry3;
+  "Entries" :: ptrT;
   "Eof" :: boolT
 ].
 
@@ -684,11 +684,11 @@ Definition Entryplus3 := struct.decl [
   "Cookie" :: Cookie3;
   "Name_attributes" :: struct.t Post_op_attr;
   "Name_handle" :: struct.t Post_op_fh3;
-  "Nextentry" :: refT anyT
+  "Nextentry" :: ptrT
 ].
 
 Definition Dirlistplus3 := struct.decl [
-  "Entries" :: struct.ptrT Entryplus3;
+  "Entries" :: ptrT;
   "Eof" :: boolT
 ].
 
@@ -877,26 +877,26 @@ Definition Mountres3 := struct.decl [
 Definition Mount3 := struct.decl [
   "Ml_hostname" :: Name3;
   "Ml_directory" :: Dirpath3;
-  "Ml_next" :: refT anyT
+  "Ml_next" :: ptrT
 ].
 
 Definition Mountopt3 := struct.decl [
-  "P" :: struct.ptrT Mount3
+  "P" :: ptrT
 ].
 
 Definition Groups3 := struct.decl [
   "Gr_name" :: Name3;
-  "Gr_next" :: refT anyT
+  "Gr_next" :: ptrT
 ].
 
 Definition Exports3 := struct.decl [
   "Ex_dir" :: Dirpath3;
-  "Ex_groups" :: struct.ptrT Groups3;
-  "Ex_next" :: refT anyT
+  "Ex_groups" :: ptrT;
+  "Ex_next" :: ptrT
 ].
 
 Definition Exportsopt3 := struct.decl [
-  "P" :: struct.ptrT Exports3
+  "P" :: ptrT
 ].
 
 End code.

--- a/external/Goose/github_com/tchajed/goose/internal/examples/semantics.v
+++ b/external/Goose/github_com/tchajed/goose/internal/examples/semantics.v
@@ -484,7 +484,7 @@ Definition standardForLoop: val :=
 
 (* based off diskAppendWait loop pattern in logging2 *)
 Definition LoopStruct := struct.decl [
-  "loopNext" :: refT uint64T
+  "loopNext" :: ptrT
 ].
 
 Definition LoopStruct__forLoopWait: val :=
@@ -714,8 +714,8 @@ Definition testComparePointerToNil: val :=
 
 Definition testCompareNilToNil: val :=
   rec: "testCompareNilToNil" <> :=
-    let: "s" := ref (zero_val (refT uint64T)) in
-    (![refT uint64T] "s" = #null).
+    let: "s" := ref (zero_val ptrT) in
+    (![ptrT] "s" = #null).
 
 Definition testComparePointerWrappedToNil: val :=
   rec: "testComparePointerWrappedToNil" <> :=
@@ -1132,8 +1132,8 @@ Definition failing_testStructUpdates: val :=
     struct.storeF TwoInts "x" "b1" #3;;
     let: "b2" := ref_to (struct.t TwoInts) (S__readB "ns") in
     "ok" <-[boolT] (![boolT] "ok") && (struct.get TwoInts "x" (![struct.t TwoInts] "b2") = #1);;
-    let: "b3" := ref_to (refT (struct.t TwoInts)) (struct.fieldRef S "b" "ns") in
-    "ok" <-[boolT] (![boolT] "ok") && (struct.loadF TwoInts "x" (![refT (struct.t TwoInts)] "b3") = #1);;
+    let: "b3" := ref_to ptrT (struct.fieldRef S "b" "ns") in
+    "ok" <-[boolT] (![boolT] "ok") && (struct.loadF TwoInts "x" (![ptrT] "b3") = #1);;
     S__updateBValX "ns" #4;;
     "ok" <-[boolT] (![boolT] "ok") && (struct.get TwoInts "x" (S__readBVal "ns") = #4);;
     ![boolT] "ok".
@@ -1141,27 +1141,27 @@ Definition failing_testStructUpdates: val :=
 Definition testNestedStructUpdates: val :=
   rec: "testNestedStructUpdates" <> :=
     let: "ok" := ref_to boolT #true in
-    let: "ns" := ref_to (refT (struct.t S)) (NewS #()) in
-    struct.storeF TwoInts "x" (struct.fieldRef S "b" (![refT (struct.t S)] "ns")) #5;;
-    "ok" <-[boolT] (![boolT] "ok") && (struct.get TwoInts "x" (struct.loadF S "b" (![refT (struct.t S)] "ns")) = #5);;
-    "ns" <-[refT (struct.t S)] NewS #();;
-    let: "p" := ref_to (refT (struct.t TwoInts)) (struct.fieldRef S "b" (![refT (struct.t S)] "ns")) in
-    struct.storeF TwoInts "x" (![refT (struct.t TwoInts)] "p") #5;;
-    "ok" <-[boolT] (![boolT] "ok") && (struct.get TwoInts "x" (struct.loadF S "b" (![refT (struct.t S)] "ns")) = #5);;
-    "ns" <-[refT (struct.t S)] NewS #();;
-    "p" <-[refT (struct.t TwoInts)] struct.fieldRef S "b" (![refT (struct.t S)] "ns");;
-    struct.storeF TwoInts "x" (struct.fieldRef S "b" (![refT (struct.t S)] "ns")) #5;;
-    "ok" <-[boolT] (![boolT] "ok") && (struct.get TwoInts "x" (struct.load TwoInts (![refT (struct.t TwoInts)] "p")) = #5);;
-    "ns" <-[refT (struct.t S)] NewS #();;
-    "p" <-[refT (struct.t TwoInts)] struct.fieldRef S "b" (![refT (struct.t S)] "ns");;
-    struct.storeF TwoInts "x" (struct.fieldRef S "b" (![refT (struct.t S)] "ns")) #5;;
-    "ok" <-[boolT] (![boolT] "ok") && (struct.loadF TwoInts "x" (![refT (struct.t TwoInts)] "p") = #5);;
+    let: "ns" := ref_to ptrT (NewS #()) in
+    struct.storeF TwoInts "x" (struct.fieldRef S "b" (![ptrT] "ns")) #5;;
+    "ok" <-[boolT] (![boolT] "ok") && (struct.get TwoInts "x" (struct.loadF S "b" (![ptrT] "ns")) = #5);;
+    "ns" <-[ptrT] NewS #();;
+    let: "p" := ref_to ptrT (struct.fieldRef S "b" (![ptrT] "ns")) in
+    struct.storeF TwoInts "x" (![ptrT] "p") #5;;
+    "ok" <-[boolT] (![boolT] "ok") && (struct.get TwoInts "x" (struct.loadF S "b" (![ptrT] "ns")) = #5);;
+    "ns" <-[ptrT] NewS #();;
+    "p" <-[ptrT] struct.fieldRef S "b" (![ptrT] "ns");;
+    struct.storeF TwoInts "x" (struct.fieldRef S "b" (![ptrT] "ns")) #5;;
+    "ok" <-[boolT] (![boolT] "ok") && (struct.get TwoInts "x" (struct.load TwoInts (![ptrT] "p")) = #5);;
+    "ns" <-[ptrT] NewS #();;
+    "p" <-[ptrT] struct.fieldRef S "b" (![ptrT] "ns");;
+    struct.storeF TwoInts "x" (struct.fieldRef S "b" (![ptrT] "ns")) #5;;
+    "ok" <-[boolT] (![boolT] "ok") && (struct.loadF TwoInts "x" (![ptrT] "p") = #5);;
     ![boolT] "ok".
 
 Definition testStructConstructions: val :=
   rec: "testStructConstructions" <> :=
     let: "ok" := ref_to boolT #true in
-    let: "p1" := ref (zero_val (refT (struct.t TwoInts))) in
+    let: "p1" := ref (zero_val ptrT) in
     let: "p2" := ref (zero_val (struct.t TwoInts)) in
     let: "p3" := struct.mk TwoInts [
       "y" ::= #0;
@@ -1171,12 +1171,12 @@ Definition testStructConstructions: val :=
       "x" ::= #0;
       "y" ::= #0
     ] in
-    "ok" <-[boolT] (![boolT] "ok") && (![refT (struct.t TwoInts)] "p1" = #null);;
-    "p1" <-[refT (struct.t TwoInts)] struct.alloc TwoInts (zero_val (struct.t TwoInts));;
+    "ok" <-[boolT] (![boolT] "ok") && (![ptrT] "p1" = #null);;
+    "p1" <-[ptrT] struct.alloc TwoInts (zero_val (struct.t TwoInts));;
     "ok" <-[boolT] (![boolT] "ok") && (![struct.t TwoInts] "p2" = "p3");;
     "ok" <-[boolT] (![boolT] "ok") && ("p3" = "p4");;
-    "ok" <-[boolT] (![boolT] "ok") && ("p4" = struct.load TwoInts (![refT (struct.t TwoInts)] "p1"));;
-    "ok" <-[boolT] (![boolT] "ok") && ("p4" ≠ ![refT (struct.t TwoInts)] "p1");;
+    "ok" <-[boolT] (![boolT] "ok") && ("p4" = struct.load TwoInts (![ptrT] "p1"));;
+    "ok" <-[boolT] (![boolT] "ok") && ("p4" ≠ ![ptrT] "p1");;
     ![boolT] "ok".
 
 Definition testIncompleteStruct: val :=
@@ -1207,9 +1207,9 @@ Definition testStoreInStructVar: val :=
 
 Definition testStoreInStructPointerVar: val :=
   rec: "testStoreInStructPointerVar" <> :=
-    let: "p" := ref_to (refT (struct.t StructWrap)) (struct.alloc StructWrap (zero_val (struct.t StructWrap))) in
-    struct.storeF StructWrap "i" (![refT (struct.t StructWrap)] "p") #5;;
-    (struct.loadF StructWrap "i" (![refT (struct.t StructWrap)] "p") = #5).
+    let: "p" := ref_to ptrT (struct.alloc StructWrap (zero_val (struct.t StructWrap))) in
+    struct.storeF StructWrap "i" (![ptrT] "p") #5;;
+    (struct.loadF StructWrap "i" (![ptrT] "p") = #5).
 
 Definition testStoreComposite: val :=
   rec: "testStoreComposite" <> :=
@@ -1256,9 +1256,9 @@ Definition logLength : expr := #1 + #2 * MaxTxnWrites.
 
 Definition Log := struct.decl [
   "d" :: disk.Disk;
-  "l" :: lockRefT;
+  "l" :: ptrT;
   "cache" :: mapT disk.blockT;
-  "length" :: refT uint64T
+  "length" :: ptrT
 ].
 
 Definition intToBlock: val :=

--- a/external/Goose/github_com/tchajed/goose/internal/examples/simpledb.v
+++ b/external/Goose/github_com/tchajed/goose/internal/examples/simpledb.v
@@ -158,7 +158,7 @@ Definition tableRead: val :=
 
 Definition bufFile := struct.decl [
   "file" :: fileT;
-  "buf" :: refT (slice.T byteT)
+  "buf" :: ptrT
 ].
 
 Definition newBuf: val :=
@@ -196,7 +196,7 @@ Definition tableWriter := struct.decl [
   "index" :: mapT uint64T;
   "name" :: stringT;
   "file" :: struct.t bufFile;
-  "offset" :: refT uint64T
+  "offset" :: ptrT
 ].
 
 Definition newTableWriter: val :=
@@ -255,13 +255,13 @@ Definition tablePut: val :=
 
 (* Database is a handle to an open database. *)
 Definition Database := struct.decl [
-  "wbuffer" :: refT (mapT (slice.T byteT));
-  "rbuffer" :: refT (mapT (slice.T byteT));
-  "bufferL" :: lockRefT;
-  "table" :: struct.ptrT Table;
-  "tableName" :: refT stringT;
-  "tableL" :: lockRefT;
-  "compactionL" :: lockRefT
+  "wbuffer" :: ptrT;
+  "rbuffer" :: ptrT;
+  "bufferL" :: ptrT;
+  "table" :: ptrT;
+  "tableName" :: ptrT;
+  "tableL" :: ptrT;
+  "compactionL" :: ptrT
 ].
 
 Definition makeValueBuffer: val :=

--- a/external/Goose/github_com/tchajed/goose/internal/examples/unittest.v
+++ b/external/Goose/github_com/tchajed/goose/internal/examples/unittest.v
@@ -35,10 +35,10 @@ Definition hasEndComment: val :=
 
 Definition condvarWrapping: val :=
   rec: "condvarWrapping" <> :=
-    let: "mu" := ref (zero_val lockRefT) in
-    "mu" <-[lockRefT] lock.new #();;
-    let: "cond1" := lock.newCond (![lockRefT] "mu") in
-    "mu" <-[lockRefT] lock.new #();;
+    let: "mu" := ref (zero_val ptrT) in
+    "mu" <-[ptrT] lock.new #();;
+    let: "cond1" := lock.newCond (![ptrT] "mu") in
+    "mu" <-[ptrT] lock.new #();;
     lock.condWait "cond1";;
     #().
 
@@ -362,7 +362,7 @@ Definition useCondVar: val :=
     #().
 
 Definition hasCondVar := struct.decl [
-  "cond" :: condvarRefT
+  "cond" :: ptrT
 ].
 
 (* log_debugging.go *)
@@ -567,8 +567,8 @@ Definition AssignNilSlice: val :=
 
 Definition AssignNilPointer: val :=
   rec: "AssignNilPointer" <> :=
-    let: "s" := NewSlice (refT uint64T) #4 in
-    SliceSet (refT uint64T) "s" #2 slice.nil;;
+    let: "s" := NewSlice ptrT #4 in
+    SliceSet ptrT "s" #2 slice.nil;;
     #().
 
 Definition CompareSliceToNil: val :=

--- a/external/Goose/github_com/tchajed/goose/internal/examples/wal.v
+++ b/external/Goose/github_com/tchajed/goose/internal/examples/wal.v
@@ -9,9 +9,9 @@ Definition logLength : expr := #1 + #2 * MaxTxnWrites.
 
 Definition Log := struct.decl [
   "d" :: disk.Disk;
-  "l" :: lockRefT;
+  "l" :: ptrT;
   "cache" :: mapT disk.blockT;
-  "length" :: refT uint64T
+  "length" :: ptrT
 ].
 
 Definition intToBlock: val :=

--- a/external/Goose/github_com/tchajed/marshal.v
+++ b/external/Goose/github_com/tchajed/marshal.v
@@ -7,7 +7,7 @@ Local Coercion Var' s: expr := Var s.
 (* Enc is a stateful encoder for a statically-allocated array. *)
 Definition Enc := struct.decl [
   "b" :: slice.T byteT;
-  "off" :: refT uint64T
+  "off" :: ptrT
 ].
 
 Definition NewEnc: val :=
@@ -65,7 +65,7 @@ Definition Enc__Finish: val :=
    sequentially in a single slice. *)
 Definition Dec := struct.decl [
   "b" :: slice.T byteT;
-  "off" :: refT uint64T
+  "off" :: ptrT
 ].
 
 Definition NewDec: val :=

--- a/src/goose_lang/lib/into_val.v
+++ b/src/goose_lang/lib/into_val.v
@@ -66,13 +66,13 @@ Qed.
 (** instances for IntoVal *)
 Section instances.
   Context {ext: ffi_syntax} {ext_ty: ext_types ext}.
+
   Definition u64val (x:u64) : val := #x.
   Global Instance u64_IntoVal : IntoVal u64.
   Proof.
     refine {| to_val := λ (x: u64), #x;
               IntoVal_def := U64 0; |}; congruence.
   Defined.
-
   Global Instance u64_IntoVal_uint64T : IntoValForType u64 uint64T.
   Proof.
     constructor; auto.
@@ -83,7 +83,6 @@ Section instances.
     refine {| to_val := λ (x: u8), #x;
               IntoVal_def := U8 0; |}; congruence.
   Defined.
-
   Global Instance u8_IntoVal_byteT : IntoValForType u8 byteT.
   Proof.
     constructor; eauto.
@@ -94,13 +93,15 @@ Section instances.
     refine {| to_val := λ (l: loc), #l;
               IntoVal_def := null; |}; congruence.
   Defined.
-
   Global Instance loc_IntoVal_struct_ptr t : IntoValForType loc (struct.ptrT t).
   Proof.
     constructor; auto.
   Qed.
-
   Global Instance loc_IntoVal_ref t : IntoValForType loc (refT t).
+  Proof.
+    constructor; auto.
+  Qed.
+  Global Instance loc_IntoVal_ptr : IntoValForType loc ptrT.
   Proof.
     constructor; auto.
   Qed.
@@ -113,7 +114,6 @@ Section instances.
     intros [] [].
     inversion 1; auto.
   Defined.
-
   Global Instance slice_IntoVal_ref t : IntoValForType Slice.t (slice.T t).
   Proof.
     constructor; auto.
@@ -127,7 +127,6 @@ Section instances.
     refine {| into_val.to_val := λ (x: bool), #x;
               IntoVal_def := false; |}; congruence.
   Defined.
-
   Global Instance bool_IntoVal_boolT : IntoValForType bool boolT.
   Proof. constructor; auto. Qed.
 

--- a/src/goose_lang/lib/typed_mem/impl.v
+++ b/src/goose_lang/lib/typed_mem/impl.v
@@ -52,6 +52,7 @@ Section goose_lang.
   | unit_ty : lit_ty LitUnit unitT
   | loc_array_ty x t : lit_ty (LitLoc x) (arrayT t)
   | loc_struct_ty x ts : lit_ty (LitLoc x) (structRefT ts)
+  | loc_ptr_ty x : lit_ty (LitLoc x) ptrT
   .
 
   Inductive val_ty : val -> ty -> Prop :=

--- a/src/goose_lang/logical_reln_defns.v
+++ b/src/goose_lang/logical_reln_defns.v
@@ -196,8 +196,8 @@ Fixpoint val_interp (t: sty) {struct t} :=
   | arrayT t => arrayT_interp t flatten_val_interp
   | arrowT t1 t2 => arrowT_interp t1 t2 val_interp
   | extT x => sty_val_interp hS x
-  | mapValT vt => λ _ _, False%I
   | structRefT ts => structRefT_interp (map val_interp ts)
+  | mapValT _ | ptrT => λ _ _, False%I
   end with
  flatten_val_interp (t: sty) {struct t} : list (sval → ival → iProp Σ) :=
     match t with
@@ -209,8 +209,8 @@ Fixpoint val_interp (t: sty) {struct t} :=
     | arrayT t => [arrayT_interp t flatten_val_interp]
     | arrowT t1 t2 => [arrowT_interp t1 t2 val_interp]
     | extT x => [sty_val_interp hS x]
-    | mapValT vt => [λ _ _, False%I]
     | structRefT ts => [structRefT_interp (map val_interp ts)]
+    | mapValT _ | ptrT => [λ _ _, False%I]
     end.
 
 Lemma flatten_val_interp_flatten_ty t:

--- a/src/goose_lang/logical_reln_defns.v
+++ b/src/goose_lang/logical_reln_defns.v
@@ -178,6 +178,9 @@ Definition structRefT_interp (ts: list (sval → ival → iProp Σ)) (* (val_lis
                       ⌜addr_offset l + length ts ≤ 0 ∨ n ≤ addr_offset l⌝))
                  ∨ (∃ off, ⌜ vs = #(null +ₗ off) ∧ v = #(null +ₗ off) ⌝))%I.
 
+Definition ptrT_interp : sval → ival → iProp Σ :=
+  λ vs v, (∃ off, ⌜ vs = #(null +ₗ off) ∧ v = #(null +ₗ off) ⌝)%I.
+
 Definition arrowT_interp (t1 t2: sty) (val_interp: sty → sval → ival → iProp Σ) : sval → ival → iProp Σ :=
   λ vs v,
     (∃ f x e fs xs es,
@@ -197,7 +200,8 @@ Fixpoint val_interp (t: sty) {struct t} :=
   | arrowT t1 t2 => arrowT_interp t1 t2 val_interp
   | extT x => sty_val_interp hS x
   | structRefT ts => structRefT_interp (map val_interp ts)
-  | mapValT _ | ptrT => λ _ _, False%I
+  | ptrT => ptrT_interp
+  | mapValT _ => λ _ _, False%I
   end with
  flatten_val_interp (t: sty) {struct t} : list (sval → ival → iProp Σ) :=
     match t with
@@ -210,7 +214,8 @@ Fixpoint val_interp (t: sty) {struct t} :=
     | arrowT t1 t2 => [arrowT_interp t1 t2 val_interp]
     | extT x => [sty_val_interp hS x]
     | structRefT ts => [structRefT_interp (map val_interp ts)]
-    | mapValT _ | ptrT => [λ _ _, False%I]
+    | ptrT => [ptrT_interp]
+    | mapValT _ => [λ _ _, False%I]
     end.
 
 Lemma flatten_val_interp_flatten_ty t:

--- a/src/goose_lang/logical_reln_fund.v
+++ b/src/goose_lang/logical_reln_fund.v
@@ -337,6 +337,7 @@ Proof.
   - iDestruct "Hval" as "[Hval|Hnull]"; last first.
     { iDestruct "Hnull" as (?) "(%&%)"; subst. eauto. }
     iDestruct "Hval" as (?????? (?&?&?&?)) "H1". subst; eauto.
+  - iDestruct "Hval" as (?) "(%&%)"; subst. eauto.
   - iDestruct "Hval" as "[Hval|Hnull]"; last first.
     { iDestruct "Hnull" as (?) "(%&%)"; subst. eauto. }
     iDestruct "Hval" as (????? (?&?&?&?)) "H1". subst; eauto.
@@ -399,6 +400,9 @@ Proof.
       simpl in Hlookup1. destruct i; simpl in *; try inversion Hlookup1; subst; eauto.
       simpl in *; inversion Hlookup2; inversion Hlookup3; subst; eauto.
       iRight. eauto. }
+  - iDestruct "Hval" as (?) "(%&%)"; subst.
+    simpl in Hlookup1. destruct i; simpl in *; try inversion Hlookup1; subst; eauto.
+    simpl in *; inversion Hlookup2; inversion Hlookup3; subst; eauto.
   - iDestruct "Hval" as "[Hval|Hnull]".
     { iDestruct "Hval" as (????? (?&?&?&?)) "H1". subst; eauto.
       simpl in Hlookup1. destruct i; simpl in *; try inversion Hlookup1; subst; eauto.

--- a/src/program_proof/buf/buf_proof.v
+++ b/src/program_proof/buf/buf_proof.v
@@ -632,7 +632,7 @@ Theorem wp_BufMap__DirtyBufs l m stk E1 :
     BufMap__DirtyBufs #l @ stk ; E1
   {{{
     (s : Slice.t) (bufptrlist : list loc), RET (slice_val s);
-    is_slice s (refT (struct.t Buf)) 1 bufptrlist ∗
+    is_slice s ptrT 1 bufptrlist ∗
     let dirtybufs := filter (λ x, (snd x).(bufDirty) = true) m in
     [∗ maplist] a ↦ b;bufptr ∈ dirtybufs;bufptrlist,
       is_buf bufptr a b
@@ -656,8 +656,8 @@ Proof using.
         "%Hamtodo" ∷ ⌜flatid_addr_map bmtodo amtodo ∧ dom (gset addr) amtodo = dom (gset addr) mtodo⌝ ∗
         "Htodo" ∷ ( [∗ map] fa↦b ∈ bmtodo, ∃ a, ⌜fa = addr2flat a⌝ ∗
                                            (∃ y2 : buf, ⌜mtodo !! a = Some y2⌝ ∗ is_buf b a y2) ) ∗
-        "Hbufs" ∷ bufs ↦[slice.T (refT (struct.t Buf))] (slice_val bufptrslice) ∗
-        "Hbufptrslice" ∷ is_slice bufptrslice (refT (struct.t Buf)) 1 bufptrlist ∗
+        "Hbufs" ∷ bufs ↦[slice.T ptrT] (slice_val bufptrslice) ∗
+        "Hbufptrslice" ∷ is_slice bufptrslice ptrT 1 bufptrlist ∗
         "Hresult" ∷ ( [∗ maplist] a↦b;bufptr ∈ filter (λ x, (x.2).(bufDirty) = true) mdone;bufptrlist,
                                 is_buf bufptr a b )
     )%I

--- a/src/program_proof/crash_lockmap_proof.v
+++ b/src/program_proof/crash_lockmap_proof.v
@@ -733,7 +733,7 @@ Qed.
 Definition is_lockMap (l: loc) (ghs: list gname) (covered: gset u64) (P Pc: u64 -> iProp Σ) : iProp Σ :=
   ∃ (shards: list loc) (shardslice: Slice.t),
     "#Href" ∷ readonly (l ↦[LockMap :: "shards"] (slice_val shardslice)) ∗
-    "#Hslice" ∷ readonly (is_slice_small shardslice (struct.ptrT lockShard) 1 shards) ∗
+    "#Hslice" ∷ readonly (is_slice_small shardslice ptrT 1 shards) ∗
     "%Hlen" ∷ ⌜ length shards = Z.to_nat NSHARD ⌝ ∗
     "#Hshards" ∷ [∗ list] shardnum ↦ shardloc; shardgh ∈ shards; ghs,
       is_lockShard shardloc shardgh (covered_by_shard shardnum covered) P Pc.
@@ -741,7 +741,7 @@ Definition is_lockMap (l: loc) (ghs: list gname) (covered: gset u64) (P Pc: u64 
 Definition is_free_lockMap (l: loc) : iProp Σ :=
   ∃ (shards: list loc) (shardslice: Slice.t),
     "#Href" ∷ readonly (l ↦[LockMap :: "shards"] (slice_val shardslice)) ∗
-    "#Hslice" ∷ readonly (is_slice_small shardslice (struct.ptrT lockShard) 1 shards) ∗
+    "#Hslice" ∷ readonly (is_slice_small shardslice ptrT 1 shards) ∗
     "%Hlen" ∷ ⌜ length shards = Z.to_nat NSHARD ⌝ ∗
     "Hfree_shards" ∷ [∗ list] shardnum ↦ shardloc ∈ shards, is_free_lockShard shardloc.
 
@@ -776,8 +776,8 @@ Proof.
   wp_pures.
   wp_apply (wp_forUpto (λ (i : u64),
                           ∃ s shardlocs,
-                            "Hvar" ∷ shards ↦[slice.T (refT (struct.t lockShard))] (slice_val s) ∗
-                            "Hslice" ∷ is_slice s (struct.ptrT lockShard) 1 shardlocs ∗
+                            "Hvar" ∷ shards ↦[slice.T ptrT] (slice_val s) ∗
+                            "Hslice" ∷ is_slice s ptrT 1 shardlocs ∗
                             "%Hlen" ∷ ⌜ length shardlocs = int.nat i ⌝ ∗
                             "Hshards" ∷ [∗ list] shardnum ↦ shardloc ∈ shardlocs,
                               is_free_lockShard shardloc)%I

--- a/src/program_proof/lockmap_proof.v
+++ b/src/program_proof/lockmap_proof.v
@@ -85,7 +85,7 @@ Proof.
 
   wp_pures.
   iDestruct (is_free_lock_ty with "Hfreelock") as "%".
-  wp_apply wp_allocStruct; first by eauto.
+  wp_apply wp_allocStruct; first val_ty.
   iIntros (ls) "Hls".
 
   iMod (ghost_map_alloc (∅: gmap u64 bool)) as (hG) "[Hheapctx _]".
@@ -559,7 +559,7 @@ Qed.
 Definition is_lockMap (l: loc) (ghs: list gname) (covered: gset u64) (P: u64 -> iProp Σ) : iProp Σ :=
   ∃ (shards: list loc) (shardslice: Slice.t),
     "#Href" ∷ readonly (l ↦[LockMap :: "shards"] (slice_val shardslice)) ∗
-    "#Hslice" ∷ readonly (is_slice_small shardslice (struct.ptrT lockShard) 1 shards) ∗
+    "#Hslice" ∷ readonly (is_slice_small shardslice ptrT 1 shards) ∗
     "%Hlen" ∷ ⌜ length shards = Z.to_nat NSHARD ⌝ ∗
     "#Hshards" ∷ [∗ list] shardnum ↦ shardloc; shardgh ∈ shards; ghs,
       is_lockShard shardloc shardgh (covered_by_shard shardnum covered) P.
@@ -590,8 +590,8 @@ Proof.
   wp_pures.
   wp_apply (wp_forUpto (λ (i : u64),
                           ∃ s shardlocs ghs,
-                            "Hvar" ∷ shards ↦[slice.T (refT (struct.t lockShard))] (slice_val s) ∗
-                            "Hslice" ∷ is_slice s (struct.ptrT lockShard) 1 shardlocs ∗
+                            "Hvar" ∷ shards ↦[slice.T ptrT] (slice_val s) ∗
+                            "Hslice" ∷ is_slice s ptrT 1 shardlocs ∗
                             "%Hlen" ∷ ⌜ length shardlocs = int.nat i ⌝ ∗
                             "Hpp" ∷ ( [∗ set] shardnum ∈ rangeSet (int.Z i) (NSHARD-int.Z i),
                               [∗ set] a ∈ covered_by_shard (int.Z shardnum) covered, P a ) ∗

--- a/src/program_proof/memkv/connman_proof.v
+++ b/src/program_proof/memkv/connman_proof.v
@@ -194,7 +194,7 @@ Proof.
   wp_apply (wp_ConnMan__getClient with "Hconn").
   iIntros (cl) "Hcl".
   wp_store.
-  iAssert (∃ cl : loc, cl_ptr ↦[refT (struct.t rpc.RPCClient)] #cl ∗ RPCClient_own cl host)%I with "[Hcl Hcl_ptr]" as "Hcl".
+  iAssert (∃ cl : loc, cl_ptr ↦[ptrT] #cl ∗ RPCClient_own cl host)%I with "[Hcl Hcl_ptr]" as "Hcl".
   { eauto with iFrame. }
   clear cl.
   wp_pures.

--- a/src/program_proof/memkv/memkv_clerk_proof.v
+++ b/src/program_proof/memkv/memkv_clerk_proof.v
@@ -10,7 +10,7 @@ Context `{!heapGS Σ (ext:=grove_op) (ffi:=grove_model), !rpcG Σ ShardReplyC, !
 Local Definition own_KVClerk (p:loc) (γ:gname) : iProp Σ :=
   ∃ (freeClerks_sl:Slice.t) (freeClerks:list loc),
   "HfreeClerks" ∷ p ↦[KVClerk :: "freeClerks"] (slice_val freeClerks_sl) ∗
-  "HfreeClerks_sl" ∷ is_slice (V:=loc) freeClerks_sl (struct.ptrT SeqKVClerk) 1 freeClerks ∗
+  "HfreeClerks_sl" ∷ is_slice (V:=loc) freeClerks_sl ptrT 1 freeClerks ∗
   "HfreeClerks_own" ∷ [∗ list] ck ∈ freeClerks, own_SeqKVClerk ck γ
 .
 

--- a/src/program_proof/memkv/memkv_coord_start_proof.v
+++ b/src/program_proof/memkv/memkv_coord_start_proof.v
@@ -283,8 +283,6 @@ Proof.
   iIntros "#Hdom #His_coord #His_memkv !#" (Φ) "_ HΦ".
   wp_lam.
   wp_pures.
-  change (Alloc (InjLV (λ: <>, (λ: <>, #())%V))) with
-      (NewMap ((slice.T byteT -> refT (slice.T byteT) -> unitT)%ht)).
   wp_apply map.wp_NewMap.
   iIntros (handlers_ptr) "Hmap".
   wp_pures.

--- a/src/program_proof/memkv/rpc_proof.v
+++ b/src/program_proof/memkv/rpc_proof.v
@@ -148,7 +148,7 @@ Definition RPCClient_lock_inner Γ  (cl : loc) (lk : loc) mref : iProp Σ :=
             "Hmapping_ctx" ∷ map_ctx (ccmapping_name Γ) 1 reqs ∗
             "Hescrow_ctx" ∷ map_ctx (ccescrow_name Γ) 1 estoks ∗
             "Hextracted_ctx" ∷ map_ctx (ccextracted_name Γ) 1 extoks ∗
-            "Hpending_map" ∷ map.is_map mref 1 (pending, zero_val (struct.ptrT callback)) ∗
+            "Hpending_map" ∷ map.is_map mref 1 (pending, zero_val ptrT) ∗
             "Hreqs" ∷ [∗ map] seqno ↦ req ∈ reqs,
                  ∃ (Post : list u8 → iProp Σ),
                  "Hreg_entry" ∷  ptsto_ro (ccmapping_name Γ) seqno req ∗

--- a/src/program_proof/obj/commit_proof.v
+++ b/src/program_proof/obj/commit_proof.v
@@ -106,7 +106,7 @@ Theorem wp_txn__installBufsMap l q walptr γ dinit lwh bufs buflist (bufamap : g
       is_wal (wal_heap_inv γ.(txn_walnames)) walptr (wal_heap_walnames γ.(txn_walnames)) dinit ∗
       readonly (l ↦[obj.Log :: "log"] #walptr) ∗
       is_locked_walheap γ.(txn_walnames) lwh ∗
-      is_slice bufs (refT (struct.t buf.Buf)) q buflist ∗
+      is_slice bufs ptrT q buflist ∗
       [∗ maplist] a ↦ buf; bufptrval ∈ bufamap; buflist,
         is_txn_buf_pre γ bufptrval a buf
   }}}
@@ -409,7 +409,7 @@ Theorem wp_txn__installBufs l q walptr γ dinit lwh bufs buflist (bufamap : gmap
       is_wal (wal_heap_inv γ.(txn_walnames)) walptr (wal_heap_walnames γ.(txn_walnames)) dinit ∗
       readonly (l ↦[obj.Log :: "log"] #walptr) ∗
       is_locked_walheap γ.(txn_walnames) lwh ∗
-      is_slice bufs (refT (struct.t buf.Buf)) q buflist ∗
+      is_slice bufs ptrT q buflist ∗
       [∗ maplist] a ↦ buf; bufptrval ∈ bufamap; buflist,
         is_txn_buf_pre γ bufptrval a buf
   }}}
@@ -599,7 +599,7 @@ Qed.
 
 Theorem wp_txn__doCommit l q γ dinit bufs buflist (bufamap : gmap addr _) E (PreQ: iProp Σ) (Q : nat -> iProp Σ) :
   {{{ is_txn l γ dinit ∗
-      is_slice bufs (refT (struct.t buf.Buf)) q buflist ∗
+      is_slice bufs ptrT q buflist ∗
       ( [∗ maplist] a ↦ buf; bufptrval ∈ bufamap; buflist, is_txn_buf_pre γ bufptrval a buf ) ∗
       PreQ ∧ (|NC={⊤ ∖ ↑walN ∖ ↑invN, E}=>
         ∀ CP,
@@ -1205,7 +1205,7 @@ Qed.
 
 Theorem wp_txn_CommitWait l q γ dinit bufs buflist (bufamap : gmap addr _) (wait : bool) E (PreQ: iProp Σ) (Q : nat -> iProp Σ) :
   {{{ is_txn l γ dinit ∗
-      is_slice bufs (refT (struct.t buf.Buf)) q buflist ∗
+      is_slice bufs ptrT q buflist ∗
       ( [∗ maplist] a ↦ buf; bufptrval ∈ bufamap; buflist, is_txn_buf_pre γ bufptrval a buf ) ∗
       PreQ ∧ ( ⌜bufamap ≠ ∅⌝ -∗ |NC={⊤ ∖ ↑walN ∖ ↑invN, E}=>
         ∀ CP,

--- a/src/program_proof/pb/replica_defns.v
+++ b/src/program_proof/pb/replica_defns.v
@@ -59,7 +59,7 @@ Definition own_ReplicaServer (s:loc) (me:u64) γ
 
   (* only used for primary *)
   "HreplicaClerks" ∷ s ↦[ReplicaServer :: "replicaClerks"] (slice_val replicaClerks_sl) ∗
-  "HreplicaClerks_slice" ∷ is_slice replicaClerks_sl (struct.ptrT ReplicaClerk) 1%Qp replicaClerks
+  "HreplicaClerks_slice" ∷ is_slice replicaClerks_sl ptrT 1%Qp replicaClerks
 .
 
 Definition ReplicaServerN := nroot .@ "ReplicaServer".


### PR DESCRIPTION
This is the Perennial side of https://github.com/tchajed/goose/pull/28. I re-goosed most things, except for perennial-examples which is not in a clean state currently (something related to async).

In `typing.v` there are some predicates that seem to be used only in the logrel; originally I meant ptrT to be consistent with structRefT but that imposes some new proof obligations in logical_reln_fund so instead of made ptrT return `false` for all of those... @jtassarotti is that okay?