### PR TITLE
Fix incorrect "replace by"

### DIFF
--- a/src/program_proof/wal/recovery_proof.v
+++ b/src/program_proof/wal/recovery_proof.v
@@ -1331,7 +1331,7 @@ Proof.
             rewrite Nat.max_l; last by lia.
             iApply "Hdurable_lb_pos".
           }
-          replace (slidingM.memEnd _) with (int.Z diskEnd) by reflexivity.
+          replace (slidingM.memEnd _) with (int.Z diskEnd) by assumption.
           iSplit.
           {
             iPureIntro.


### PR DESCRIPTION
Before Coq 8.19 `replace foo with bar by tac` actually meant `replace foo with bar by first [assumption | symmetry; assumption | tac]`.