### PR TITLE
Adapt wrt Coq/Coq#18164

### DIFF
--- a/src/algebra/na_heap.v
+++ b/src/algebra/na_heap.v
@@ -1,5 +1,4 @@
 From stdpp Require Export namespaces.
-From Coq Require Import Min.
 From stdpp Require Import coPset.
 From iris.algebra Require Import big_op gmap frac agree reservation_map.
 From iris.algebra Require Import csum excl auth cmra_big_op numbers lib.gmap_view.


### PR DESCRIPTION
Very small deletion in src/algebra/na_heap.v.
This should be backward compatible.