### PR TITLE
switch to Iris's standard iFrame

### DIFF
--- a/src/program_proof/aof/proof.v
+++ b/src/program_proof/aof/proof.v
@@ -719,7 +719,7 @@ Proof.
         { by iIntros "$ _ !> $ !>". }
         unfold aof_length_lb.
         rewrite Hlengthsafe.
-        iFrame "#∗".
+        iFrame "∗#".
       }
       wp_pures.
       iRight.
@@ -1392,7 +1392,7 @@ Proof.
     wp_apply (wp_condWait with "[-Htok HΦ]").
     {
       iFrame "Hmu_inv HdurableCond HoldDurableCond Hclosed HcloseRequested".
-      by iFrame "#∗".
+      by iFrame "∗#".
     }
     iIntros "[Hlocked Haof_own]".
     wp_pures.

--- a/src/program_proof/chat/chat4/proof.v
+++ b/src/program_proof/chat/chat4/proof.v
@@ -289,7 +289,7 @@ Proof using ghost_varG0 heapGS0 waitgroupG0 Σ.
     iMod (readonly_alloc_1 with "Ha_sn") as "#Ha_sn".
     iMod (readonly_alloc_1 with "Ha_err") as "#Ha_err".
     wp_apply (wp_WaitGroup__Done with "[-]"); try done.
-    iFrame "#∗".
+    iFrame "∗#".
     iModIntro.
     change (int.Z 0) with 0.
     repeat iExists _.

--- a/src/program_proof/chat/full/lib.v
+++ b/src/program_proof/chat/full/lib.v
@@ -113,7 +113,7 @@ Proof.
   wp_apply (release_spec with "[-HΦ $Hlk_inv $Hlocked]").
   {
     iExists _, _, _.
-    iFrame "#∗".
+    iFrame "∗#".
     naive_solver.
   }
 
@@ -171,12 +171,12 @@ Proof.
   wp_apply (release_spec with "[-HΦ Hret $Hlk_inv $Hlocked]").
   {
     iExists _, _, _.
-    iFrame "#∗".
+    iFrame "∗#".
   }
 
   wp_pures.
   iApply "HΦ".
-  by iFrame "#∗".
+  by iFrame "∗#".
 Qed.
 
 End lib.

--- a/src/program_proof/chat/full2/clerk.v
+++ b/src/program_proof/chat/full2/clerk.v
@@ -64,9 +64,9 @@ Proof.
   wp_storeField.
   iMod (mono_list_own_alloc []) as (γ) "(Hauth & #Hlb)".
   iApply ("HΦ" $! γ).
-  iFrame "#∗".
+  iFrame "∗#".
   iExists _, s, _, _, _, vks, _.
-  iFrame "%#∗".
+  iFrame "∗%#".
   rewrite replicate_0.
   by iApply big_sepL2_nil.
 Qed.
@@ -200,7 +200,7 @@ Proof.
   iClear "Hlog_own' Hargs HP".
   iExists _, _, _, _, _, _, _.
   iDestruct (big_sepL2_app_inv with "Hsep") as "(Hsep & _)"; [naive_solver|].
-  by iFrame "#∗".
+  by iFrame "∗#".
 Qed.
 
 (*
@@ -357,14 +357,14 @@ Proof.
   iEval (rewrite /MsgTSlice.own) in "Hold".
   iRename "Hsep" into "Hsepold".
   iNamed "Hold".
-  iFrame "#∗".
+  iFrame "∗#".
   iSplitL.
   2: {
     rewrite /prefix.
     naive_solver.
   }
   repeat iExists _.
-  by iFrame "#∗".
+  by iFrame "∗#".
 Qed.
 
 End clerk.

--- a/src/program_proof/crash_lockmap_proof.v
+++ b/src/program_proof/crash_lockmap_proof.v
@@ -108,7 +108,7 @@ Proof.
   iMod (readonly_alloc_1 with "Hstate") as "Hstate".
   iModIntro.
   iApply "HΦ".
-  iExists _, _. iFrame "# ∗".
+  iExists _, _. iFrame "∗#".
 Qed.
 
 Theorem alloc_lockShard_init_cancel covered ls (P Pc : u64 → iProp Σ):
@@ -142,7 +142,7 @@ Proof.
     }
     iMod (alloc_lock lockN with "Hfree1 Hinner") as "Hlock".
     iModIntro.
-    iExists _, _, _. iFrame "# ∗". iModIntro.
+    iExists _, _, _. iFrame "∗#". iModIntro.
     iApply (big_sepS_mono with "Hwand"); eauto.
     iIntros (??) "H". iApply "H".
   - iIntros "H2". iApply (big_sepS_mono with "H2").
@@ -980,7 +980,7 @@ Proof.
     rewrite -Hgh_lookup. f_equal.
     unseal_nshard.
     word. }
-  iExists _, _. iFrame "# ∗". eauto.
+  iExists _, _. iFrame "∗#". eauto.
 Qed.
 
 Theorem wp_LockMap__Release l ghs (addr : u64) (P Pc : u64 -> iProp Σ) :

--- a/src/program_proof/ctrexample/client.v
+++ b/src/program_proof/ctrexample/client.v
@@ -35,7 +35,7 @@ Proof.
 
   iAssert (∃ x, counter_lb γ x ∗ localBound_ptr ↦[uint64T] #(U64 x))%I with "[HlocalBound Hlb]" as "HH".
   {
-    iExists 0%nat. iFrame "#∗".
+    iExists 0%nat. iFrame "∗#".
   }
   wp_forBreak.
   wp_pures.

--- a/src/program_proof/examples/alloc_addrset.v
+++ b/src/program_proof/examples/alloc_addrset.v
@@ -186,12 +186,12 @@ Proof.
       { iPureIntro.
         rewrite -Hmapdom.
         apply elem_of_dom; eauto. }
-      iExists _; by iFrame "% ∗".
+      iExists _; by iFrame "∗%".
     + iSplitR.
       { iPureIntro.
         rewrite -Hmapdom; subst.
         rewrite dom_empty_L //. }
-      iExists _; by iFrame "% ∗".
+      iExists _; by iFrame "∗%".
 Qed.
 
 Theorem wp_mapRemove m_ref remove_ref free remove E :

--- a/src/program_proof/examples/alloc_crash_proof.v
+++ b/src/program_proof/examples/alloc_crash_proof.v
@@ -359,7 +359,7 @@ Proof using allocG0.
   iModIntro.
   iIntros "Htoks".
   iApply "HΦ".
-  iExists _, _; iFrame "# ∗".
+  iExists _, _; iFrame "∗#".
   iSplitR; first auto.
   (*
   iSplitR "Htoks"; last first.
@@ -397,7 +397,7 @@ Lemma alloc_crash_cond_from_post_crash d :
   alloc_crash_cond d true -∗ alloc_crash_cond d false.
 Proof.
   iNamed 1.
-  iExists _; iFrame "% ∗".
+  iExists _; iFrame "∗%".
 Qed.
 
 Lemma alloc_crash_cond_strip_later `{∀ σ, Timeless (P σ)} d b :
@@ -412,7 +412,7 @@ Lemma alloc_crash_cond_no_later_from_post_crash d :
   alloc_crash_cond_no_later d true -∗ alloc_crash_cond_no_later d false.
 Proof.
   iNamed 1.
-  iExists _; iFrame "% ∗".
+  iExists _; iFrame "∗%".
 Qed.
 
 Definition revert_reserved (σ : alloc.t) : alloc.t :=

--- a/src/program_proof/examples/alloc_proof.v
+++ b/src/program_proof/examples/alloc_proof.v
@@ -109,7 +109,7 @@ Proof using allocG0.
           with "[$Hlock] [-HΦ]") as "#Hlock".
   { iExists _; iFrame.
     rewrite /alloc.free /=.
-    iFrame "% ∗". }
+    iFrame "∗%". }
   iModIntro.
   iApply ("HΦ" $! _ γ).
   iExists _, _; iFrame "#".

--- a/src/program_proof/examples/async_inode_proof.v
+++ b/src/program_proof/examples/async_inode_proof.v
@@ -262,14 +262,14 @@ Proof.
   iExists _, _; iFrame.
   iSplitR.
   { iFrame "#". }
-  iExists _, (Slice.nil), [], addrs. iFrame "% ∗".
+  iExists _, (Slice.nil), [], addrs. iFrame "∗%".
   iSplitL "".
   { eauto. }
   iSplitR ""; last first.
   { rewrite /blocks_slice.
     iExists 1%Qp. rewrite big_sepL2_nil. rewrite right_id.
     by iApply own_slice_nil. }
-  iExists _. iFrame "% ∗".
+  iExists _. iFrame "∗%".
   iPureIntro; eauto.
 Qed.
 
@@ -309,7 +309,7 @@ Proof.
   iDestruct (is_inode_durable_addrs with "Hdurable") as "%Haddr_set".
   iExists addrs.
   iSplitL "addrs Haddrs".
-  { iExists _; iFrame "% ∗". }
+  { iExists _; iFrame "∗%". }
   iFrame.
   iNamed 1.
   iIntros "Hdurable".

--- a/src/program_proof/examples/async_mem_alloc_inode_proof.v
+++ b/src/program_proof/examples/async_mem_alloc_inode_proof.v
@@ -253,7 +253,7 @@ Proof.
   iExists _, _; iFrame.
   iSplitR.
   { iFrame "#". }
-  iFrame "% ∗".
+  iFrame "∗%".
 Qed.
 
 Theorem is_inode_durable_addrs addr σ addrs :
@@ -292,7 +292,7 @@ Proof.
   iDestruct (is_inode_durable_addrs with "Hdurable") as "%Haddr_set".
   iExists addrs.
   iSplitL "addrs Haddrs".
-  { iExists _; iFrame "% ∗". }
+  { iExists _; iFrame "∗%". }
   iFrame.
   iNamed 1.
   iIntros "Hdurable".

--- a/src/program_proof/examples/indirect_inode_proof.v
+++ b/src/program_proof/examples/indirect_inode_proof.v
@@ -213,7 +213,7 @@ Proof.
   iNamed "Hinv".
   iNamed "Hdurable".
   iExists ds.
-  iFrame "% ∗".
+  iFrame "∗%".
   auto.
 Qed.
 

--- a/src/program_proof/examples/inode_proof.v
+++ b/src/program_proof/examples/inode_proof.v
@@ -274,7 +274,7 @@ Proof.
   iDestruct (is_inode_durable_addrs with "Hdurable") as "%Haddr_set".
   iExists addrs.
   iSplitL "addrs Haddrs".
-  { iExists _; iFrame "% ∗". }
+  { iExists _; iFrame "∗%". }
   iFrame.
   iNamed 1.
   iIntros "Hdurable".

--- a/src/program_proof/examples/replicated_block_proof.v
+++ b/src/program_proof/examples/replicated_block_proof.v
@@ -426,7 +426,7 @@ Section goose.
     wpc_apply (wpc_RepBlock__Read with "Hrblock").
     iSplit.
     { iIntros "_". iLeft in "HΦ". eauto. }
-    iIntros "!> * ?". iModIntro. iFrame "# ∗".
+    iIntros "!> * ?". iModIntro. iFrame "∗#".
     rewrite left_id.
     iSplit.
     - iLeft in "HΦ". eauto.

--- a/src/program_proof/examples/single_async_inode_proof.v
+++ b/src/program_proof/examples/single_async_inode_proof.v
@@ -417,7 +417,7 @@ Section goose.
     iModIntro.
     iSplitL "Halloc Hinode".
     { iExists _, _, _, _, _, _. iFrame "Hinode". iFrame "Halloc".
-      iFrame "# ∗". }
+      iFrame "∗#". }
     iModIntro.
     iMod "Halloc_crash" as "Halloc".
     iMod "Hinode_crash" as "Hinode".

--- a/src/program_proof/examples/single_inode_proof.v
+++ b/src/program_proof/examples/single_inode_proof.v
@@ -299,7 +299,7 @@ Section goose.
     iApply (init_cancel_cfupd ⊤).
     iApply (init_cancel_wand with "H [] [Hinv_crash]").
     { iIntros "(Halloc&Hinode)".
-      iNamed "Hinode". iFrame "#∗".
+      iNamed "Hinode". iFrame "∗#".
       rewrite Halloc_dom. eauto. }
     iIntros "(Hinode&Halloc)".
     iMod (cfupd_weaken_mask with "Hinv_crash") as "Hs_inode".

--- a/src/program_proof/fencing/ctr_proof.v
+++ b/src/program_proof/fencing/ctr_proof.v
@@ -815,10 +815,10 @@ Proof.
         {
           iNext.
           iRight.
-          iFrame "#∗".
+          iFrame "∗#".
         }
         iModIntro.
-        iFrame "#∗".
+        iFrame "∗#".
       }
       iDestruct "Hi" as "[HopIncomplete [[HneIncomplete Hgood] | Hi]]"; last first.
       { (* the request was run previously, but the Get fupd wasn't fired
@@ -832,7 +832,7 @@ Proof.
         iLeft.
         iFrame.
         iRight.
-        iFrame "#∗".
+        iFrame "∗#".
       }
       iEval (rewrite /EnterNewEpoch_spec) in "Hgood".
       iMod "Hgood".

--- a/src/program_proof/fencing/frontend_proof.v
+++ b/src/program_proof/fencing/frontend_proof.v
@@ -814,12 +814,12 @@ Proof using Type*.
     unfold is_Server.
     iMod (readonly_alloc_1 with "mu") as "#Hmu".
     iMod (readonly_alloc_1 with "epoch") as "#Hepoch".
-    iExists _; iFrame "#∗".
+    iExists _; iFrame "∗#".
     iApply (alloc_lock with "HmuInv").
     iNext.
     iExists _.
     iExists _, _.
-    iFrame "ck1 ck2 #∗".
+    iFrame "ck1 ck2 ∗#".
     iDestruct "Hunused" as "[$ $]".
   }
 

--- a/src/program_proof/grove_shared/erpc_lib.v
+++ b/src/program_proof/grove_shared/erpc_lib.v
@@ -227,7 +227,7 @@ Proof.
       iLeft. iFrame.
     }
     iModIntro. iFrame.
-    iFrame "# ∗".
+    iFrame "∗#".
   }
   { (* impossible case: reply for request has already been set *)
     by iExFalso; iApply (new_seq_implies_unproc with "Hlseq_lb Hlseq_own").
@@ -254,7 +254,7 @@ Proof.
   {
     iDestruct "Hpre2" as "[>Hproc_tok|[>HγPre2 _]]".
     - iMod ("HMClose" with "[HγPre Hpre Hunproc]") as "_"; last by [iModIntro; iFrame].
-      iNext. iFrame "#". iLeft. iFrame "#∗". iRight. iFrame.
+      iNext. iFrame "#". iLeft. iFrame "∗#". iRight. iFrame.
     - by iDestruct (own_valid_2 with "HγPre HγPre2") as %Hbad.
   }
   {
@@ -446,7 +446,7 @@ Proof.
     iDestruct (big_sepM_insert_2 _ _ (req.(Req_CID), req.(Req_Seq)) (Some reply) with "[Hreqeq_lb] Hcseq_lb") as "Hcseq_lb2"; eauto.
     iMod ("HNClose" with "[Hrcctx Hcseq_lb2]") as "_".
     {
-      iNext. iExists _; iFrame "# ∗".
+      iNext. iExists _; iFrame "∗#".
     }
 
     iDestruct (big_sepS_elem_of_acc_impl req.(Req_CID) with "Hlseq_own") as "[Hlseq_one Hlseq_own]";

--- a/src/program_proof/grove_shared/erpc_proof.v
+++ b/src/program_proof/grove_shared/erpc_proof.v
@@ -209,7 +209,7 @@ Proof.
       wp_loadField.
       wp_apply (release_spec with "[-HΦ Hrep_val_sl Hrepptr]").
       {
-        iFrame "#∗".
+        iFrame "∗#".
         iNext.
         iExists _,_,_, _, _, _.
         iFrame.
@@ -232,7 +232,7 @@ Proof.
       wp_loadField.
       wp_apply (release_spec with "[-HΦ Hrep_val_sl Hrepptr]").
       {
-        iFrame "#∗".
+        iFrame "∗#".
         iNext.
         iExists _,_,_, _, _, _.
         iFrame.
@@ -334,7 +334,7 @@ Proof.
   }
   wp_pures. iApply "HΦ". iExists _.
   iMod (readonly_alloc_1 with "mu") as "$".
-  by iFrame "# ∗".
+  by iFrame "∗#".
 Qed.
 
 Lemma wp_erpc_GetFreshCID s γ :

--- a/src/program_proof/grove_shared/urpc_proof.v
+++ b/src/program_proof/grove_shared/urpc_proof.v
@@ -232,7 +232,7 @@ Proof.
   unshelve (iMod (readonly_alloc_1 with "handlers") as "#handlers"); [| apply _ |].
   unshelve (iMod (readonly_alloc_1 with "Hmap") as "#Hmap"); [| apply _ |].
   iApply "HΦ". iExists _, _.
-  iFrame "# ∗". eauto.
+  iFrame "∗#". eauto.
 Qed.
 
 Definition urpc_handler_mapping (γ : server_chan_gnames) (host : u64) (handlers : gmap u64 val) : iProp Σ :=
@@ -259,7 +259,7 @@ Proof.
     iNamed "His_urpc_spec_pred". iFrame "% #".
     rewrite big_sepM_insert //. iSplitL "His_urpcHandler".
     { iExists Spec, _.
-      iFrame "# ∗". }
+      iFrame "∗#". }
     apply dom_empty_iff_L in Hemp. rewrite Hemp big_sepM_empty. eauto.
   }
   iDestruct ("IH" with "[//] [$]") as "HIH".
@@ -269,7 +269,7 @@ Proof.
     rewrite /is_urpc_spec_pred.
     iDestruct "His_urpc_spec_pred" as (g0 rpcdom) "H".
     iDestruct "H" as "(#Hdom1&%Hdom2&#Hspec_name&#Hspec_saved&H)".
-    iExists _, _.  iFrame "# ∗".
+    iExists _, _.  iFrame "∗#".
   }
 Qed.
 
@@ -528,7 +528,7 @@ Proof.
   wp_pures.
   wp_if_destruct; last first.
   { wp_pures. wp_loadField. wp_apply (release_spec with "[-]").
-    { iFrame "# ∗". iNext. iExists _, _, _, _, _. iFrame.
+    { iFrame "∗#". iNext. iExists _, _, _, _, _. iFrame.
       eauto. }
     wp_pures. eauto.
   }
@@ -574,12 +574,12 @@ Proof.
     { iThaw "Hclo". iApply (big_sepM_mono with "Hclo").
       iIntros (?? Hlookup) "H". iNamed "H".
       iExists _. iFrame "Hreg_entry HPost_saved". iDestruct "H" as "[Hcase1|[Hcase2|Hcase3]]".
-      { iNamed "Hcase1". iLeft. iExists _, _, _, aborted0. iFrame "# ∗".
+      { iNamed "Hcase1". iLeft. iExists _, _, _, aborted0. iFrame "∗#".
         iPureIntro.
         destruct (decide (seqno = k)).
         { subst. rewrite lookup_delete in Hlookup; congruence. }
         rewrite lookup_delete_ne //=. }
-      { iNamed "Hcase2". iRight. iLeft. iExists _, _. iFrame "# ∗".
+      { iNamed "Hcase2". iRight. iLeft. iExists _, _. iFrame "∗#".
         iPureIntro.
         apply lookup_delete_None; auto.
       }
@@ -839,7 +839,7 @@ Proof.
     }
     iExists Post.
     iFrame "Hreg Hsaved".
-    iLeft. iExists _, _, _, false. iFrame "# ∗".
+    iLeft. iExists _, _, _, false. iFrame "∗#".
     iPureIntro. rewrite lookup_insert //. }
   wp_pures.
   wp_apply (wp_slice_len).
@@ -933,13 +933,13 @@ Proof.
       iExists _. iFrame.
       iIntros "H". iFrame "∗ # %".
       iThaw "Hclo". iApply "Hclo".
-      { simpl. iExists _. iFrame "Hsaved Hreg". iLeft. iExists _, _, _. iFrame "# ∗". eauto. }
+      { simpl. iExists _. iFrame "Hsaved Hreg". iLeft. iExists _, _, _. iFrame "∗#". eauto. }
     }
     { iNamed "Hcase2". iExists _. iFrame.
       iIntros "H". iFrame "∗ # %".
       iThaw "Hclo". iApply "Hclo".
       { simpl. iExists _. iFrame "HPost_saved Hreg". iRight.
-        iLeft. iExists _, _. iFrame "# ∗". eauto. }
+        iLeft. iExists _, _. iFrame "∗#". eauto. }
     }
     { iDestruct "Hcase3" as "(?&Hex)".
       iDestruct (ptsto_valid_2 with "Hex [$]") as %Hval.
@@ -974,7 +974,7 @@ Proof.
     wp_pures.
     iThaw "Hclo".
     iDestruct ("Hclo" with "[Hdone Hcond Hescrow Hrep_ptr]") as "H".
-    { simpl. iExists _. iFrame "Hsaved Hreg". iLeft. iExists _, _, _. iFrame "# ∗". eauto. }
+    { simpl. iExists _. iFrame "Hsaved Hreg". iLeft. iExists _, _, _. iFrame "∗#". eauto. }
     rewrite bool_decide_false.
     2: by destruct aborted.
     wp_loadField.

--- a/src/program_proof/jrnl/jrnl_proof.v
+++ b/src/program_proof/jrnl/jrnl_proof.v
@@ -321,7 +321,7 @@ Proof.
     intuition idtac; subst.
     + iModIntro.
       iExists _, _, _.
-      iFrame "# ∗".
+      iFrame "∗#".
 
       iSplit.
       { iPureIntro.
@@ -349,7 +349,7 @@ Proof.
 
     + iModIntro.
       iExists _, _, _.
-      iFrame "# ∗".
+      iFrame "∗#".
 
       iSplit.
       { iPureIntro.
@@ -869,7 +869,7 @@ Proof.
         iIntros (k x Hkx) "[(#Hunify & HCP & Hcrashstates_frag) [Hpointsto Hextra]]".
         intuition try congruence.
         iDestruct ("Hunify" with "[$HCP $Hcrashstates_frag $Hpointsto]") as "#Hu".
-        iSplitL "HCP Hcrashstates_frag". 1: iFrame "#∗".
+        iSplitL "HCP Hcrashstates_frag". 1: iFrame "∗#".
         iAssert (⌜committed x = modified x⌝)%I as %Heq.
         { iDestruct "Hextra" as %Hextra. intuition eauto. }
         iSplitL "Hpointsto Hextra".

--- a/src/program_proof/jrnl/sep_jrnl_invariant.v
+++ b/src/program_proof/jrnl/sep_jrnl_invariant.v
@@ -648,7 +648,7 @@ Section goose_lang.
     { iSplitL "Htok0".
       - iLeft. eauto.
       - iExists _. iFrame "#". }
-    iFrame "# ∗".
+    iFrame "∗#".
   Qed.
 
   Lemma exchange_durable_pointsto γ γ' m :
@@ -696,7 +696,7 @@ Section goose_lang.
     iDestruct (exchange_big_sepM_addrs with "[$] [$] Hm") as "(Hexchanger&Hval)".
     { eauto. }
     iMod ("Hclo" with "[Hexchanger Hdurable_exchanger Hasync]").
-    { iNext. iExists _, _. iFrame "# ∗". eauto. }
+    { iNext. iExists _, _. iFrame "∗#". eauto. }
     iModIntro. eauto.
   Qed.
 
@@ -767,7 +767,7 @@ Section goose_lang.
       iDestruct (exchange_big_sepM_addrs with "[$] [$] Hval") as "(Hexchanger&Hval)".
       { etransitivity; last eassumption; eauto. }
       iMod ("Hclo" with "[Hexchanger Hdurable_exchanger Hasync]").
-      { iNext. iExists _, _. iFrame "# ∗". eauto. }
+      { iNext. iExists _, _. iFrame "∗#". eauto. }
       iModIntro. eauto.
     - (* We go forward, txn_id is durable *)
       iAssert (async_ctx γ.(jrnl_async_name) 1 logm ∗
@@ -784,7 +784,7 @@ Section goose_lang.
       iDestruct (exchange_big_sepM_addrs with "[$] [$] Hval") as "(Hexchanger&Hval)".
       { eauto. }
       iMod ("Hclo" with "[Hexchanger Hdurable_exchanger Hasync]").
-      { iNext. iExists _, _. iFrame "# ∗". eauto. }
+      { iNext. iExists _, _. iFrame "∗#". eauto. }
       iModIntro. eauto.
   Qed.
 

--- a/src/program_proof/jrnl/sep_jrnl_ops.v
+++ b/src/program_proof/jrnl/sep_jrnl_ops.v
@@ -134,7 +134,7 @@ Section goose_lang.
       rewrite (insert_id (mspec.committed <$> mT)); last first.
       { rewrite lookup_fmap Hmt_lookup //. }
       rewrite orb_true_r.
-      iFrame "#∗".
+      iFrame "∗#".
       iPureIntro; intros; congruence.
     - (* user did not change buf, so no basic updates are needed *)
       iModIntro.
@@ -231,7 +231,7 @@ Section goose_lang.
     rewrite !fmap_insert !mspec.committed_mkVersioned !mspec.modified_mkVersioned /=.
     rewrite (insert_id (mspec.committed <$> mT)); last first.
     { rewrite lookup_fmap Hlookup //. }
-    iFrame "#∗".
+    iFrame "∗#".
     iSplit.
     2: eauto.
     iExactEq "Htxn_ctx".
@@ -477,7 +477,7 @@ Section goose_lang.
       rewrite length_possible_async_put.
       replace (S (length (possible σs)) - 1)%nat with (length (possible σs))%nat by lia.
       iSplit.
-      { iModIntro. iModIntro. generalize (length (possible σs)); intros. iFrame "# ∗". }
+      { iModIntro. iModIntro. generalize (length (possible σs)); intros. iFrame "∗#". }
       iExactEq "Hnew".
       auto with f_equal lia. }
     iSplit.

--- a/src/program_proof/lockservice/aof_proof.v
+++ b/src/program_proof/lockservice/aof_proof.v
@@ -142,7 +142,7 @@ Proof.
     {
       wp_loadField.
       wp_apply (wp_condWait with "[- Hfile_ctx]").
-      { iFrame "#∗". iExists _, _, _, _; iFrame "∗#". done. }
+      { iFrame "∗#". iExists _, _, _, _; iFrame "∗#". done. }
       iIntros "[Hlocked Haof_own]".
       wp_pures.
       iLeft.
@@ -174,7 +174,7 @@ Proof.
     { by apply prefix_app_r. }
     iDestruct "Hpredur" as "[Hpredur Hpredurable]".
     wp_apply (release_spec with "[-Hfile Hctx Hpredur Hmembuf_fupd Hmembuf_sl HdurLen Hlen]").
-    { iFrame "#∗". iNext. iExists _, [], (predurableC ++ membufC), _. iFrame "∗#".
+    { iFrame "∗#". iNext. iExists _, [], (predurableC ++ membufC), _. iFrame "∗#".
       rewrite app_nil_r.
       iFrame.
       iSplitL ""; first done.
@@ -594,10 +594,10 @@ Proof.
   wp_loadField.
   wp_apply (release_spec with "[-HΦ Haof_log HfupdQ]").
   {
-    iFrame "#∗".
+    iFrame "∗#".
     iNext.
     iExists _, _, _, _.
-    iFrame "#∗".
+    iFrame "∗#".
     iSplitR ""; last done.
     replace (word.add (length (predurableC ++ membufC)) (length newData)) with
         (U64 (length (predurableC ++ membufC'))); last first.
@@ -663,8 +663,8 @@ Proof.
     wp_loadField.
     wp_apply (wp_condWait with "[- HΦ]").
     {
-      iFrame "#∗".
-      iExists _, _, _, _. iFrame "#∗".
+      iFrame "∗#".
+      iExists _, _, _, _. iFrame "∗#".
       done.
     }
     iIntros "[Hlocked Haof_own]".
@@ -691,8 +691,8 @@ Proof.
   wp_loadField.
   wp_apply (release_spec with "[- HΦ]").
   {
-    iFrame "#∗".
-    iExists _, _, _, _. iFrame "#∗".
+    iFrame "∗#".
+    iExists _, _, _, _. iFrame "∗#".
     done.
   }
   iFrame.

--- a/src/program_proof/lockservice/incr_proxy_proof.v
+++ b/src/program_proof/lockservice/incr_proxy_proof.v
@@ -164,7 +164,7 @@ Proof using Type*.
   iDestruct "HrpcPost" as (reply') "[Hown_reply [%He|(%He & HrpcPost)]]".
   - rewrite He. iNamed "Herrb_ptr". wp_store. wp_load. wp_binop. wp_pures.
     iLeft.
-    iFrame "#∗".
+    iFrame "∗#".
     iSplitL ""; first done.
     iSplitL "Herrb_ptr".
     { iExists _; iFrame. }
@@ -377,7 +377,7 @@ Proof.
   wp_storeField.
   iMod (readonly_alloc_1 with "req") as "#req".
   iApply "HΦ".
-  by iFrame "#∗".
+  by iFrame "∗#".
 Qed.
 
 Variable γ:incrservice_names.
@@ -602,7 +602,7 @@ Proof.
   iSplitL "req".
   { iExists _, _, _, _; iFrame. }
   rewrite HincrSafe.
-  iFrame "#∗".
+  iFrame "∗#".
   by iExists _; iFrame.
 Qed.
 
@@ -790,7 +790,7 @@ Proof.
         iSplitR "Hback_rest Hctx HownCIDs Hfown_lastCID".
         { iRight.
           iExists data2,_,_.
-          iFrame "#∗".
+          iFrame "∗#".
           simpl.
           done.
         }
@@ -820,7 +820,7 @@ Proof.
     { (* Re-prove crash obligation in the special case. Nothing interesting about this. *)
       iDestruct "Hpost" as "[HΦc _]". iModIntro. iApply "HΦc".
       iSplitL "Hreqtok Hpointsto Hrpcclient_own Hfown".
-      - iRight. iFrame. iExists _,_,_; iFrame "#∗".
+      - iRight. iFrame. iExists _,_,_; iFrame "∗#".
         done.
       - by iExists _; iFrame.
     }
@@ -845,7 +845,7 @@ Proof.
       iDestruct "Hpost" as "[HΦc _]".
       iModIntro. iIntros. iApply "HΦc".
       iSplitR "Hghost".
-      - iRight. by iExists _, _, _; iFrame "#∗".
+      - iRight. by iExists _, _, _; iFrame "∗#".
       - by iExists _; iFrame.
     }
     iNext.
@@ -855,7 +855,7 @@ Proof.
     { (* Prove crash obligation after destructing above; TODO: do this earlier *)
       iDestruct "Hpost" as "[HΦc _]". iModIntro. iApply "HΦc". iFrame.
       iSplitR "Hghost".
-      - iRight. by iExists _,_, _; iFrame "#∗".
+      - iRight. by iExists _,_, _; iFrame "∗#".
       - eauto.
     }
    wpc_pures.
@@ -900,7 +900,7 @@ Proof.
       wpc_frame.
       wp_apply (wp_ShortTermIncrClerk__MakePreparedRequest with "His_incrserver [Hown_ck Hisreq]").
       { iNamed "Hown_ck".
-        iFrame "#∗".
+        iFrame "∗#".
         iExists _; iFrame "Hisreq".
       }
 
@@ -932,7 +932,7 @@ Proof.
           iMod (get_request_post with "Hisreq HmakeReqPost HrpcToken") as ">Hbackpointsto"; first done.
           by iFrame.
         }
-        { iRight. by iExists _,_,_; iFrame "#∗". }
+        { iRight. by iExists _,_,_; iFrame "∗#". }
       }
 
       (* Prove the fupd *)

--- a/src/program_proof/lockservice/lockservice_proof.v
+++ b/src/program_proof/lockservice/lockservice_proof.v
@@ -277,7 +277,7 @@ Proof using Type*.
   wp_loadField.
   wp_apply (RPCClient__MakeRequest_spec _ cl_ptr (mkRPCValsC _ _) γ.(ls_rpcGN) with "[] [Hcl]"); eauto.
   {
-    iNamed "Hserver". iNamed "His_rpc". iFrame "# ∗".
+    iNamed "Hserver". iNamed "His_rpc". iFrame "∗#".
   }
   iIntros (v) "Hretv".
 
@@ -341,7 +341,7 @@ Proof using Type*.
   wp_loadField.
   wp_apply (RPCClient__MakeRequest_spec _ cl_ptr (mkRPCValsC _ _) γ.(ls_rpcGN) with "[] [Hcl HP]"); eauto.
   {
-    iNamed "Hserver". iNamed "His_rpc". iFrame "# ∗".
+    iNamed "Hserver". iNamed "His_rpc". iFrame "∗#".
   }
   iIntros (v) "Hretv".
 

--- a/src/program_proof/lockservice/rpc_logatom.v
+++ b/src/program_proof/lockservice/rpc_logatom.v
@@ -404,7 +404,7 @@ Lemma neutralize_request (req:RPCRequestID) γrpc γreq (PreCond:iProp Σ) PostC
   <disc> neutralized_pre γrpc req.(Req_CID) PreCond PostCond.
 Proof.
     iIntros "%HincrSafe #Hsrpc #His_req Hγpost".
-    iFrame "#∗".
+    iFrame "∗#".
 
 
     iInv "His_req" as "[>#Hcseq_lb_strict HN]" "HNClose".
@@ -433,7 +433,7 @@ Proof.
 
       iMod ("HNClose" with "[Hγpost]") as "_".
       {
-        iNext. iFrame "Hcseq_lb_strict". iRight. iFrame "#∗".
+        iNext. iFrame "Hcseq_lb_strict". iRight. iFrame "∗#".
         iApply (fmcounter_map_mono_lb with "Hlb").
         word.
       }
@@ -452,7 +452,7 @@ Proof.
         iNext.
         iFrame "Hcseq_lb_strict".
         iRight.
-        iFrame "# ∗".
+        iFrame "∗#".
       }
       iDestruct "Hreply_post" as (last_reply) "[#Hreply Hpost]".
       iModIntro.

--- a/src/program_proof/lockservice/rpc_logatom_proof.v
+++ b/src/program_proof/lockservice/rpc_logatom_proof.v
@@ -144,7 +144,7 @@ Proof using Type*.
     {
       iSplit; last first.
       { unfold read_request.
-        iFrame "#∗".
+        iFrame "∗#".
         simpl. iPureIntro. lia.
       }
       iFrame "Hreqinv_init".

--- a/src/program_proof/lockservice/two_pc_example.v
+++ b/src/program_proof/lockservice/two_pc_example.v
@@ -345,7 +345,7 @@ Proof.
   {
     iMod (unfinished_coord_aborted_abort with "Hunfinished Hcoordabort") as "#?".
     iMod ("Hpclose" with "[]") as "_".
-    { iRight; iRight. iRight. iFrame "#∗". }
+    { iRight; iRight. iRight. iFrame "∗#". }
     iDestruct "HR" as "[$|>?]"; first by iModIntro.
     iExFalso. iApply coordinator_aborted_unstarted_false; eauto.
   }
@@ -373,7 +373,7 @@ Proof.
     { iExFalso. iApply (unfinished_unfinished_false with "Hunfinished HRfinish"). }
     iFrame.
     iMod ("Htclose" with  "[Hunfinished]"); last by iModIntro.
-    iRight; iRight; iLeft; iFrame "#∗".
+    iRight; iRight; iLeft; iFrame "∗#".
   }
   iDestruct "Ht" as ">#Habort".
   { iExFalso. iApply (unfinished_aborted_false with "[$] [$]"). }
@@ -406,7 +406,7 @@ Proof.
       {
         iMod (do_commit with "Hdodec Hundec") as "#$".
         iMod ("Htclose" with "[HR']"); last by iModIntro.
-        iRight; iRight; iLeft. iFrame "#∗".
+        iRight; iRight; iLeft. iFrame "∗#".
       }
       iDestruct "Ht" as "[[#>Hcommitted _]|Ht]".
       { iExFalso. iApply (do_decide_committed_false with "[$] [$]"). }
@@ -562,12 +562,12 @@ Proof using Type*.
     iDestruct "Hi" as "[Hundec|Hi]".
     {
       iRight; iLeft. iDestruct "Hundec" as "[$ [HR|$]]".
-      iLeft. iExists _; iFrame "#∗".
+      iLeft. iExists _; iFrame "∗#".
     }
     iDestruct "Hi" as "[Hcom|$]".
     {
       iRight; iRight; iLeft. iDestruct "Hcom" as "[$ [HR|$]]".
-      iLeft. iExists _; iFrame "#∗".
+      iLeft. iExists _; iFrame "∗#".
     }
   }
 Qed.
@@ -619,7 +619,7 @@ Proof.
     { done. }
     wp_loadField. wp_apply (release_spec with "[$Hmu_inv $Hmulocked Hkvs Htxns HfinishedTxns HlockMap_ptr HkvsMap HtxnsMap HfinishedTxnsMap Hkvs_ctx Hfreshtxns Htxns_postcommit]").
     {
-      iNext. iExists _, _, _,_,_,_,_; iFrame "#∗".
+      iNext. iExists _, _, _,_,_,_,_; iFrame "∗#".
       done.
     }
     wp_pures.
@@ -638,7 +638,7 @@ Proof.
   { (* Transaction already finished *)
     wp_loadField. wp_apply (release_spec with "[$Hmu_inv $Hmulocked Hkvs Htxns HfinishedTxns HlockMap_ptr HkvsMap HtxnsMap HfinishedTxnsMap Hkvs_ctx Hfreshtxns Htxns_postcommit]").
     {
-      iNext. iExists _, _, _,_,_,_,_; iFrame "#∗".
+      iNext. iExists _, _, _,_,_,_,_; iFrame "∗#".
       done.
     }
     wp_pures.
@@ -666,7 +666,7 @@ Proof.
     wp_pures.
     wp_loadField. wp_apply (release_spec with "[$Hmu_inv $Hmulocked Hkvs Htxns HfinishedTxns HlockMap_ptr HkvsMap HtxnsMap HfinishedTxnsMap Hkvs_ctx Hfreshtxns Htxns_postcommit]").
     {
-      iNext. iExists _, _, _,_,_,_,_; iFrame "#∗".
+      iNext. iExists _, _, _,_,_,_,_; iFrame "∗#".
       done.
     }
     wp_pures.
@@ -859,8 +859,8 @@ Proof.
   { (* No pending transaction with that TID *)
     wp_loadField. wp_apply (release_spec with "[- HΦ]").
     {
-      iFrame "#∗".
-      iNext. iExists _, _, _,_,_,_,_; iFrame "#∗".
+      iFrame "∗#".
+      iNext. iExists _, _, _,_,_,_,_; iFrame "∗#".
       done.
     }
     wp_pures.
@@ -972,8 +972,8 @@ Proof.
   { (* No pending transaction with that TID *)
     wp_loadField. wp_apply (release_spec with "[- HΦ]").
     {
-      iFrame "#∗".
-      iNext. iExists _, _, _,_,_,_,_; iFrame "#∗".
+      iFrame "∗#".
+      iNext. iExists _, _, _,_,_,_,_; iFrame "∗#".
       done.
     }
     wp_pures.

--- a/src/program_proof/memkv/memkv_coord_ghost_init.v
+++ b/src/program_proof/memkv/memkv_coord_ghost_init.v
@@ -33,7 +33,7 @@ Proof.
     iSplitL. { iFrame "Hadd". }
     iFrame "Hget".
   }
-  iExists Γsrv. iFrame "# ∗".
+  iExists Γsrv. iFrame "∗#".
   eauto.
 Qed.
 

--- a/src/program_proof/memkv/memkv_coord_make_proof.v
+++ b/src/program_proof/memkv/memkv_coord_make_proof.v
@@ -200,7 +200,7 @@ Proof.
     iFrame. rewrite big_sepM_empty. eauto.
   }
   unshelve (iMod (readonly_alloc_1 with "mu") as "#mu"); [| apply _ |].
-  iModIntro. iApply "HΦ". iExists _. iFrame "# ∗".
+  iModIntro. iApply "HΦ". iExists _. iFrame "∗#".
 Qed.
 
 End memkv_coord_make_proof.

--- a/src/program_proof/memkv/memkv_coord_start_proof.v
+++ b/src/program_proof/memkv/memkv_coord_start_proof.v
@@ -152,7 +152,7 @@ Proof.
       iIntros (ck_ptr) "(Hclerk&Hclerk_clo)".
       wp_bind (KVShardClerk__MoveShard #ck_ptr #_ #x).
       wp_apply (wp_KVShardClerk__MoveShard with "[$Hclerk]").
-      { iFrame "#His_shard". iPureIntro.
+      { iFrame "His_shard". iPureIntro.
         eapply lookup_lt_Some in Heq. lia. }
       iIntros "Hclerk".
       wp_pures.
@@ -217,7 +217,7 @@ Proof.
       iIntros (ck_ptr) "(Hclerk&Hclerk_clo)".
       wp_bind (KVShardClerk__MoveShard #ck_ptr #_ #x).
       wp_apply (wp_KVShardClerk__MoveShard with "[$Hclerk]").
-      { iFrame "#His_shard". iPureIntro.
+      { iFrame "His_shard". iPureIntro.
         eapply lookup_lt_Some in Heq. lia. }
       iIntros "Hclerk".
       wp_pures.
@@ -310,7 +310,7 @@ Proof.
     iApply (big_sepM_insert_2 with "").
     { (* GetShardMapping RPC handler_is *)
       iExists _.
-      iFrame "#HgetSpec".
+      iFrame "HgetSpec".
 
       clear Φ.
       iIntros (????) "!#".
@@ -349,7 +349,7 @@ Proof.
     iApply (big_sepM_insert_2 with "").
     { (* AddServerRPC *)
       iExists _.
-      iFrame "#HaddSpec".
+      iFrame "HaddSpec".
 
       clear Φ.
       rewrite /is_urpc_handler.

--- a/src/program_proof/memkv/memkv_move_shard_proof.v
+++ b/src/program_proof/memkv/memkv_move_shard_proof.v
@@ -55,7 +55,7 @@ Proof.
       iIntros "Hmap".
       wp_pures.
       iSplit; eauto.
-      iExists _. iFrame "# ∗".
+      iExists _. iFrame "∗#".
       iSplit.
       { iPureIntro. rewrite /typed_map.map_insert lookup_insert; eauto. }
       iApply big_sepM_insert.

--- a/src/program_proof/memkv/memkv_seq_clerk_proof.v
+++ b/src/program_proof/memkv/memkv_seq_clerk_proof.v
@@ -150,7 +150,7 @@ Proof using Type*.
     iApply "HΦ".
     iDestruct ("HcloseShardSet" with "HshardCk") as "HshardSet".
     iDestruct ("HslClose" with "Hsmall_sl") as "?".
-    by iFrame "#∗".
+    by iFrame "∗#".
   }
   {
     wp_loadField.
@@ -166,7 +166,7 @@ Proof using Type*.
 
     iSplitL ""; first done.
     iDestruct "Hatomic" as "[_ $]".
-    iExists _,_,_,_; by iFrame "#∗".
+    iExists _,_,_,_; by iFrame "∗#".
   }
 Qed.
 
@@ -247,7 +247,7 @@ Proof using Type*.
     iApply "Hpost".
     iDestruct ("HcloseShardSet" with "HshardCk") as "HshardSet".
     iDestruct ("HslClose" with "Hsmall_sl") as "?".
-    iModIntro. iExists _, _, _, _. by iFrame "#∗".
+    iModIntro. iExists _, _, _, _. by iFrame "∗#".
   }
   {
     wp_loadField.

--- a/src/program_proof/memkv/memkv_shard_ghost_init.v
+++ b/src/program_proof/memkv/memkv_shard_ghost_init.v
@@ -46,7 +46,7 @@ Proof.
     iSplitL. { iFrame "Hinstall". }
     iFrame "Hfresh".
   }
-  iExists Γsrv. iFrame "# ∗".
+  iExists Γsrv. iFrame "∗#".
   eauto.
 Qed.
 

--- a/src/program_proof/memkv/memkv_shard_make_proof.v
+++ b/src/program_proof/memkv/memkv_shard_make_proof.v
@@ -250,7 +250,7 @@ Proof.
   iMod (readonly_alloc_1 with "mu") as "$".
   iMod (readonly_alloc_1 with "cm") as "$".
   iMod (readonly_alloc_1 with "erpc") as "$".
-  by iFrame "# ∗".
+  by iFrame "∗#".
 Qed.
 
 End memkv_shard_make_proof.

--- a/src/program_proof/memkv/memkv_shard_start_proof.v
+++ b/src/program_proof/memkv/memkv_shard_start_proof.v
@@ -205,7 +205,7 @@ Proof.
     iApply (big_sepM_insert_2 with "").
     { (* MoveShardRPC handler_is *)
       simpl. iExists _.
-      iFrame "#HmoveSpec".
+      iFrame "HmoveSpec".
 
       clear Φ.
       iIntros (????) "!#".

--- a/src/program_proof/mvcc/db_mk.v
+++ b/src/program_proof/mvcc/db_mk.v
@@ -156,7 +156,7 @@ Proof.
     }
     iDestruct (big_sepL_cons with "HactiveAuths") as "[HactiveAuth HactiveAuths]".
     iDestruct (big_sepL_cons with "Hsids") as "[Hsid Hsids]".
-    wp_apply (wp_MkTxnSite with "[HactiveAuth $Hsid]"); first by iFrame "#∗".
+    wp_apply (wp_MkTxnSite with "[HactiveAuth $Hsid]"); first by iFrame "∗#".
     iIntros (site) "HsiteRP".
     wp_pures.
     

--- a/src/program_proof/mvcc/mvcc_inv.v
+++ b/src/program_proof/mvcc/mvcc_inv.v
@@ -314,7 +314,7 @@ Proof.
   { do 2 iExists _.
     apply tuple_mods_rel_last_logi in Htmrel as Hlogi.
     apply (tuplext_linearize_unchanged ts') in Htmrel.
-    iFrame "% ∗".
+    iFrame "∗%".
     iPureIntro.
     split.
     { rewrite -Hlmrel. apply extend_last. }

--- a/src/program_proof/mvcc/tuple_free.v
+++ b/src/program_proof/mvcc/tuple_free.v
@@ -50,7 +50,7 @@ Proof.
     do 4 iExists _.
     iSplitL "Howned Htidlast Hvers HversS".
     { eauto with iFrame. }
-    iFrame "% # ∗".
+    iFrame "∗%#".
     iDestruct "Htoken" as (vchain') "[Hptuple' %HvchainLenLt]".
     destruct owned; last iFrame.
     by iDestruct (vchain_combine (1 / 2) with "Hptuple Hptuple'") as "[Hptuple ->]"; first compute_done.

--- a/src/program_proof/mvcc/tuple_own.v
+++ b/src/program_proof/mvcc/tuple_own.v
@@ -88,7 +88,7 @@ Proof.
     do 4 iExists _.
     iSplitL "Howned Htidlast Hvers HversS".
     { eauto with iFrame. }
-    iFrame "% ∗".
+    iFrame "∗%".
     iFrame "∗ #".
   }
   wp_pures.

--- a/src/program_proof/mvcc/tuple_remove_versions.v
+++ b/src/program_proof/mvcc/tuple_remove_versions.v
@@ -147,7 +147,7 @@ Proof.
       iModIntro.
       unfold P.
       iExists _.
-      iFrame "% ∗".
+      iFrame "∗%".
       iPureIntro.
       right.
       split; first word.
@@ -351,7 +351,7 @@ Proof.
     iExists tid, vers', vchain.
     iSplitL "Howned Htidlast Hvers HversS".
     { eauto with iFrame. }
-    iFrame "% # ∗".
+    iFrame "∗%#".
     iSplit.
     { (* Prove [HtupleAbs]. *)
       iPureIntro.

--- a/src/program_proof/mvcc/txnsite_deactivate.v
+++ b/src/program_proof/mvcc/txnsite_deactivate.v
@@ -171,7 +171,7 @@ Proof.
     iExists _.
     iDestruct (own_slice_sz with "HtidsS") as "%HtidsSz".
     rewrite fmap_length in HtidsSz.
-    iFrame "% ∗".
+    iFrame "∗%".
     iPureIntro.
     split.
     { replace (int.nat _) with (S (int.nat idx)); last word.

--- a/src/program_proof/mvcc/txnsite_mk.v
+++ b/src/program_proof/mvcc/txnsite_mk.v
@@ -46,7 +46,7 @@ Proof.
     unfold own_txnsite.
     iExists (Slice.mk tids 0 8), [], ∅.
     replace (int.nat (U64 0)) with 0%nat by word.
-    iFrame "% # ∗".
+    iFrame "∗%#".
     iPureIntro.
     rewrite fmap_nil.
     split; [done | apply NoDup_nil_2].

--- a/src/program_proof/obj/recovery_proof.v
+++ b/src/program_proof/obj/recovery_proof.v
@@ -839,7 +839,7 @@ Proof.
   iFrame "Hcrash_heaps".
   iSplitL "".
   { iModIntro. iPureIntro. eapply log_crash_to_post_crash; eauto. }
-  iFrame "#∗".
+  iFrame "∗#".
   simpl. iEval (rewrite right_id) in "logheap". iFrame "logheap".
   eauto.
 Qed.

--- a/src/program_proof/proof_prelude.v
+++ b/src/program_proof/proof_prelude.v
@@ -17,35 +17,3 @@ Global Set Default Proof Using "Type".
 Global Set Printing Projections.
 
 Global Opaque load_ty store_ty.
-
-Import sel_patterns.
-
-Fixpoint fix_frame_selpat (Hs: list sel_pat) : list sel_pat :=
-  match Hs with
-  | nil => []
-  | SelIntuitionistic :: Hs => fix_frame_selpat Hs ++ [SelIntuitionistic]
-  | SelPure :: Hs => fix_frame_selpat Hs ++ [SelPure]
-  | s :: Hs => s :: fix_frame_selpat Hs
-  end.
-
-Ltac iFrame_hyps_fast :=
-  repeat match goal with
-         | |- envs_entails ?Δ (?P ∗ _)%I =>
-           lazymatch Δ with
-           | context[Esnoc _ ?i P] => iFrameHyp i
-           end
-         end.
-
-Ltac iFrame_go Hs :=
-  lazymatch Hs with
-  | [] => idtac
-  | SelPure :: ?Hs => iFrameAnyPure; iFrame_go Hs
-  | SelIntuitionistic :: ?Hs => iFrameAnyIntuitionistic; iFrame_go Hs
-  | SelSpatial :: ?Hs => iFrame_hyps_fast; iFrameAnySpatial; iFrame_go Hs
-  | SelIdent ?H :: ?Hs => iFrameHyp H; iFrame_go Hs
-  end.
-
-Tactic Notation "iFrame" constr(Hs) :=
-  let Hs := sel_pat.parse Hs in
-  let Hs := (eval cbv in (fix_frame_selpat Hs)) in
-  iFrame_go Hs.

--- a/src/program_proof/single/try_decide_proof.v
+++ b/src/program_proof/single/try_decide_proof.v
@@ -656,7 +656,7 @@ Proof.
         (* TODO: Pure reasoning to know that numAccepted > f+1 *)
         admit.
       }
-      iFrame "#∗".
+      iFrame "∗#".
       done.
     }
     iApply "HΦ".

--- a/src/program_proof/tutorial/kvservice/full_proof.v
+++ b/src/program_proof/tutorial/kvservice/full_proof.v
@@ -929,7 +929,7 @@ Proof.
   { word. }
   wp_apply (release_spec with "[-HΦ Hspec]").
   {
-    iFrame "#∗". iNext.
+    iFrame "∗#". iNext.
     repeat iExists _.
     iFrame.
     repeat iExists _.
@@ -1023,7 +1023,7 @@ Proof.
     { done. }
     wp_apply (release_spec with "[-HΦ Hspec]").
     {
-      iFrame "#∗". iNext.
+      iFrame "∗#". iNext.
       repeat iExists _; iFrame "Hghost".
       repeat iExists _; iFrame "∗%".
     }
@@ -1049,7 +1049,7 @@ Proof.
   { apply map_get_false in HlastReply as [? _]. done. }
   wp_apply (release_spec with "[-HΦ Hspec]").
   {
-    iFrame "#∗". iNext.
+    iFrame "∗#". iNext.
     repeat iExists _; iFrame "Hghost".
     repeat iExists _; iFrame "∗%".
     iPureIntro. simpl. unfold typed_map.map_insert. by f_equiv.
@@ -1201,7 +1201,7 @@ Proof.
     { by apply map_get_true in HlastReply. }
     wp_apply (release_spec with "[-HΦ Hspec]").
     {
-      iFrame "#∗". iNext.
+      iFrame "∗#". iNext.
       repeat iExists _; iFrame "Hghost".
       repeat iExists _; iFrame "∗%".
     }
@@ -1251,7 +1251,7 @@ Proof.
 
     wp_apply (release_spec with "[-HΦ Hspec Hret]").
     {
-      iFrame "#∗". iNext.
+      iFrame "∗#". iNext.
       repeat iExists _; iFrame "Hghost".
       repeat iExists _; iFrame "∗%".
       iPureIntro.
@@ -1287,7 +1287,7 @@ Proof.
 
   wp_apply (release_spec with "[-HΦ Hspec Hret]").
   {
-    iFrame "#∗". iNext.
+    iFrame "∗#". iNext.
     repeat iExists _; iFrame "Hghost".
     repeat iExists _; iFrame "∗%".
   }
@@ -1383,7 +1383,7 @@ Proof.
     { by apply map_get_true in HlastReply. }
     wp_apply (release_spec with "[-HΦ Hspec]").
     {
-      iFrame "#∗". iNext.
+      iFrame "∗#". iNext.
       repeat iExists _; iFrame "Hghost".
       repeat iExists _; iFrame "∗%".
     }
@@ -1412,7 +1412,7 @@ Proof.
   erewrite <- (server.gauge_proper_default_lookup _ _ st.(server.kvs) Hrel_phys).
   wp_apply (release_spec with "[-HΦ Hspec]").
   {
-    iFrame "#∗". iNext.
+    iFrame "∗#". iNext.
     repeat iExists _; iFrame "Hghost".
     repeat iExists _; iFrame "∗%".
   }

--- a/src/program_proof/tutorial/kvservice/proof.v
+++ b/src/program_proof/tutorial/kvservice/proof.v
@@ -604,7 +604,7 @@ Proof.
   wp_loadField.
   wp_apply (release_spec with "[-HΦ Hspec]").
   {
-    iFrame "#∗". iNext.
+    iFrame "∗#". iNext.
     repeat iExists _.
     iFrame.
   }
@@ -646,7 +646,7 @@ Proof.
     wp_loadField.
     wp_apply (release_spec with "[-HΦ Hspec]").
     {
-      iFrame "#∗". iNext.
+      iFrame "∗#". iNext.
       repeat iExists _.
       iFrame.
     }
@@ -670,7 +670,7 @@ Proof.
   wp_loadField.
   wp_apply (release_spec with "[-HΦ Hspec]").
   {
-    iFrame "#∗". iNext.
+    iFrame "∗#". iNext.
     repeat iExists _.
     iFrame.
   }
@@ -710,7 +710,7 @@ Proof.
     wp_loadField.
     wp_apply (release_spec with "[-HΦ Hspec]").
     {
-      iFrame "#∗". iNext.
+      iFrame "∗#". iNext.
       repeat iExists _.
       iFrame.
     }
@@ -752,7 +752,7 @@ Proof.
     wp_loadField.
     wp_apply (release_spec with "[-HΦ Hspec Hret]").
     {
-      iFrame "#∗". iNext.
+      iFrame "∗#". iNext.
       repeat iExists _.
       iFrame.
     }
@@ -774,7 +774,7 @@ Proof.
   wp_loadField.
   wp_apply (release_spec with "[-HΦ Hspec Hret]").
   {
-    iFrame "#∗". iNext.
+    iFrame "∗#". iNext.
     repeat iExists _.
     iFrame.
   }
@@ -818,7 +818,7 @@ Proof.
     wp_loadField.
     wp_apply (release_spec with "[-HΦ Hspec]").
     {
-      iFrame "#∗". iNext.
+      iFrame "∗#". iNext.
       repeat iExists _.
       iFrame.
     }
@@ -840,7 +840,7 @@ Proof.
   wp_loadField.
   wp_apply (release_spec with "[-HΦ Hspec]").
   {
-    iFrame "#∗". iNext.
+    iFrame "∗#". iNext.
     repeat iExists _.
     iFrame.
   }

--- a/src/program_proof/tutorial/queue/proof.v
+++ b/src/program_proof/tutorial/queue/proof.v
@@ -381,7 +381,7 @@ Proof.
         wp_pures.
         wp_loadField.
         wp_apply (release_spec with "[HlockC H0 Hqueue Hfirst Hcount H1 Helem]").
-        { iFrame "#∗". iNext. iExists _, _, _. iFrame. eauto. }
+        { iFrame "∗#". iNext. iExists _, _, _. iFrame. eauto. }
         wp_pures.
         iModIntro.
         iApply "Post".
@@ -389,7 +389,7 @@ Proof.
       } }
   - wp_loadField.
     wp_apply (release_spec with "[HlockC H0 Hqueue Hfirst Hcount isSlice Helem]").
-    { iFrame "#∗". iNext. iExists _,_,_. iFrame. eauto. }
+    { iFrame "∗#". iNext. iExists _,_,_. iFrame. eauto. }
     wp_pures.
     iModIntro.
     iApply "Post".
@@ -676,7 +676,7 @@ Proof.
     erewrite (remove_one queue1 first1 count1); eauto; try word.
     iDestruct "Helem" as "[Hp Helem]". 
     wp_apply (release_spec with "[HlockC H2 Hqueue Hfirst Hcount H3 Helem]").
-    { iFrame "#∗". 
+    { iFrame "∗#". 
       iNext.
       iExists _, (u64_instance.u64.(word.sub) count1 1).
       iExists _. 

--- a/src/program_proof/txn/twophase_refinement_proof.v
+++ b/src/program_proof/txn/twophase_refinement_proof.v
@@ -123,7 +123,7 @@ Proof.
     wp_apply (wp_Init JRNL_KIND_SIZE (nroot.@"H") with "[Hj]").
     { solve_ndisj. }
     { solve_ndisj. }
-    { iFrame "# ∗". }
+    { iFrame "∗#". }
     iIntros (l') "(Hj&Hopen&H)". iNamed "H".
     iExists _. iFrame "Hj". rewrite /val_interp//=/twophase_val_interp.
     iExists _, _, _, _, _.

--- a/src/program_proof/txn/wrapper_init_proof.v
+++ b/src/program_proof/txn/wrapper_init_proof.v
@@ -301,13 +301,12 @@ Section proof.
         iMod ("Hobj" with "[$]") as "Hobj".
         iDestruct "Hobj" as (mt'' Hdom Heqkinds Hforall) "Hpointstos".
         iExists _, _, _, _. iFrame.
-        rewrite Hdom Heqkinds. iFrame "#Hdom".
+        rewrite Hdom Heqkinds. iFrame "Hdom".
         eauto.
       }
       iSplit; first done.
       iApply "HΦ".
       iFrame "Hj".
-      iSplit; first by iFrame "Hopen".
-      iExists _, _, _, _. by iFrame.
+      by iFrame.
   Qed.
 End proof.

--- a/src/program_proof/vrsm/apps/vkv/clerkpool_proof.v
+++ b/src/program_proof/vrsm/apps/vkv/clerkpool_proof.v
@@ -71,7 +71,7 @@ Proof.
     { word. }
     rewrite skipn_cons drop_0.
     wp_apply (release_spec with "[-HΦ Hcl_own Hl]").
-    { iFrame "#∗". iNext. repeat iExists _. iFrame "∗#". }
+    { iFrame "∗#". iNext. repeat iExists _. iFrame "∗#". }
     wp_pures.
     wp_load.
     wp_bind (f #_).
@@ -93,14 +93,14 @@ Proof.
     wp_storeField.
     wp_loadField.
     wp_apply (release_spec with "[-HΦ Hl]").
-    { iFrame "#∗". iNext. repeat iExists _. iFrame "∗#". done. }
+    { iFrame "∗#". iNext. repeat iExists _. iFrame "∗#". done. }
     wp_pures.
     iApply "HΦ".
   }
   {
     wp_loadField.
     wp_apply (release_spec with "[-HΦ Hl]").
-    { iFrame "#∗". iNext. repeat iExists _. iFrame "∗#". }
+    { iFrame "∗#". iNext. repeat iExists _. iFrame "∗#". }
     wp_pures.
     wp_loadField.
     wp_apply (wp_MakeClerk with "[]").
@@ -125,7 +125,7 @@ Proof.
     wp_storeField.
     wp_loadField.
     wp_apply (release_spec with "[-HΦ Hl]").
-    { iFrame "#∗". iNext. repeat iExists _. iFrame "∗#". done. }
+    { iFrame "∗#". iNext. repeat iExists _. iFrame "∗#". done. }
     wp_pures.
     iApply "HΦ".
   }

--- a/src/program_proof/vrsm/configservice/config_proof.v
+++ b/src/program_proof/vrsm/configservice/config_proof.v
@@ -1346,7 +1346,7 @@ Proof.
   wp_pures.
   wp_loadField.
   wp_apply (release_spec with "[Hlocked Hleader]").
-  { iFrame "#∗". iNext. iExists _; iFrame "∗%". }
+  { iFrame "∗#". iNext. iExists _; iFrame "∗%". }
   wp_pures.
   wp_apply wp_NewSlice.
   iIntros (?) "Hargs_sl".
@@ -1456,7 +1456,7 @@ Proof.
           wp_loadField.
           wp_apply (release_spec with "[Hlocked Hleader]").
           {
-            iFrame "#∗".
+            iFrame "∗#".
             iNext. repeat iExists _; iFrame.
             iPureIntro.
             rewrite Hsl_sz.
@@ -1476,7 +1476,7 @@ Proof.
           wp_loadField.
           wp_apply (release_spec with "[Hlocked Hleader]").
           {
-            iFrame "#∗".
+            iFrame "∗#".
             iNext. repeat iExists _; iFrame "∗%".
           }
           wp_pures.
@@ -1656,7 +1656,7 @@ Proof.
   wp_pures.
   wp_loadField.
   wp_apply (release_spec with "[Hlocked Hleader]").
-  { iFrame "#∗". iNext. iExists _; iFrame "∗%". }
+  { iFrame "∗#". iNext. iExists _; iFrame "∗%". }
   wp_pures.
   wp_load.
   wp_loadField.
@@ -1747,7 +1747,7 @@ Proof.
           wp_loadField.
           wp_apply (release_spec with "[Hlocked Hleader]").
           {
-            iFrame "#∗".
+            iFrame "∗#".
             iNext. repeat iExists _; iFrame.
             iPureIntro.
             rewrite Hsl_sz.
@@ -1766,7 +1766,7 @@ Proof.
           wp_loadField.
           wp_apply (release_spec with "[Hlocked Hleader]").
           {
-            iFrame "#∗".
+            iFrame "∗#".
             iNext. repeat iExists _; iFrame "∗%".
           }
           wp_pures.
@@ -1847,7 +1847,7 @@ Proof.
   wp_pures.
   wp_loadField.
   wp_apply (release_spec with "[Hlocked Hleader]").
-  { iFrame "#∗". iNext. iExists _; iFrame "∗%". }
+  { iFrame "∗#". iNext. iExists _; iFrame "∗%". }
   wp_pures.
   wp_load.
   wp_loadField.
@@ -1929,7 +1929,7 @@ Proof.
           wp_loadField.
           wp_apply (release_spec with "[Hlocked Hleader]").
           {
-            iFrame "#∗".
+            iFrame "∗#".
             iNext. repeat iExists _; iFrame.
             iPureIntro.
             rewrite Hsl_sz.
@@ -1948,7 +1948,7 @@ Proof.
           wp_loadField.
           wp_apply (release_spec with "[Hlocked Hleader]").
           {
-            iFrame "#∗".
+            iFrame "∗#".
             iNext. repeat iExists _; iFrame "∗%".
           }
           wp_pures.

--- a/src/program_proof/vrsm/paxos/tryacquire_proof.v
+++ b/src/program_proof/vrsm/paxos/tryacquire_proof.v
@@ -409,7 +409,7 @@ Proof.
     wp_pures.
     wp_apply (wp_condWait with "[-HΦ Herr]").
     {
-      iFrame "#∗".
+      iFrame "∗#".
       iExists _, _.
       iFrame "∗#".
     }
@@ -670,7 +670,7 @@ Proof.
 
   wp_apply ("Hwp" $! _ _ _ γghost_op with "[-Hfail Htok Hlc2] [-]").
   {
-    iFrame "#∗".
+    iFrame "∗#".
     iInv "Hinv" as "HH" "Hclose".
     iMod (lc_fupd_elim_later with "Hlc1 HH") as "HH".
     iDestruct "HH" as (?) "(Hstate & Hghost & #HQs)".

--- a/src/program_proof/vrsm/replica/apply_proof.v
+++ b/src/program_proof/vrsm/replica/apply_proof.v
@@ -187,7 +187,7 @@ Proof.
   rewrite Hprim.
   iMod (apply_eph_primary_step with "Hupd Hlc Hprimary") as "(Hprimary & #? & #? & #?)".
   { done. }
-  by iFrame "∗#%".
+  by iFrame "∗%#".
 Qed.
 
 Definition own_slice_elt {V} {H:IntoVal V} (sl:Slice.t) (idx:u64) typ q (v:V) : iProp Σ :=
@@ -894,7 +894,7 @@ Proof.
       wp_loadField.
       iDestruct (become_backup with "HghostEph") as "HghostEph".
       wp_apply (release_spec with "[-HΦ Hreply Err Reply Hcred1 Hcred2 Hcred3]").
-      { iFrame "#∗".
+      { iFrame "∗#".
         repeat iExists _; iSplitR "HghostEph"; last iFrame.
         repeat iExists _; iFrame "∗#".
         iFrame "%". by iLeft.
@@ -907,7 +907,7 @@ Proof.
     }
     wp_loadField.
     wp_apply (release_spec with "[-HΦ Hreply Err Reply Hcred1 Hcred2 Hcred3]").
-    { iFrame "#∗".
+    { iFrame "∗#".
       repeat iExists _; iSplitR "HghostEph"; last iFrame.
       repeat iExists _; iFrame "∗#".
       iFrame "%".

--- a/src/program_proof/vrsm/replica/becomeprimary_proof.v
+++ b/src/program_proof/vrsm/replica/becomeprimary_proof.v
@@ -560,7 +560,7 @@ Proof.
       repeat (iExists _).
       iSplitR "HghostEph"; last iFrame.
       repeat (iExists _).
-      iFrame "∗#%".
+      iFrame "∗%#".
       simpl.
       iRight.
       repeat iExists _.

--- a/src/program_proof/vrsm/replica/roapply_proof.v
+++ b/src/program_proof/vrsm/replica/roapply_proof.v
@@ -394,7 +394,7 @@ Proof.
   { done. }
   iFrame "H".
   iMod "Hmask". iModIntro.
-  repeat iExists _; iFrame "∗#%".
+  repeat iExists _; iFrame "∗%#".
 Qed.
 
 Lemma wp_Server__ApplyRo (s:loc) γ γsrv op_sl op (enc_op:list u8) Ψ (Φ: val → iProp Σ) :

--- a/src/program_proof/wal/circ_proof.v
+++ b/src/program_proof/wal/circ_proof.v
@@ -351,7 +351,7 @@ Proof.
     iExists _, _. iFrame. eauto.
   }
   iSplitL "Hstart2 HdiskEnd2 Hγaddrs Hγblocks".
-  { iFrame "#∗". eauto. }
+  { iFrame "∗#". eauto. }
   iSplitL "Haddrs Hblocks Hstart Hend Hend_at_least".
   { iModIntro.
     rewrite /is_circular_state_crash.
@@ -429,7 +429,7 @@ Theorem is_circular_state_pos_acc γ σ :
 Proof.
   iIntros "His_circ".
   iDestruct "His_circ" as "(%Hwf&$&Hrest)"; iIntros "Hpos".
-  iFrame "% ∗".
+  iFrame "∗%".
 Qed.
 
 Theorem is_circular_inner_wf γ addrs blocks σ :

--- a/src/program_proof/wal/circ_proof_crash.v
+++ b/src/program_proof/wal/circ_proof_crash.v
@@ -150,7 +150,7 @@ Proof.
     { rewrite /circ_positions.
       rewrite /start_is /diskEnd_is /diskEnd_at_least /=.
       rewrite HdiskEnd.
-      iFrame "#∗".
+      iFrame "∗#".
       iPureIntro; lia. }
     iExists _, _.
     rewrite /circ_own.
@@ -207,12 +207,12 @@ Proof.
 
   iCache with "HΦ Hpos Haddrs Hblocks Hd0 Hd1 Hd2 Hres".
   { crash_case.
-    iFrame "% ∗". }
+    iFrame "∗%". }
 
   wpc_apply (wpc_Read with "[Hd0]"); first by iFrame.
   iSplit.
   { iLeft in "HΦ". iIntros "Hd0". iApply "HΦ".
-    iFrame "% ∗". }
+    iFrame "∗%". }
 
   iIntros (s0) "!> [Hd0 Hs0]".
   wpc_pures.
@@ -220,7 +220,7 @@ Proof.
   wpc_apply (wpc_Read with "[Hd1]"); first iFrame.
   iSplit.
   { iLeft in "HΦ". iIntros "Hd1". iApply "HΦ".
-    iFrame "% ∗". }
+    iFrame "∗%". }
 
   iIntros (s1) "!> [Hd1 Hs1]".
   wpc_pures.
@@ -375,7 +375,7 @@ Proof.
   - iSplit.
     { iLeft in "HΦ". iDestruct 1 as (i) "(Hd2&%)".
       iApply "HΦ".
-      iFrame "% ∗". }
+      iFrame "∗%". }
 
     iIntros "!> [(_ & HI & Hdiskaddrs & Hd2) Hposl]".
     iDestruct "HI" as (bufSlice) "[Hbufsloc Hupds]".

--- a/src/program_proof/wal/common_proof.v
+++ b/src/program_proof/wal/common_proof.v
@@ -144,7 +144,7 @@ Proof.
   iSplit.
   { iPureIntro. lia. }
   iNamed "HnextDiskEnd".
-  iFrame "#∗".
+  iFrame "∗#".
   iSplit.
   2: {
     iPureIntro.
@@ -349,7 +349,7 @@ Proof.
     { by iFrame. }
     iExists nextDiskEnd_txn_id.
     iSplitL "HownStableSet".
-    { by iFrame "#∗". }
+    { by iFrame "∗#". }
     rewrite subslice_zero_length.
     eapply is_txn_bound in HnextDiskEnd_txn.
     iPureIntro. intuition eauto; lia.

--- a/src/program_proof/wal/flush_proof.v
+++ b/src/program_proof/wal/flush_proof.v
@@ -365,7 +365,7 @@ Proof.
   (* this is very bad, breaks sliding abstraction boundary *)
   iNamed "His_memLog"; iNamed "Hinv". wp_loadField.
   iApply "HΦ".
-  by iFrame "# ∗".
+  by iFrame "∗#".
 Qed.
 
 Theorem wp_Walog__Flush (Q: iProp Σ) l γ dinit txn_id pos :
@@ -427,7 +427,7 @@ Proof.
       iFrame "Hlocked".
       iNamed "HdiskEnd_circ".
       iSplitL.
-      { by iFrame "# ∗". }
+      { by iFrame "∗#". }
       iApply (diskEnd_at_least_mono with "HdiskEnd_at_least"); auto.
   }
 

--- a/src/program_proof/wal/heapspec.v
+++ b/src/program_proof/wal/heapspec.v
@@ -546,7 +546,7 @@ Proof using walheapG0.
     rewrite !dom_insert_L //.
     iSplit; first by (iPureIntro; congruence).
     rewrite big_sepM_insert //.
-    iFrame "#∗".
+    iFrame "∗#".
 Qed.
 
 Lemma wal_heap_inv_crash_as_last_disk crash_heap ls :
@@ -787,7 +787,7 @@ Proof.
   iDestruct "Hcrash_heaps_exchange" as "[H|H]"; iNamed "H".
   - iDestruct (ghost_var_agree with "[$] [$]") as %<-.
     iSplitR "Hcrash_heaps H Hdurable_lb_old2".
-    * iFrame "% # ∗".
+    * iFrame "∗%#".
     * iFrame.
       { iDestruct "Hdurable_lb_old2" as (? n Hle) "H".
         iFrame "%".
@@ -897,7 +897,7 @@ Proof.
   iModIntro.
   iDestruct "resources" as "(?&?&?&?)".
   iFrame.
-  iFrame "%∗".
+  iFrame "∗%".
   apply log_crash_unfold in Htrans as (crash_txn & Hbound & Hls'_eq).
   subst ls'; simpl.
   iSplit; first by (iPureIntro; lia).

--- a/src/program_proof/wal/installer_proof.v
+++ b/src/program_proof/wal/installer_proof.v
@@ -144,7 +144,7 @@ Proof.
   iMod "HinnerN" as "_".
   iFrame.
   iMod ("Hclose" with "[-HQ HΦ]") as "_".
-  { by iFrame "#∗". }
+  { by iFrame "∗#". }
   iIntros "!>" (s) "Hs".
   iApply "HΦ".
   iExists _; iFrame.

--- a/src/program_proof/wal/invariant.v
+++ b/src/program_proof/wal/invariant.v
@@ -905,7 +905,7 @@ Proof.
   iIntros (shutdown' nthread') "Hshutdown Hnthread".
   iExists σ. iFrame "HdiskEnd_circ Hstart_circ HmemLog_linv".
   iExists (set shutdown (λ _, shutdown') (set nthread (λ _, nthread') σₗ)); simpl.
-  by iFrame "# ∗".
+  by iFrame "∗#".
 Qed.
 
 Lemma is_txn_pos_unique txns tid pos pos' :

--- a/src/program_proof/wal/logger_proof.v
+++ b/src/program_proof/wal/logger_proof.v
@@ -72,7 +72,7 @@ Proof.
       wp_pures.
       iApply "HΦ"; iFrame.
       iNamed "Hlkinv".
-      iExists _; iFrame "# ∗".
+      iExists _; iFrame "∗#".
       iPureIntro; inversion 1.
     - iApply "HΦ"; iFrame.
       iPureIntro. split; [done | ].
@@ -812,7 +812,7 @@ Proof.
     wp_if_destruct.
     - wp_pures.
       wp_apply (wp_Walog__logAppend with "[$Hlkinv $Hlk_held $Hlogger]").
-      { iFrame "# ∗". }
+      { iFrame "∗#". }
       iIntros (progress) "(Hlkinv&Hlk_held&Hlogger)".
       wp_pures.
       wp_if_destruct.

--- a/src/program_proof/wal/recovery_proof.v
+++ b/src/program_proof/wal/recovery_proof.v
@@ -473,7 +473,7 @@ Proof.
     rewrite /slidingM.wf /=.
     word. }
   rewrite /named.
-  iFrame "#∗".
+  iFrame "∗#".
   iApply (memLog_linv_init with "HmemLog_pers HmemLog_ghost").
 Qed.
 
@@ -762,7 +762,7 @@ Proof.
     rewrite gset_to_gmap_union_singleton.
     iFrame.
     rewrite big_sepM_insert //.
-    iFrame "#∗".
+    iFrame "∗#".
 Qed.
 
 Lemma map_set_ctx_alloc {K} `{Countable K} `{!mapG Σ K ()} {γ: gname} (s' s: gset K) :
@@ -929,7 +929,7 @@ Lemma memLog_linv_nextDiskEnd_txn_id_post_crash γ diskEnd diskEnd_txn_id instal
   memLog_linv_nextDiskEnd_txn_id γ diskEnd (durable_lb `max` diskEnd_txn_id)%nat.
 Proof.
   iIntros (Hbound) "Hctx #Hpos #HdiskEnd_stable".
-  iExists _; iFrame "#∗".
+  iExists _; iFrame "∗#".
   iPureIntro.
   intros ??.
   apply lookup_gset_to_gmap_None.
@@ -1230,7 +1230,7 @@ Proof.
       iFrame "Htxns_ctx'".
       iFrame "Htxns2".
       iSplitL "Hstable_txns2".
-      { iThaw "#". iExists _. iFrame "# ∗".
+      { iThaw "#". iExists _. iFrame "∗#".
         iPureIntro.
         (* we proved this before with [memLog_linv_nextDiskEnd_txn_id_post_crash] *)
         assumption. }
@@ -1620,7 +1620,7 @@ Proof.
       iSplit; first by auto.
       iSplit; first by auto.
       iExists _. iFrame "Hwal_linv". iFrame "Hcirc". rewrite /disk_inv. iFrame "Howncs".
-      iExists _, _, _. iFrame "# ∗". eauto.
+      iExists _, _, _. iFrame "∗#". eauto.
     }
     { by iFrame. }
   }
@@ -1699,7 +1699,7 @@ Proof.
     HownDiskEnd_logger HownDiskEndTxn_logger
     HownDiskEndMem_logger HownDiskEndMemTxn_logger
   ".
-  { iExists _. iFrame "# ∗". }
+  { iExists _. iFrame "∗#". }
   iFrame "Hinstaller".
 Qed.
 
@@ -1796,7 +1796,7 @@ Proof.
     by wp_apply (wp_Walog__installer with "[$]").
   }
   wp_pures. iIntros "!> H Hcfupd".
-  iApply "H". by iFrame "# ∗".
+  iApply "H". by iFrame "∗#".
 Qed.
 
 End goose_lang.
@@ -1830,7 +1830,7 @@ Proof.
   rewrite /IntoCrash. iNamed 1.
   iNamed "Howninstalled".
   iDestruct "Hbeing_installed_txns" as "-#Hbeing_installed_txns".
-  iCrash. iExists _. iFrame "% ∗".
+  iCrash. iExists _. iFrame "∗%".
 Qed.
 
 Instance disk_inv_stable γ s cs dinit:

--- a/src/program_proof/wal/sliding_proof.v
+++ b/src/program_proof/wal/sliding_proof.v
@@ -77,7 +77,7 @@ Proof.
   replace logSlice.(Slice.sz) with (U64 $ length σ.(slidingM.log)) by word.
   iApply "HΦ". iModIntro.
   iSplit; auto.
-  iExists _, _; iFrame "# ∗".
+  iExists _, _; iFrame "∗#".
 Qed.
 
 Lemma take_0 {A} (l: list A) : take 0 l = [].
@@ -339,7 +339,7 @@ Proof.
   replace (word.add σ.(slidingM.start) logSlice.(Slice.sz)) with (slidingM.endPos σ) by word.
   iApply "HΦ". iModIntro.
   iSplit; auto.
-  iExists _, _; iFrame "# ∗".
+  iExists _, _; iFrame "∗#".
 Qed.
 
 Hint Unfold slidingM.logIndex : word.
@@ -407,7 +407,7 @@ Proof.
   wp_pures.
   iApply "HΦ". iModIntro.
   iSplitL.
-  { iFrame "# % ∗". }
+  { iFrame "∗#%". }
   iPureIntro.
   destruct ok.
   - apply map_get_true in Hmapget as Hindex.
@@ -644,7 +644,7 @@ Proof.
   wp_pures. iModIntro. iApply "HΦ".
   iSplitR.
   { eauto. }
-  iExists _, _; iFrame "# ∗".
+  iExists _, _; iFrame "∗#".
   iExactEq "is_addrPos".
   rewrite /named.
   f_equal.
@@ -871,7 +871,7 @@ Proof.
   { revert Hbks_len; word. }
   iApply "HΦ".
   iSplitR "Hs2 Hblocks".
-  { iFrame "# % ∗". }
+  { iFrame "∗#%". }
   iExists _.
   rewrite -fmap_drop.
   iFrame "Hs2".
@@ -939,7 +939,7 @@ Proof.
   iApply "HΦ".
   iSplitR "Hupds".
   { iSplit; auto.
-    iExists _, _; iFrame "# ∗". }
+    iExists _, _; iFrame "∗#". }
   rewrite take_take.
   iExactEq "Hupds".
   repeat (f_equal; try word).

--- a/src/program_proof/wal/txns_ctx.v
+++ b/src/program_proof/wal/txns_ctx.v
@@ -175,7 +175,7 @@ Lemma txns_ctx_make_factory γ txns crash_txn γ' :
 Proof.
   rewrite {2 3}/txns_ctx /list_ctx /old_txn_factory.
   iIntros "Htxn [Hctx #Hels]".
-  iFrame "#∗".
+  iFrame "∗#".
 Qed.
 
 Lemma old_txn_get γ γ' crash_txn txn_id txn :

--- a/src/program_proof/wp_auto/experiments.v
+++ b/src/program_proof/wp_auto/experiments.v
@@ -144,7 +144,7 @@ Proof.
   { tc_solve. }
   2:{ done. }
   simpl.
-  iFrame "#∗".
+  iFrame "∗#".
   iApply later_sep_l_intro.
   unfold tracker_inv.
   iApply sep_exist_r.


### PR DESCRIPTION
Perennial currently uses a non-standard iFrame for parts of its codebase (the part in `src/program_proof`). I don't think that is still needed, and it makes it unnecessary confusing to copy code between that part of Perennial and the rest of Perennial / other Iris projects.

@tchajed is there any easy way to see whether this introduces terrible performance regressions?