### PR TITLE
Fix python venv inside docker-coq-action container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,8 @@ jobs:
           install: |
             startGroup Install dependencies
               sudo apt-get update
-              sudo apt-get install -y python3 python3-venv sqlite3
-              python3 -m venv ~/.py-venv
-              source ~/.py-venv/bin/activate
-              pip3 install .
+              sudo apt-get install -y python3 python3-pip sqlite3
+              pip3 install --break-system-packages .
             endGroup
           # for permissions issue, see: https://github.com/coq-community/docker-coq-action#permissions.
           before_script: |
@@ -75,10 +73,8 @@ jobs:
           install: |
             startGroup Install dependencies
               sudo apt-get update
-              sudo apt-get install -y python3 python3-venv sqlite3
-              python3 -m venv ~/.py-venv
-              source ~/.py-venv/bin/activate
-              pip3 install .
+              sudo apt-get install -y python3 python3-pip sqlite3
+              pip3 install --break-system-packages .
             endGroup
           before_script: |
             sudo chown -R coq:coq .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,9 @@ jobs:
           install: |
             startGroup Install dependencies
               sudo apt-get update
-              sudo apt-get install -y python3 python3-pip sqlite3
+              sudo apt-get install -y python3 sqlite3
+              python3 -m venv ~/.py-venv
+              source ~/.py-venv/bin/activate
               pip3 install .
             endGroup
           # for permissions issue, see: https://github.com/coq-community/docker-coq-action#permissions.
@@ -73,7 +75,9 @@ jobs:
           install: |
             startGroup Install dependencies
               sudo apt-get update
-              sudo apt-get install -y python3 python3-pip sqlite3
+              sudo apt-get install -y python3 sqlite3
+              python3 -m venv ~/.py-venv
+              source ~/.py-venv/bin/activate
               pip3 install .
             endGroup
           before_script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           install: |
             startGroup Install dependencies
               sudo apt-get update
-              sudo apt-get install -y python3 sqlite3
+              sudo apt-get install -y python3 python3-venv sqlite3
               python3 -m venv ~/.py-venv
               source ~/.py-venv/bin/activate
               pip3 install .
@@ -75,7 +75,7 @@ jobs:
           install: |
             startGroup Install dependencies
               sudo apt-get update
-              sudo apt-get install -y python3 sqlite3
+              sudo apt-get install -y python3 python3-venv sqlite3
               python3 -m venv ~/.py-venv
               source ~/.py-venv/bin/activate
               pip3 install .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,7 @@ jobs:
           install: |
             startGroup Install dependencies
               sudo apt-get update
-              sudo apt-get install -y python3 python3-pip sqlite3
-              pip3 install --break-system-packages .
+              sudo apt-get install -y python3 python3-pandas sqlite3
             endGroup
           # for permissions issue, see: https://github.com/coq-community/docker-coq-action#permissions.
           before_script: |
@@ -73,8 +72,7 @@ jobs:
           install: |
             startGroup Install dependencies
               sudo apt-get update
-              sudo apt-get install -y python3 python3-pip sqlite3
-              pip3 install --break-system-packages .
+              sudo apt-get install -y python3 python3-pandas sqlite3
             endGroup
           before_script: |
             sudo chown -R coq:coq .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ name = "perennial"
 version = "2024.0.0"
 dependencies = [
   "ruff==0.5.5",
-  "pandas==2.2.2",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
docker-coq-action used Python 3.11 instead of 3.9, which requires more isolation.
Also, something changed, and it appears the previous `pip install .`, which wrote some files out, now gives a permissions denied error.