### PR TITLE
Make wp_if_destruct and word more powerful

### DIFF
--- a/new/golang/theory/slice.v
+++ b/new/golang/theory/slice.v
@@ -215,11 +215,7 @@ Proof.
     iApply "HΦ".
     iModIntro.
     rewrite own_slice_unseal own_slice_cap_unseal.
-    assert (len = W64 0); subst.
-    {
-      assert (uint.Z (W64 0) = uint.Z len ∨ uint.Z (W64 0) < uint.Z len) as [|] by word; try word.
-      apply word.unsigned_inj. done.
-    }
+    assert (len = W64 0) by word; subst.
     unfold own_slice_def. unfold own_slice_cap_def. simpl.
     assert (uint.nat (W64 0) = 0)%nat as -> by word.
     simpl. done.

--- a/src/goose_lang/lib/rwlock/rwlock.v
+++ b/src/goose_lang/lib/rwlock/rwlock.v
@@ -285,9 +285,7 @@ Section proof.
         iSplitL "Hl1 Hl2 Hc1"; first (iNext; iExists (word.add u 1); eauto).
         { iFrame.
           rewrite (decide_False); last first.
-          { intros Heq0. rewrite Heq0 in a. word_cleanup.
-            assert (uint.Z 0 = 0%Z) by word.
-            lia. }
+          { intros Heq0. word. }
           iFrame.
         }
         wp_pures. iModIntro. iApply "HΦ". eauto.

--- a/src/goose_lang/lib/rwlock/rwlock_noncrash.v
+++ b/src/goose_lang/lib/rwlock/rwlock_noncrash.v
@@ -265,9 +265,7 @@ Section proof.
         iSplitL "Hl1 Hl2 Hc1"; first (iNext; iExists (word.add u 1); eauto).
         { iFrame.
           rewrite (decide_False); last first.
-          { intros Heq0. rewrite Heq0 in a. word_cleanup.
-            assert (uint.Z 0 = 0%Z) by word.
-            lia. }
+          { intros Heq0. word. }
           iFrame.
         }
         wp_pures. iModIntro. iApply "HΦ". eauto.

--- a/src/goose_lang/lib/slice/slice.v
+++ b/src/goose_lang/lib/slice/slice.v
@@ -395,9 +395,7 @@ Proof.
     iIntros (cap Hcapge).
     wp_pures.
     wp_apply (wp_allocN t); eauto.
-    { apply u64_val_ne in Heqb.
-      change (uint.Z 0) with 0 in Heqb.
-      word. }
+    { word. }
   iIntros (l) "Hl".
   wp_pures.
   rewrite slice_val_fold. iApply "HΦ". rewrite /own_slice /own_slice_small /=.
@@ -429,16 +427,12 @@ Proof.
   rewrite ->bool_decide_false by lia.
   wp_if_destruct.
   - rewrite /slice.nil slice_val_fold.
-    (* FIXME: why can [word] not prove [sz = 0] without this help? *)
-    rewrite unsigned_U64_0 in Hsz.
     assert (sz = 0) as -> by word.
     iApply "HΦ".
     rewrite replicate_0.
     iApply own_slice_zero.
   - wp_apply (wp_allocN t); eauto.
-    { apply u64_val_ne in Heqb.
-      change (uint.Z 0) with 0 in Heqb.
-      word. }
+    { word. }
   iIntros (l) "Hl".
   wp_pures.
   rewrite slice_val_fold. iApply "HΦ". rewrite /own_slice /own_slice_small /=.
@@ -1119,9 +1113,7 @@ Proof.
   - change (uint.nat 0) with 0%nat.
     iEval (rewrite firstn_O array_nil) in "HΦ" .
     iApply "HΦ"; by iFrame.
-  - apply u64_val_ne in Heqb.
-    change (uint.Z 0) with 0 in *.
-    destruct vs1, vs2; simpl in Hvs1, Hvs2; try word.
+  - destruct vs1, vs2; simpl in Hvs1, Hvs2; try word.
     iDestruct (array_cons with "Hdst") as "[Hdst Hvs1]".
     iDestruct (array_cons with "Hsrc") as "[Hsrc Hvs2]".
     wp_load.

--- a/src/goose_lang/lib/waitgroup/waitgroup.v
+++ b/src/goose_lang/lib/waitgroup/waitgroup.v
@@ -434,10 +434,8 @@ Proof.
     { exfalso.
       eapply u64_set_size_all_lt in Hremaining.
       assert (size remaining = 0%nat) as Hzero.
-      { word_cleanup.
-        rewrite /W64 in Heqb.
-        apply word.of_Z_inj_small in Heqb; try lia.
-      }
+      { apply word.of_Z_inj_small in Heqb; try lia.
+        word. }
       apply size_empty_inv in Hzero. set_solver.
     }
     eauto.

--- a/src/program_proof/alloc/alloc_proof.v
+++ b/src/program_proof/alloc/alloc_proof.v
@@ -334,7 +334,6 @@ Proof.
   iIntros (Φ) "H HΦ".
   wp_rec. wp_pures.
   wp_if_destruct.
-  { contradiction Hnonzero. word. }
   wp_apply (wp_freeBit with "H"); eauto.
   wp_pures. by iApply "HΦ".
 Qed.

--- a/src/program_proof/marshal_proof.v
+++ b/src/program_proof/marshal_proof.v
@@ -700,7 +700,7 @@ Proof.
                         "Hdec" ∷ is_dec dec_v ((EncUInt64 <$> todo) ++ r) s q data ∗
                         "*" ∷ ∃ s, "Hsptr" ∷ s_l ↦[slice.T uint64T] (slice_val s) ∗
                                    "Hdone" ∷ own_slice s uint64T (DfracOwn 1) done
-           )%I with "[] [Hi Hsptr Hdec]").
+           )%I _ _ (W64 0) with "[] [Hi Hsptr Hdec]").
   - word.
   - clear Φ.
     iIntros (?) "!>".

--- a/src/program_proof/memkv/memkv_coord_make_proof.v
+++ b/src/program_proof/memkv/memkv_coord_make_proof.v
@@ -97,9 +97,7 @@ Proof.
       { iIntros (? Hin) "H".
         assert (uint.nat i ≠ uint.nat x).
         { cut (i ≠ x).
-          { intros. intros Heq. apply Z2Nat.inj in Heq; try word.
-             apply int_Z_inj in Heq; eauto with *.
-          }
+          { intros. word. }
           move:Hin. set_solver+. }
         rewrite ?list_lookup_insert_ne //.
         iDestruct "H" as (hid ?) "H". iExists hid; iSplit; first eauto.

--- a/src/program_proof/memkv/memkv_coord_start_proof.v
+++ b/src/program_proof/memkv/memkv_coord_start_proof.v
@@ -182,10 +182,7 @@ Proof.
         { subst. rewrite list_lookup_insert; eauto.
           word. }
         { rewrite list_lookup_insert_ne; eauto.
-          intros Heq'.
-          apply Z2Nat.inj in Heq'; try word.
-          eapply (int_Z_inj) in Heq'; eauto. apply _.
-        }
+          word. }
       }
       iModIntro. iIntros (? Hin Hlookup').
       destruct (decide (sid = uint.nat k)).
@@ -241,10 +238,7 @@ Proof.
         { subst. rewrite list_lookup_insert; eauto.
           word. }
         { rewrite list_lookup_insert_ne; eauto.
-          intros Heq'.
-          apply Z2Nat.inj in Heq'; try word.
-          eapply (int_Z_inj) in Heq'; eauto. apply _.
-        }
+          word. }
       }
       iModIntro. iIntros (? Hin Hlookup').
       destruct (decide (sid = uint.nat k)).

--- a/src/program_proof/memkv/memkv_shard_make_proof.v
+++ b/src/program_proof/memkv/memkv_shard_make_proof.v
@@ -159,9 +159,7 @@ Proof.
         { iIntros (??) "H".
           assert (uint.nat i ≠ uint.nat x).
           { cut (i ≠ x).
-            { intros. intros Heq. apply Z2Nat.inj in Heq; try word.
-               apply int_Z_inj in Heq; eauto with *.
-            }
+            { intros. word. }
             set_solver. }
           rewrite ?list_lookup_insert_ne //.
         }
@@ -201,9 +199,7 @@ Proof.
         { iIntros (??) "H".
           assert (uint.nat i ≠ uint.nat x).
           { cut (i ≠ x).
-            { intros. intros Heq. apply Z2Nat.inj in Heq; try word.
-               apply int_Z_inj in Heq; eauto with *.
-            }
+            { intros. word. }
             set_solver. }
           rewrite ?list_lookup_insert_ne //.
         }

--- a/src/program_proof/mvcc/tuple_remove_versions.v
+++ b/src/program_proof/mvcc/tuple_remove_versions.v
@@ -140,7 +140,6 @@ Proof.
     iIntros "[HversX %Hval_ty]".
     destruct (val_to_ver_with_val_ty ver) as (b & d & v & ->); first auto.
     wp_pures.
-    apply u64_val_ne in Heqb.
     rewrite list_lookup_fmap in HSome.
     apply fmap_Some_1 in HSome as (verx & Hlookup & Everx).
     wp_if_destruct.

--- a/src/program_proof/mvcc/txnsite_deactivate.v
+++ b/src/program_proof/mvcc/txnsite_deactivate.v
@@ -178,8 +178,7 @@ Proof.
       rewrite (take_S_r _ _ tidx); last done.
       apply Forall_app_2; first done.
       apply Forall_singleton.
-      apply u64_val_ne in Heqb.
-      unfold not. intros H. rewrite H in Heqb. word.
+      intros H. word.
     }
     { destruct (decide (uint.Z idx < Z.of_nat (length tids) - 1)); first word.
       apply Znot_lt_ge in n.
@@ -192,8 +191,7 @@ Proof.
       rewrite (take_S_r _ _ tidx); last done.
       apply Forall_app_2; first done.
       apply Forall_singleton.
-      apply u64_val_ne in Heqb.
-      unfold not. intros H. rewrite H in Heqb. word.
+      intros H. word.
     }
   }
   { iExists _.

--- a/src/program_proof/mvcc/wrbuf_proof.v
+++ b/src/program_proof/mvcc/wrbuf_proof.v
@@ -338,6 +338,7 @@ Proof.
       word.
     }
     iIntros "wr".
+    subst key.
     word_cleanup.
     set entR := (entsS.(Slice.ptr) +ₗ[_] (uint.Z pos)).
     set ent' := (ent.1.1.1, val, true, ent.2).
@@ -372,7 +373,7 @@ Proof.
     { (* prove insertion to list -> insertion to map representation *)
       rewrite Hmods.
       rewrite list_fmap_insert.
-      subst ent' key. unfold wrent_to_key_dbval. simpl.
+      subst ent'. unfold wrent_to_key_dbval. simpl.
       apply list_to_map_insert with (to_dbval ent.1.2 ent.1.1.2); first by apply NoDup_wrent_to_key_dbval.
       by rewrite list_lookup_fmap Hlookup.
     }
@@ -486,6 +487,7 @@ Proof.
       word.
     }
     iIntros "wr".
+    subst key.
     word_cleanup.
     set entR := (entsS.(Slice.ptr) +ₗ[_] (uint.Z pos)).
     set ent' := (ent.1.1.1, ent.1.1.2, false, ent.2).
@@ -520,7 +522,7 @@ Proof.
     { (* prove insertion to list -> insertion to map representation *)
       rewrite Hmods.
       rewrite list_fmap_insert.
-      subst ent' key. unfold wrent_to_key_dbval. simpl.
+      subst ent'. unfold wrent_to_key_dbval. simpl.
       apply list_to_map_insert with (to_dbval ent.1.2 ent.1.1.2); first by apply NoDup_wrent_to_key_dbval.
       by rewrite list_lookup_fmap Hlookup.
     }

--- a/src/program_proof/simple/setattr.v
+++ b/src/program_proof/simple/setattr.v
@@ -221,9 +221,7 @@ Proof using Ptimeless.
           iDestruct (big_sepM_lookup with "Hnooverflow") as %Hnooverflow; eauto.
           exfalso.
           revert Heqb. word_cleanup. intros.
-          revert H0. rewrite length_replicate. word_cleanup. intros.
-          apply Heqb0. rewrite Z.max_r; last by lia. word_cleanup.
-          f_equal. f_equal. word.
+          revert H0 Heqb0. word.
         }
 
         {

--- a/src/program_proof/tutorial/kvservice/proof.v
+++ b/src/program_proof/tutorial/kvservice/proof.v
@@ -1076,7 +1076,6 @@ Proof.
     iIntros (??) "Hreq_sl Hrep". iNamed 1.
     wp_pures.
     wp_if_destruct.
-    { by exfalso. }
     wp_pures.
     iApply "HΦ".
     by rewrite decide_False.
@@ -1135,7 +1134,6 @@ Proof.
     iNamed 1.
     wp_pures.
     wp_if_destruct.
-    { by exfalso. }
     wp_pures.
     iApply "HΦ".
     by rewrite decide_False.
@@ -1199,7 +1197,6 @@ Proof.
     iNamed 1.
     wp_pures.
     wp_if_destruct.
-    { by exfalso. }
     wp_pures.
     iApply "HΦ".
     by rewrite decide_False.
@@ -1263,7 +1260,6 @@ Proof.
     iNamed 1.
     wp_pures.
     wp_if_destruct.
-    { by exfalso. }
     wp_pures.
     iApply "HΦ".
     by rewrite decide_False.

--- a/src/program_proof/tutorial/queue/proof.v
+++ b/src/program_proof/tutorial/queue/proof.v
@@ -629,8 +629,6 @@ Proof.
       iFrame.
       iFrame "Hqueue".
       iPureIntro.
-      apply u64_val_ne in Heqb.
-      rewrite unsigned_U64_0 in Heqb.
       word.
   - iExists first0, count0, queue0.
     iFrame.

--- a/src/program_proof/util_proof.v
+++ b/src/program_proof/util_proof.v
@@ -29,10 +29,7 @@ Proof.
   iIntros (Hlt) "HΦ".
   wp_rec. wp_pures.
   wp_if_destruct.
-  - assert (uint.Z n = uint.Z m) by word.
-    apply word.unsigned_inj in H; subst.
-    by iFrame.
-  - by iFrame.
+  by iFrame.
 Qed.
 
 Theorem wp_DPrintf stk E (level: u64) (msg arg: val) :

--- a/src/program_proof/vrsm/clerk/clerk_int_proof.v
+++ b/src/program_proof/vrsm/clerk/clerk_int_proof.v
@@ -416,10 +416,6 @@ Proof.
     wp_load.
     wp_pures.
     wp_if_destruct.
-    {
-      exfalso.
-      done.
-    }
     wp_apply (wp_Sleep).
     wp_pures.
     wp_loadField.
@@ -651,7 +647,6 @@ Proof.
       wp_load.
       wp_pures.
       wp_if_destruct.
-      { exfalso. apply Herr. word. }
       wp_load. wp_store.
       wp_apply wp_GetTimeRange. iIntros "* _ _ $ !>".
       wp_pures. wp_storeField. wp_pures.
@@ -670,13 +665,11 @@ Proof.
     iDestruct "Hloopcase" as "[Hsuccess | Hfailure]".
     + iNamed "Hsuccess".
       wp_if_destruct.
-      2: { exfalso. replace (Z.of_nat 0) with (0%Z) in Herrval by word. congruence. }
       iModIntro. iRight. iSplitR; first done.
       wp_pures. wp_load. iApply "HΦ".
 
     + iNamed "Hfailure".
       wp_if_destruct.
-      { exfalso. apply Herrval. word. }
 
       wp_apply wp_RandomUint64. iIntros (?) "_".
       wp_pures.

--- a/src/program_proof/vrsm/configservice/config_proof.v
+++ b/src/program_proof/vrsm/configservice/config_proof.v
@@ -1490,7 +1490,6 @@ Proof.
         wp_load.
         wp_pures.
         wp_if_destruct.
-        { exfalso. done. }
         iModIntro.
         iLeft. iSplitR; first done.
         iExists _; iFrame.
@@ -1501,7 +1500,6 @@ Proof.
     iIntros (?) "%Herr Hreply_sl Hrep".
     wp_pures.
     wp_if_destruct.
-    2:{ exfalso. done. }
     iModIntro. iLeft.
     iSplitR; first done.
     iExists _. iFrame.
@@ -1583,7 +1581,6 @@ Proof.
     iIntros (?) "%Herr Hreply_sl Hrep".
     wp_pures.
     wp_if_destruct.
-    { exfalso. done. }
     iModIntro. iLeft.
     iSplitR; first done.
     iExists _. iFrame.
@@ -1793,7 +1790,6 @@ Proof.
     iIntros (?) "%Herr Hreply_sl Hrep".
     wp_pures.
     wp_if_destruct.
-    2:{ exfalso. done. }
     iModIntro. iNamed 1. iLeft.
     iSplitR; first done.
     iFrame.
@@ -1979,7 +1975,6 @@ Proof.
     iIntros (?) "%Herr Hreply_sl Hrep".
     wp_pures.
     wp_if_destruct.
-    2:{ exfalso. done. }
     iModIntro. iNamed 1. iLeft.
     iSplitR; first done.
     iFrame.

--- a/src/program_proof/vrsm/replica/apply_proof.v
+++ b/src/program_proof/vrsm/replica/apply_proof.v
@@ -109,10 +109,6 @@ Proof.
     iIntros.
     wp_pures.
     wp_if_destruct.
-    {
-      wp_load.
-      exfalso. done.
-    }
     iRight in "HΦ".
     replace (slice.nil) with (slice_val Slice.nil) by done.
     wp_pures.

--- a/src/program_proof/vrsm/replica/applybackup_proof.v
+++ b/src/program_proof/vrsm/replica/applybackup_proof.v
@@ -141,7 +141,6 @@ Proof.
       { exfalso. done. }
       { done. }
     }
-    { exfalso. done. }
   }
 Qed.
 

--- a/src/program_proof/vrsm/replica/becomeprimary_proof.v
+++ b/src/program_proof/vrsm/replica/becomeprimary_proof.v
@@ -92,7 +92,6 @@ Proof.
       iApply "HΦ".
       done.
     }
-    { exfalso. done. }
   }
 Qed.
 
@@ -283,10 +282,8 @@ Proof.
       { (* continue with loop *)
         assert (uint.nat i < length backupγ) as Hi.
         { (* XXX: annoying proof *)
-          rewrite length_cons /= Hreplicas_sz in Hreplicas_backup_len.
-          rewrite length_replicate in Hnew_clerks_sz.
-
-          rewrite length_app in Hlen.
+          autorewrite with len in *.
+          rewrite /= Hreplicas_sz in Hreplicas_backup_len.
           rewrite HcompleteLen in Hlen.
           replace (length backupγ) with (length args.(BecomePrimaryArgs.replicas) - 1) by word.
           rewrite Hreplicas_sz.
@@ -451,8 +448,7 @@ Proof.
       wp_load.
       wp_loadField.
 
-      assert (numClerks = uint.nat numClerks) as HnumClerksSafe.
-      { unfold numClerks. word. }
+      assert (Z.of_nat numClerks < 2^64)%Z as HnumClerksSafe' by (rewrite /numClerks; lia).
 
       wp_apply (wp_SliceSet with "[$Hclerkss_sl]").
       {
@@ -487,9 +483,7 @@ Proof.
       iSplitR.
       {
         iPureIntro.
-        rewrite length_app.
-        simpl.
-        word.
+        len.
       }
       iSplitR.
       {

--- a/src/program_proof/vrsm/replica/getstate_proof.v
+++ b/src/program_proof/vrsm/replica/getstate_proof.v
@@ -130,7 +130,6 @@ Proof.
       replace (zero_val (slice.T byteT)) with (slice_val Slice.nil) by done.
       iFrame.
     }
-    { exfalso. done. }
   }
 Qed.
 

--- a/src/program_proof/vrsm/replica/roapply_proof.v
+++ b/src/program_proof/vrsm/replica/roapply_proof.v
@@ -109,10 +109,6 @@ Proof.
     iIntros.
     wp_pures.
     wp_if_destruct.
-    {
-      wp_load.
-      exfalso. done.
-    }
     iRight in "HΦ".
     replace (slice.nil) with (slice_val Slice.nil) by done.
     wp_pures.

--- a/src/program_proof/vrsm/replica/setstate_proof.v
+++ b/src/program_proof/vrsm/replica/setstate_proof.v
@@ -104,13 +104,7 @@ Proof.
       iApply "HΦ".
       iFrame.
       iModIntro.
-      destruct (decide _).
-      {
-        exfalso. done.
-      }
-      {
-        done.
-      }
+      rewrite decide_False //.
     }
   }
   { (* RPC error *)
@@ -121,11 +115,9 @@ Proof.
       iModIntro.
       iIntros "HΦ".
       iApply "HΦ".
-      destruct (decide (_)).
-      { exfalso. done. }
-      { done. }
+      rewrite -> decide_False by auto.
+      done.
     }
-    { exfalso. done. }
   }
 Qed.
 


### PR DESCRIPTION
- After destructing an equality test, the not equals branch was not simplified. It is now turned into not equals statement over base literals.
- word can now make use of the fact that two words are not equal by deriving that their uint.Z and sint.Z values are inequal.
- `uint.Z (W64 0)` is now simplified in hypotheses, a bug that was a result of a weird implementation where 0 was handled differently from strictly positive literals.
- The addition of `; try contradiction` to `wp_if_destruct` now sometimes solves one of the branches. This isn't required by the other changes but it makes some proofs a bit nicer.

The combination of these changes mean a few scattered proofs throughout become significantly simpler, since word handles more on its own and doesn't need manual pre-processing, and in some cases one branch of an if statement goes away.