### PR TITLE
Improve word's rewriting with a repeat

### DIFF
--- a/src/Helpers/Integers.v
+++ b/src/Helpers/Integers.v
@@ -512,13 +512,15 @@ Ltac word_cleanup_core :=
       | |- not (@eq u32 _ _) => apply (f_not_equal uint.Z)
       | |- not (@eq u8 _ _) => apply (f_not_equal uint.Z)
       end;
-  (* can't replace this with [autorewrite], probably because typeclass inference
+  (* can't replace some of these with [autorewrite], probably because typeclass inference
   isn't the same *)
-  rewrite ?word.unsigned_add, ?word.unsigned_sub,
-  ?word.unsigned_divu_nowrap, ?word.unsigned_modu_nowrap,
-  ?word.unsigned_of_Z, ?word.of_Z_unsigned, ?unsigned_U64, ?unsigned_U32,
-  ?w64_unsigned_ltu;
-  try autorewrite with word;
+  repeat (
+      rewrite -> ?word.unsigned_add, ?word.unsigned_sub,
+      ?word.unsigned_divu_nowrap, ?word.unsigned_modu_nowrap,
+      ?word.unsigned_of_Z, ?word.of_Z_unsigned, ?unsigned_U64, ?unsigned_U32,
+      ?w64_unsigned_ltu
+      || autorewrite with word
+    );
   repeat match goal with
          | [ H: context[word.unsigned (W64 ?x)] |- _ ] => change (uint.Z x) with x in H
          | [ |- context[word.unsigned (W64 ?x)] ] => change (uint.Z x) with x
@@ -557,11 +559,11 @@ Ltac word_cleanup_core :=
          end;
   repeat match goal with
          | |- context[@word.wrap _ ?word ?ok ?z] =>
-           rewrite (@wrap_small _ word ok z) by lia
+           rewrite -> (@wrap_small _ word ok z) by lia
          | |- context[@word.swrap _ ?word ?ok ?z] =>
-           rewrite (@swrap_small _ word ok z) by lia
+           rewrite -> (@swrap_small _ word ok z) by lia
          | |- context[Z.of_nat (Z.to_nat ?z)] =>
-           rewrite (Z2Nat.id z) by lia
+           rewrite -> (Z2Nat.id z) by lia
          end.
 
 (* TODO: only for backwards compatibility.

--- a/src/goose_lang/ffi/grove_ffi/grove_ffi.v
+++ b/src/goose_lang/ffi/grove_ffi/grove_ffi.v
@@ -597,8 +597,7 @@ lemmas. *)
     2: subst new; iFrame "Htsc Hfiles".
     { subst new. word_cleanup.
       case_bool_decide; [ | word ].
-      (* FIXME: word introduces a word.wrap which causes [lia] to fail *)
-      apply Z2Nat.inj_le; lia. }
+      word. }
     iApply "HΦ". iFrame. iPureIntro. lia.
   Qed.
 

--- a/src/goose_lang/lib/rwlock/rwlock.v
+++ b/src/goose_lang/lib/rwlock/rwlock.v
@@ -34,6 +34,8 @@ Section proof.
   Definition remaining_frac (n: u64) :=
     ((Qp_of_Z (remaining_readers n)) * rfrac)%Qp.
 
+  Hint Unfold num_readers remaining_readers : word.
+
   Lemma remaining_frac_read_acquire n :
     1 ≤ uint.Z n →
     uint.Z n < uint.Z (word.add n 1) →
@@ -43,24 +45,13 @@ Section proof.
     intros.
     rewrite -Qp.to_Qc_inj_iff/Qp_of_Z//=.
     assert (Heq1: Qc_of_Z (1 `max` remaining_readers n) = Qc_of_Z (remaining_readers n)).
-    { f_equal. rewrite /remaining_readers.
-      rewrite Z.max_r //. rewrite /num_readers.
-      word_cleanup.
-    }
+    { f_equal. word. }
     assert (Heq2: Qc_of_Z (1 `max` remaining_readers (word.add n 1)) =
                   Qc_of_Z (remaining_readers (word.add n 1))).
-    { f_equal. rewrite /remaining_readers.
-      rewrite Z.max_r //. rewrite /num_readers.
-      word_cleanup.
-    }
+    { f_equal. word. }
     rewrite ?Heq1 ?Heq2.
     assert (Heq3: (remaining_readers (word.add n 1)) = remaining_readers n - 1).
-    { rewrite /remaining_readers/num_readers.
-      word_cleanup.
-      assert ((uint.Z (word.add n 1) - 1) = uint.Z n) as ->.
-      { word_cleanup. }
-      lia.
-    }
+    { word. }
     rewrite Heq3 //=.
     rewrite Z2Qc_inj_sub.
     field_simplify => //=.
@@ -74,21 +65,12 @@ Section proof.
     intros Hlt.
     rewrite -Qp.to_Qc_inj_iff/Qp_of_Z//=.
     assert (Heq1: Qc_of_Z (1 `max` remaining_readers n) = Qc_of_Z (remaining_readers n)).
-    { f_equal. rewrite /remaining_readers.
-      rewrite Z.max_r //. rewrite /num_readers.
-      word_cleanup.
-    }
+    { f_equal. word. }
     assert (Heq2: Qc_of_Z (1 `max` remaining_readers (word.sub n 1)) =
                   Qc_of_Z (remaining_readers (word.sub n 1))).
-    { f_equal. rewrite /remaining_readers.
-      rewrite Z.max_r //. rewrite /num_readers.
-      word_cleanup.
-    }
+    { f_equal. word. }
     rewrite ?Heq1 ?Heq2.
-    assert (Heq3: (remaining_readers (word.sub n 1)) = remaining_readers n + 1).
-    { rewrite /remaining_readers/num_readers.
-      word_cleanup.
-    }
+    assert (Heq3: (remaining_readers (word.sub n 1)) = remaining_readers n + 1) by word.
     rewrite Heq3 //=.
     rewrite Z2Qc_inj_add.
     field_simplify => //=.
@@ -368,7 +350,7 @@ Section proof.
             }
             split.
             - lia.
-            - word_cleanup.
+            - word.
           }
           iFrame.
         }

--- a/src/goose_lang/lib/rwlock/rwlock_noncrash.v
+++ b/src/goose_lang/lib/rwlock/rwlock_noncrash.v
@@ -34,6 +34,8 @@ Section proof.
   Definition remaining_frac (n: u64) :=
     ((Qp_of_Z (remaining_readers n)) * rfrac)%Qp.
 
+  Hint Unfold num_readers remaining_readers : word.
+
   Lemma remaining_frac_read_acquire n :
     1 ≤ uint.Z n →
     uint.Z n < uint.Z (word.add n 1) →
@@ -43,24 +45,15 @@ Section proof.
     intros.
     rewrite -Qp.to_Qc_inj_iff/Qp_of_Z//=.
     assert (Heq1: Qc_of_Z (1 `max` remaining_readers n) = Qc_of_Z (remaining_readers n)).
-    { f_equal. rewrite /remaining_readers.
-      rewrite Z.max_r //. rewrite /num_readers.
-      word_cleanup.
+    { f_equal. word.
     }
     assert (Heq2: Qc_of_Z (1 `max` remaining_readers (word.add n 1)) =
                   Qc_of_Z (remaining_readers (word.add n 1))).
-    { f_equal. rewrite /remaining_readers.
-      rewrite Z.max_r //. rewrite /num_readers.
-      word_cleanup.
-    }
+    { f_equal. word. }
     rewrite ?Heq1 ?Heq2.
     assert (Heq3: (remaining_readers (word.add n 1)) = remaining_readers n - 1).
     { rewrite /remaining_readers/num_readers.
-      word_cleanup.
-      assert ((uint.Z (word.add n 1) - 1) = uint.Z n) as ->.
-      { word_cleanup. }
-      lia.
-    }
+      word. }
     rewrite Heq3 //=.
     rewrite Z2Qc_inj_sub.
     field_simplify => //=.
@@ -76,19 +69,14 @@ Section proof.
     assert (Heq1: Qc_of_Z (1 `max` remaining_readers n) = Qc_of_Z (remaining_readers n)).
     { f_equal. rewrite /remaining_readers.
       rewrite Z.max_r //. rewrite /num_readers.
-      word_cleanup.
+      word.
     }
     assert (Heq2: Qc_of_Z (1 `max` remaining_readers (word.sub n 1)) =
                   Qc_of_Z (remaining_readers (word.sub n 1))).
-    { f_equal. rewrite /remaining_readers.
-      rewrite Z.max_r //. rewrite /num_readers.
-      word_cleanup.
-    }
+    { f_equal. word. }
     rewrite ?Heq1 ?Heq2.
     assert (Heq3: (remaining_readers (word.sub n 1)) = remaining_readers n + 1).
-    { rewrite /remaining_readers/num_readers.
-      word_cleanup.
-    }
+    { word. }
     rewrite Heq3 //=.
     rewrite Z2Qc_inj_add.
     field_simplify => //=.
@@ -347,7 +335,7 @@ Section proof.
             }
             split.
             - lia.
-            - word_cleanup.
+            - word.
           }
           iFrame.
         }

--- a/src/goose_lang/lib/slice/slice.v
+++ b/src/goose_lang/lib/slice/slice.v
@@ -634,12 +634,10 @@ Theorem slice_skip_skip (n m: u64) s t :
 Proof.
   intros Hbound Hwf.
   rewrite /slice_skip /=.
+  f_equal; try word.
+  rewrite !loc_add_assoc.
   f_equal.
-  - rewrite !loc_add_assoc.
-    f_equal.
-    word_cleanup.
-  - repeat word_cleanup.
-  - repeat word_cleanup.
+  word.
 Qed.
 
 Theorem own_slice_cap_skip s t n :
@@ -665,7 +663,7 @@ Theorem own_slice_cap_skip_more s n1 n2 t :
   own_slice_cap (slice_skip s t n1) t -∗ own_slice_cap (slice_skip s t n2) t.
 Proof.
   iIntros (Hbound Hwf) "Hcap".
-  rewrite (slice_skip_skip n2 n1); try (repeat word_cleanup).
+  rewrite (slice_skip_skip n2 n1); [ | word .. ].
   iApply (own_slice_cap_skip with "Hcap"); simpl; try word.
 Qed.
 
@@ -1334,18 +1332,16 @@ Proof.
     iSplitR.
     { rewrite length_app Hlen /=.
       iPureIntro.
-      (* XXX why twice? *)
-      repeat word_cleanup.
+      word.
     }
     iExists extra'.
     simpl.
     iSplitR.
     { iPureIntro.
-      revert Hextralen. repeat word_cleanup.
+      revert Hextralen. word.
     }
     rewrite ?loc_add_assoc. iModIntro.
-    iExactEq "Hfree". f_equal. f_equal.
-    repeat word_cleanup.
+    iExactEq "Hfree". repeat (f_equal; try word).
 
   - wp_apply wp_make_cap.
     iIntros (cap Hcapgt).
@@ -1421,7 +1417,7 @@ Proof.
       * iPureIntro.
         rewrite length_app /=.
         rewrite Hlen /slice_skip /=.
-        word_cleanup. word_cleanup.
+        word.
     }
 
     iExists (replicate (uint.nat cap - uint.nat s.(Slice.sz) - 1) (zero_val t)).
@@ -1429,7 +1425,7 @@ Proof.
     { rewrite length_replicate.
       iPureIntro.
       simpl.
-      word_cleanup. word_cleanup. }
+      word. }
     simpl. iModIntro.
     iExactEq "HnewFree".
     rewrite loc_add_assoc.
@@ -1438,7 +1434,7 @@ Proof.
     replace (uint.nat n) with (length vs1) by done.
     rewrite Hlen'.
     rewrite /slice_take /=.
-    word_cleanup. word_cleanup.
+    word_cleanup.
     replace (ty_size t * uint.Z n + ty_size t * (uint.Z (Slice.sz s) + 1 - uint.Z n))
        with (ty_size t * ( uint.Z n + ( (uint.Z (Slice.sz s) + 1 - uint.Z n) ) ) ) by lia.
     word_eq.

--- a/src/program_proof/buf/buf_proof.v
+++ b/src/program_proof/buf/buf_proof.v
@@ -352,26 +352,23 @@ Proof using.
     unfold block_bytes in *.
     iPureIntro; intuition.
     { destruct K.
-      { simpl. repeat word_cleanup. }
-      { simpl. repeat word_cleanup. }
-      { change (bufSz KindBlock) with (Z.to_nat 4096 * 8)%nat.
-        repeat word_cleanup. }
-    }
+      { simpl. word. }
+      { simpl. word. }
+      { change (W64 (bufSz KindBlock)) with (W64 32768%Z).
+        change (Z.of_nat (bufSz KindBlock)) with 32768 in *.
+        word. }
+      }
     {
       replace (uint.Z s.(Slice.sz)) with (length (Block_to_vals blk) : Z).
       2: { word. }
       rewrite length_Block_to_vals. unfold block_bytes.
-      repeat word_cleanup.
+      word_cleanup.
       destruct K.
-      { simpl. repeat word_cleanup. }
-      { simpl. simpl in Hoff. repeat word_cleanup. }
+      { simpl. word. }
+      { simpl. simpl in Hoff. word. }
       {
-        assert (a.(addrOff) = 0) as Hoff0.
-        { change (bufSz KindBlock) with (Z.to_nat 4096 * 8)%nat in Hoff.
-          word.
-        }
-
-        rewrite Hoff0. vm_compute. intros; congruence.
+        change (Z.of_nat (bufSz KindBlock)) with 32768 in *.
+        word.
       }
     }
   }
@@ -402,9 +399,6 @@ Opaque PeanoNat.Nat.div.
     unfold block_bytes in *.
     intuition idtac.
     word_cleanup.
-    rewrite word.unsigned_sub.
-    rewrite word.unsigned_add.
-    word_cleanup.
     replace (uint.Z a.(addrOff) + Z.of_nat 1 - 1) with (uint.Z a.(addrOff)) by lia.
 
     rewrite -H3 /extract_nth.
@@ -422,9 +416,6 @@ Opaque PeanoNat.Nat.div.
     unfold addr2flat_z in *.
     unfold inode_bytes, block_bytes in *.
     intuition idtac.
-    word_cleanup.
-    rewrite word.unsigned_sub.
-    rewrite word.unsigned_add.
     word_cleanup.
     replace (uint.Z a.(addrOff) + Z.of_nat (Z.to_nat 128 * 8) - 1) with (uint.Z a.(addrOff) + (128*8-1)) by lia.
 

--- a/src/program_proof/crash_lockmap_proof.v
+++ b/src/program_proof/crash_lockmap_proof.v
@@ -616,8 +616,6 @@ Lemma rangeSet_lookup_mod (x : u64) (n : Z) :
 Proof.
   intros.
   apply rangeSet_lookup; try word.
-  word_cleanup.
-  word.
 Qed.
 
 Lemma covered_by_shard_split (P : u64 -> iProp Σ) covered :

--- a/src/program_proof/grove_shared/erpc_proof.v
+++ b/src/program_proof/grove_shared/erpc_proof.v
@@ -414,7 +414,7 @@ Proof.
   wp_storeField.
   wp_apply wp_slice_len.
   wp_apply (wp_NewSliceWithCap (V:=u8)).
-  { apply encoding.unsigned_64_nonneg. (* FIXME why does [word] not solve this? *) }
+  { word. }
   iIntros (req_ptr) "Hreq".
   set len := (X in (Slice.mk req_ptr _ X)).
   wp_pures.

--- a/src/program_proof/grove_shared/urpc_proof.v
+++ b/src/program_proof/grove_shared/urpc_proof.v
@@ -372,7 +372,7 @@ Proof.
   wp_apply (wp_slice_len).
 
   wp_apply (wp_NewSliceWithCap (V:=u8)).
-  { apply encoding.unsigned_64_nonneg. (* FIXME why does [word] not solve this? *) }
+  { word. }
   iIntros (ptr) "Hmsg".
   rewrite replicate_0.
   wp_apply (wp_WriteInt with "Hmsg"). clear ptr.
@@ -844,7 +844,7 @@ Proof.
   wp_pures.
   wp_apply (wp_slice_len).
   wp_apply (wp_NewSliceWithCap (V:=u8)).
-  { apply encoding.unsigned_64_nonneg. (* FIXME why does [word] not solve this? *) }
+  { word. }
   iIntros (ptr) "Hmsg".
   rewrite replicate_0.
   wp_apply (wp_WriteInt with "Hmsg"). clear ptr.

--- a/src/program_proof/lockmap_proof.v
+++ b/src/program_proof/lockmap_proof.v
@@ -491,7 +491,6 @@ Lemma rangeSet_lookup_mod (x : u64) (n : Z) :
 Proof.
   intros.
   apply rangeSet_lookup; try word.
-  repeat word_cleanup; word.
 Qed.
 
 Lemma covered_by_shard_split (P : u64 -> iProp Σ) covered :

--- a/src/program_proof/reconf/ghost_proof.v
+++ b/src/program_proof/reconf/ghost_proof.v
@@ -337,8 +337,7 @@ Proof.
   destruct (decide (uint.nat term' = uint.nat highestTerm)).
   { (* for term' == highestTerm, we have the first part of "oldInfo" *)
     replace (term') with (highestTerm); last first.
-    { (* FIXME: why doesn't word work? *)
-      apply (inj uint.Z).
+    { fold w64. (* FIXME: [word] is looking for [w64], but the type here has that definition unfolded *)
       word. }
     iDestruct (own_valid_2 with "Hproposed' Hproposed") as %Hvalid.
     rewrite singleton_op in Hvalid.

--- a/src/program_proof/tutorial/queue/proof.v
+++ b/src/program_proof/tutorial/queue/proof.v
@@ -242,7 +242,11 @@ Theorem add_one : forall slice (first : u64) (count : u64) e,
 Proof.
   intuition.
   unfold valid_elems.
-  word_cleanup.
+  (* NOTE: needs to carefully do what the old [word_cleanup] would do, so that
+  the statements of [add_one_lemma_1] and [add_one_lemma_2] apply. *)
+  rewrite -> ?word.unsigned_add, ?word.unsigned_sub,
+    ?word.unsigned_modu_nowrap, ?unsigned_U64; [ | word .. ].
+  rewrite -> !wrap_small by word.
   rewrite (subslice_split_r (uint.nat first0) (uint.nat first0 + uint.nat count0) _ (_ ++ _)).
   - rewrite add_one_lemma_1; eauto.
     rewrite app_inv_head_iff.
@@ -341,7 +345,11 @@ Theorem remove_one : forall slice (first : u64) (count : u64) e,
 Proof.
   intuition.
   unfold valid_elems.
-  word_cleanup.
+  (* NOTE: needs to carefully do what the old [word_cleanup] would do, so that
+  the statements of [add_one_lemma_1] and [add_one_lemma_2] apply. *)
+  rewrite -> ?word.unsigned_add, ?word.unsigned_sub,
+    ?word.unsigned_modu_nowrap, ?unsigned_U64; [ | word .. ].
+  rewrite -> !wrap_small by word.
   rewrite (subslice_split_r (uint.nat first0) (uint.nat first0 + 1) _ (_++_)).
   - rewrite (remove_one_lemma_1 slice first0 e); eauto.
     rewrite app_inv_head_iff.

--- a/src/program_proof/wal/circ_proof.v
+++ b/src/program_proof/wal/circ_proof.v
@@ -676,6 +676,13 @@ Proof.
   mod_bound; word.
 Qed.
 
+Theorem wrap_small_log_addr' (x:Z) :
+  word.wrap (word:=w64_word_instance) (2 + x `mod` LogSz) =
+  2 + x `mod` LogSz.
+Proof.
+  word.
+Qed.
+
 Theorem mod_neq_lt a b k :
   0 < k ->
   0 <= a < b ->
@@ -883,7 +890,7 @@ Proof.
   change (word.divu (word.sub 4096 8) 8) with (W64 LogSz).
   wp_apply (wp_Write_atomic with "Hi").
   word_cleanup.
-  rewrite wrap_small_log_addr.
+  rewrite wrap_small_log_addr'.
   word_cleanup.
 
   iInv "Hcirc" as "HcircI" "Hclose".

--- a/src/program_proof/wal/sliding_proof.v
+++ b/src/program_proof/wal/sliding_proof.v
@@ -1257,7 +1257,6 @@ Lemma numMutable_after_clear σ :
 Proof.
   intros Hwf.
   rewrite /slidingM.numMutable /slidingM.endPos /=.
-  word_cleanup.
   word.
 Qed.
 

--- a/src/program_proof/wal/write_proof.v
+++ b/src/program_proof/wal/write_proof.v
@@ -70,9 +70,9 @@ Proof.
   { by iFrame. }
   wp_if_destruct; iApply "HΦ"; iFrame; iPureIntro.
   - symmetry; apply bool_decide_eq_false.
-    revert Heqb; repeat word_cleanup.
+    revert Heqb; word.
   - symmetry; apply bool_decide_eq_true.
-    revert Heqb; repeat word_cleanup.
+    revert Heqb; word.
 Qed.
 
 (* TODO: this intermediate function still provides no value, since it has


### PR DESCRIPTION
The rewrite in [word] that simplified through `uint.Z (word.add ...)` (and similar rewrites for other operations) didn't have a `repeat`, which meant that it would (sometimes) not fully rewrite through multiple operations. This is now fixed, and proofs have been updated to deal with the more powerful tactic.

Where this caused problems was when a manually written lemma was used after a `word_cleanup`, relying on the particular set of rewrites that were performed before. These were mostly in old code, and I expect new code wants a `word` tactic that is as powerful as possible.