### PR TITLE
Rename Mutex and Cond methods for consistency

### DIFF
--- a/src/goose_lang/lib/channel/channel.v
+++ b/src/goose_lang/lib/channel/channel.v
@@ -75,7 +75,7 @@ Proof.
   { eauto. }
   iIntros (chanref) "Hc".
   wp_pures.
-  wp_apply (newlock_spec with "[Hc]").
+  wp_apply (wp_newMutex with "[Hc]").
   2: { 
     iIntros (lk) "Hlk".
     wp_pures.
@@ -197,7 +197,7 @@ Proof.
   wp_rec.
   wp_pures.
   iDestruct "HPre" as "#Hlock".
-  wp_apply acquire_spec.
+  wp_apply wp_Mutex__Lock.
   - iFrame "Hlock".
   - iIntros "[H0 H1]".
     wp_pures.
@@ -214,7 +214,7 @@ Proof.
         reflexivity.
       * iIntros "H3".
         wp_pures.
-        wp_apply (release_spec with "[H0 H2 H3]").
+        wp_apply (wp_Mutex__Unlock with "[H0 H2 H3]").
         { unfold is_channel_alloc. iFrame "Hlock". iFrame. iNext. iExists _, _, l. iFrame. simpl. iNamed "H3". iFrame. done. }
         wp_pures.
         iModIntro.
@@ -227,10 +227,10 @@ Proof.
       wp_apply (wp_IncCap chanref cap eff_cap _ ty l with "H1").
       iIntros "H1".
       wp_pures.
-      wp_apply (release_spec with "[H0 H2 H1]").
+      wp_apply (wp_Mutex__Unlock with "[H0 H2 H1]").
       { unfold is_channel_alloc. iFrame "Hlock". iFrame. iNext. iExists cap, _, l. iFrame. }
       wp_pures.
-      wp_apply acquire_spec.
+      wp_apply wp_Mutex__Lock.
       { unfold is_channel_alloc. iFrame "Hlock". }
       iIntros "[H0 H1]".
       wp_pures.
@@ -245,7 +245,7 @@ Proof.
       iIntros "H1".
       wp_pures.
       destruct l0.
-      * wp_apply (release_spec with "[H0 H2 H1]").
+      * wp_apply (wp_Mutex__Unlock with "[H0 H2 H1]").
         { unfold is_channel_alloc. 
           iFrame "Hlock".
           iFrame.
@@ -259,7 +259,7 @@ Proof.
         done.
       * simpl.
         iDestruct "H2" as "[H2 H3]".
-        wp_apply (release_spec with "[H0 H3 H1]").
+        wp_apply (wp_Mutex__Unlock with "[H0 H3 H1]").
         { unfold is_channel_alloc. 
           iFrame "Hlock".
           iFrame.
@@ -335,7 +335,7 @@ Proof.
   wp_rec.
   wp_pures.
   iDestruct "HPre" as "#Hlock".
-  wp_apply acquire_spec.
+  wp_apply wp_Mutex__Lock.
   - iFrame "Hlock".
   - iIntros "[H0 H1]".
     wp_pures.
@@ -346,7 +346,7 @@ Proof.
       iDestruct "H1" as "[H1 H3]".
       wp_untyped_load.
       wp_pures.
-      wp_apply (release_spec with "[Hlock H0 H1 H3 H2]").
+      wp_apply (wp_Mutex__Unlock with "[Hlock H0 H1 H3 H2]").
       * iFrame "Hlock".
         iFrame.
         iNext.
@@ -362,7 +362,7 @@ Proof.
       wp_apply wp_ChanLen'.
       iIntros (len) "Hlen".
       wp_pures.
-      wp_apply (release_spec with "[Hlock H0 H1 H2]").
+      wp_apply (wp_Mutex__Unlock with "[Hlock H0 H1 H2]").
       { iFrame "Hlock".
         iFrame.
         iNext.
@@ -410,7 +410,7 @@ Proof.
   wp_rec.
   wp_pures.
   iDestruct "HPre" as "#Hlock".
-  wp_apply acquire_spec.
+  wp_apply wp_Mutex__Lock.
     - iFrame "Hlock".
     - iIntros "[H0 H1]".
       wp_pures.
@@ -427,7 +427,7 @@ Proof.
       + wp_apply wp_ChanAppend.
         wp_pures.
         wp_untyped_store.
-        wp_apply (release_spec with "[Hlock Hv H0 H1 H2]").
+        wp_apply (wp_Mutex__Unlock with "[Hlock Hv H0 H1 H2]").
         { iFrame "Hlock".
           iFrame.
           iNext.
@@ -439,7 +439,7 @@ Proof.
         iModIntro.
         iApply "HΦ".
         done.
-      + wp_apply (release_spec with "[Hlock H0 H1 H2]").
+      + wp_apply (wp_Mutex__Unlock with "[Hlock H0 H1 H2]").
         { iFrame "Hlock".
           iFrame.
           iNext.

--- a/src/goose_lang/lib/lock/crash_lock.v
+++ b/src/goose_lang/lib/lock/crash_lock.v
@@ -67,7 +67,7 @@ Section proof.
     iSplitL "Hwpc".
     { iExact "Hwpc". }
 
-    iApply (newlock_spec Nlock _ (crash_borrow R Rcrash) with "[$Hborrow]").
+    iApply (wp_newMutex Nlock _ (crash_borrow R Rcrash) with "[$Hborrow]").
     iNext.
     iIntros (lk) "His_lock HP".
     iApply "HP". eauto.
@@ -105,18 +105,18 @@ Section proof.
     iApply (init_cancel_elim with "H"). eauto.
   Qed.
 
-  Lemma acquire_spec E (R Rcrash : iProp Σ) lk:
+  Lemma wp_Mutex__Lock E (R Rcrash : iProp Σ) lk:
     ↑Nlock ⊆ E →
     {{{ is_crash_lock lk R Rcrash }}}
     lock.acquire lk @ E
     {{{ RET #(); crash_locked lk R Rcrash }}}.
   Proof.
     iIntros (? Φ) "#Hcrash HΦ".
-    wp_apply (acquire_spec' with "Hcrash"); auto.
+    wp_apply (wp_Mutex__Lock' with "Hcrash"); auto.
     iIntros "(?&?)". iApply "HΦ". iFrame. iFrame "#".
   Qed.
 
-  Lemma partial_try_acquire_spec E lk R Rcrash R' Rcrash':
+  Lemma partial_try_wp_Mutex__Lock E lk R Rcrash R' Rcrash':
     ↑Nlock ⊆ E →
     □ (R' -∗ R ∗ (R -∗ R') ∧ (Rcrash -∗ Rcrash')) -∗
     □ (R -∗ Rcrash) -∗
@@ -161,7 +161,7 @@ Section proof.
       iSplitL ""; eauto.
   Qed.
 
-  Lemma partial_acquire_spec E lk R Rcrash R' Rcrash':
+  Lemma partial_wp_Mutex__Lock E lk R Rcrash R' Rcrash':
     ↑Nlock ⊆ E →
     □ (R' -∗ R ∗ (R -∗ R') ∧ (Rcrash -∗ Rcrash')) -∗
     □ (R -∗ Rcrash) -∗
@@ -169,7 +169,7 @@ Section proof.
     {{{ is_crash_lock lk R' Rcrash' }}} lock.acquire lk @ E {{{ RET #(); partial_crash_locked lk R Rcrash }}}.
   Proof.
     iIntros (?) "#H1 #H2 #H3". iIntros (Φ) "!> #Hl HΦ". iLöb as "IH". wp_rec.
-    iPoseProof (partial_try_acquire_spec E with "H1 H2") as "H"; first done.
+    iPoseProof (partial_try_wp_Mutex__Lock E with "H1 H2") as "H"; first done.
     wp_apply "H"; auto.
     iIntros ([]).
     - iIntros "Hlked". wp_pures. iApply "HΦ"; by iFrame.
@@ -197,7 +197,7 @@ Section proof.
       * iIntros.  iIntros "!>". eauto.
   Qed.
 
-  Lemma release_spec E (R Rcrash : iProp Σ) lk:
+  Lemma wp_Mutex__Unlock E (R Rcrash : iProp Σ) lk:
     ↑Nlock ⊆ E →
     {{{ crash_locked lk R Rcrash }}}
     lock.release lk @ E
@@ -205,13 +205,13 @@ Section proof.
   Proof.
     iIntros (? Φ) "Hcrash_locked HΦ".
     iDestruct "Hcrash_locked" as "(Hfull&#His_lock&Hlocked)".
-    wp_apply (release_spec' with "[His_lock Hlocked Hfull]"); swap 1 2.
+    wp_apply (wp_Mutex__Unlock' with "[His_lock Hlocked Hfull]"); swap 1 2.
     { iFrame "His_lock". iFrame. }
     { auto. }
     by iApply "HΦ".
   Qed.
 
-  Lemma partial_release_spec E (R Rcrash : iProp Σ) lk:
+  Lemma partial_wp_Mutex__Unlock E (R Rcrash : iProp Σ) lk:
     ↑Nlock ⊆ E →
     {{{ partial_crash_locked lk R Rcrash }}}
     lock.release lk @ E
@@ -260,7 +260,7 @@ Section proof.
     wpc_bind (lock.acquire lk).
     wpc_frame "Hwp".
     { iDestruct "Hwp" as "($&_)".  }
-    iApply (acquire_spec with "Hcrash").
+    iApply (wp_Mutex__Lock with "Hcrash").
     { set_solver. }
     iNext. iIntros "H Hwp".
     wpc_pures.
@@ -285,7 +285,7 @@ Section proof.
 
     wpc_frame "H".
     { iDestruct "H" as "($&_)". }
-    iApply (release_spec with "Hlocked").
+    iApply (wp_Mutex__Unlock with "Hlocked").
     { auto. }
     iNext. iIntros "_ H".
     { iDestruct "H" as "(_&$)". }

--- a/src/goose_lang/lib/lock/impl.v
+++ b/src/goose_lang/lib/lock/impl.v
@@ -1,24 +1,42 @@
 From Perennial.goose_lang Require Import notation.
 
+Section goose_lang.
+  Context {ext:ffi_syntax}.
+
+  (* This models `&Mutex{}` in Go. It is lowercase since it does not correspond
+  to a method from Go's sync package. *)
+  Definition newMutex: val := λ: <>, ref #false.
+  Definition Mutex__TryLock : val := λ: "l", CAS "l" #false #true.
+  Definition Mutex__Lock : val :=
+    rec: "acquire" "l" := if: Mutex__TryLock "l" then #() else "acquire" "l".
+  Definition Mutex__Unlock : val := λ: "l", CmpXchg "l" #true #false;; #().
+
+  Definition NewCond: val := λ: "l", ref "l".
+
+  (* no-op in the model, only affects scheduling *)
+  Definition Cond__Signal: val := λ: "l", #().
+  Definition Cond__Broadcast: val := λ: "l", #().
+  Definition Cond__Wait: val := λ: "l", Mutex__Unlock !"l";;
+                                      (* actual cond var waits for a signal
+                                          here, but the model does not take this
+                                          into account *)
+                                      Mutex__Lock !"l".
+  Definition Cond__WaitTimeout: val := λ: "l" "timeout", Cond__Wait "l".
+
+End goose_lang.
+
+(* abbreviations for backwards compatibility
+
+TODO: migrate all clients
+*)
 Module lock.
-  Section goose_lang.
-    Context {ext:ffi_syntax}.
-
-    Definition new: val := λ: <>, ref #false.
-    Definition try_acquire : val := λ: "l", CAS "l" #false #true.
-    Definition acquire : val :=
-      rec: "acquire" "l" := if: try_acquire "l" then #() else "acquire" "l".
-    Definition release : val := λ: "l", CmpXchg "l" #true #false;; #().
-
-    Definition newCond: val := λ: "l", ref "l".
-    (* no-op in the model, only affects scheduling *)
-    Definition condSignal: val := λ: "l", #().
-    Definition condBroadcast: val := λ: "l", #().
-    Definition condWait: val := λ: "l", release !"l";;
-                                        (* actual cond var waits for a signal
-                                           here, but the model does not take this
-                                           into account *)
-                                        acquire !"l".
-    Definition condWaitTimeout: val := λ: "l" "timeout", condWait "l".
-  End goose_lang.
+  Notation new := newMutex (only parsing).
+  Notation try_acquire := Mutex__TryLock (only parsing).
+  Notation acquire := Mutex__Lock (only parsing).
+  Notation release := Mutex__Unlock (only parsing).
+  Notation newCond := NewCond (only parsing).
+  Notation condSignal := Cond__Signal (only parsing).
+  Notation condBroadcast := Cond__Broadcast (only parsing).
+  Notation condWait := Cond__Wait (only parsing).
+  Notation condWaitTimeout := Cond__WaitTimeout (only parsing).
 End lock.

--- a/src/goose_lang/lib/rwlock/rwlock.v
+++ b/src/goose_lang/lib/rwlock/rwlock.v
@@ -214,7 +214,7 @@ Section proof.
     iApply "Hwp". eauto.
   Qed.
 
-  Lemma try_read_acquire_spec E lk R Rc :
+  Lemma try_read_wp_Mutex__Lock E lk R Rc :
     ↑N ⊆ E →
     {{{ is_rwlock lk R Rc }}} rwlock.try_read_acquire lk @ E
     {{{ b, RET #b; if b is true then crash_borrow (R rfrac) (Rc rfrac) else True }}}.
@@ -278,16 +278,16 @@ Section proof.
       * wp_pures. iModIntro. iApply "HΦ". eauto.
   Qed.
 
-  Lemma read_acquire_spec lk R Rc :
+  Lemma read_wp_Mutex__Lock lk R Rc :
     {{{ is_rwlock lk R Rc }}} rwlock.read_acquire lk {{{ RET #(); crash_borrow (R rfrac) (Rc rfrac) }}}.
   Proof.
     iIntros (Φ) "#Hl HΦ". iLöb as "IH". wp_rec.
-    wp_apply (try_read_acquire_spec with "Hl"); auto. iIntros ([]).
+    wp_apply (try_read_wp_Mutex__Lock with "Hl"); auto. iIntros ([]).
     - iIntros "H". wp_pures. iApply "HΦ"; by iFrame.
     - iIntros "_". wp_pures. iApply ("IH" with "[HΦ]"). auto.
   Qed.
 
-  Lemma try_read_release_spec lk R Rc :
+  Lemma try_read_wp_Mutex__Unlock lk R Rc :
     {{{ is_rwlock lk R Rc ∗ crash_borrow (R rfrac) (Rc rfrac) }}} rwlock.try_read_release lk
     {{{ b, RET #b; if b is false then crash_borrow (R rfrac) (Rc rfrac) else True }}}.
   Proof.
@@ -360,16 +360,16 @@ Section proof.
     - wp_pures. iModIntro. iApply "HΦ". eauto.
   Qed.
 
-  Lemma read_release_spec lk R Rc :
+  Lemma read_wp_Mutex__Unlock lk R Rc :
     {{{ is_rwlock lk R Rc ∗ crash_borrow (R rfrac) (Rc rfrac) }}} rwlock.read_release lk {{{ RET #(); True }}}.
   Proof.
     iIntros (Φ) "(#Hl&Hcb) HΦ". iLöb as "IH". wp_rec.
-    wp_apply (try_read_release_spec with "[$Hl $Hcb]"); auto. iIntros ([]).
+    wp_apply (try_read_wp_Mutex__Unlock with "[$Hl $Hcb]"); auto. iIntros ([]).
     - iIntros "H". wp_pures. iApply "HΦ"; by iFrame.
     - iIntros "H". wp_pures. iApply ("IH" with "[$] [HΦ]"). auto.
   Qed.
 
-  Lemma try_write_acquire_spec lk R Rc :
+  Lemma try_write_wp_Mutex__Lock lk R Rc :
     {{{ is_rwlock lk R Rc }}} rwlock.try_write_acquire lk
     {{{ b, RET #b; if b is true then wlocked lk ∗ crash_borrow (R 1%Qp) (Rc 1%Qp) else True }}}.
   Proof.
@@ -400,18 +400,18 @@ Section proof.
       wp_pures. by iApply "HΦ".
   Qed.
 
-  Lemma write_acquire_spec lk R Rc :
+  Lemma write_wp_Mutex__Lock lk R Rc :
     {{{ is_rwlock lk R Rc }}}
       rwlock.write_acquire lk
     {{{ RET #(); wlocked lk ∗ crash_borrow (R 1%Qp) (Rc 1%Qp) }}}.
   Proof.
     iIntros (Φ) "#Hl HΦ". iLöb as "IH". wp_rec.
-    wp_apply (try_write_acquire_spec with "Hl"); auto. iIntros ([]).
+    wp_apply (try_write_wp_Mutex__Lock with "Hl"); auto. iIntros ([]).
     - iIntros "[Hlked HR]". wp_pures. iApply "HΦ"; by iFrame.
     - iIntros "_". wp_pures. iApply ("IH" with "[HΦ]"). auto.
   Qed.
 
-  Lemma release_spec lk R Rc :
+  Lemma wp_Mutex__Unlock lk R Rc :
     {{{ is_rwlock lk R Rc ∗ wlocked lk ∗ crash_borrow (R 1%Qp) (Rc 1%Qp) }}}
       rwlock.write_release lk
     {{{ RET #(); True }}}.

--- a/src/goose_lang/lib/rwlock/rwlock_derived.v
+++ b/src/goose_lang/lib/rwlock/rwlock_derived.v
@@ -100,41 +100,41 @@ Section proof.
   Qed.
 
 
-  Lemma read_acquire_spec lk R Rc :
+  Lemma read_wp_Mutex__Lock lk R Rc :
     {{{ is_crash_rwlock lk R Rc }}} rwlock.read_acquire lk {{{ RET #(); crash_borrow (R rfrac) (Rc rfrac) }}}.
   Proof.
     iIntros (Φ) "#Hl HΦ".
-    wp_apply (read_acquire_spec with "[$]").
+    wp_apply (read_wp_Mutex__Lock with "[$]").
     eauto.
   Qed.
 
-  Lemma read_release_spec lk R Rc :
+  Lemma read_wp_Mutex__Unlock lk R Rc :
     {{{ is_crash_rwlock lk R Rc ∗ crash_borrow (R rfrac) (Rc rfrac) }}}
       rwlock.read_release lk
     {{{ RET #(); True }}}.
   Proof.
     iIntros (Φ) "(Hlock&Hborrow) HΦ".
-    wp_apply (read_release_spec with "[$Hlock $Hborrow]").
+    wp_apply (read_wp_Mutex__Unlock with "[$Hlock $Hborrow]").
     iApply "HΦ"; eauto.
   Qed.
 
-  Lemma write_acquire_spec lk R Rc :
+  Lemma write_wp_Mutex__Lock lk R Rc :
     {{{ is_crash_rwlock lk R Rc }}}
       rwlock.write_acquire lk
     {{{ RET #(); wlocked lk ∗ crash_borrow (R 1%Qp) (Rc 1%Qp) }}}.
   Proof.
     iIntros (Φ) "Hlock HΦ".
-    wp_apply (write_acquire_spec with "[$Hlock]").
+    wp_apply (write_wp_Mutex__Lock with "[$Hlock]").
     iApply "HΦ"; eauto.
   Qed.
 
-  Lemma release_spec lk R Rc :
+  Lemma wp_Mutex__Unlock lk R Rc :
     {{{ is_crash_rwlock lk R Rc ∗ wlocked lk ∗ crash_borrow (R 1%Qp) (Rc 1%Qp) }}}
       rwlock.write_release lk
     {{{ RET #(); True }}}.
   Proof.
     iIntros (Φ) "(Hlock&Hborrow) HΦ".
-    wp_apply (release_spec with "[$Hlock $Hborrow]").
+    wp_apply (wp_Mutex__Unlock with "[$Hlock $Hborrow]").
     iApply "HΦ"; eauto.
   Qed.
 

--- a/src/goose_lang/lib/rwlock/rwlock_noncrash.v
+++ b/src/goose_lang/lib/rwlock/rwlock_noncrash.v
@@ -213,7 +213,7 @@ Section proof.
     iApply "Hwp". eauto.
   Qed.
 
-  Lemma try_read_acquire_spec E lk R :
+  Lemma try_read_wp_Mutex__Lock E lk R :
     ↑N ⊆ E →
     {{{ is_rwlock lk R }}} rwlock.try_read_acquire lk @ E
     {{{ b, RET #b; if b is true then (R rfrac) else True }}}.
@@ -264,16 +264,16 @@ Section proof.
       * wp_pures. iModIntro. iApply "HΦ". eauto.
   Qed.
 
-  Lemma read_acquire_spec lk R :
+  Lemma read_wp_Mutex__Lock lk R :
     {{{ is_rwlock lk R }}} rwlock.read_acquire lk {{{ RET #(); R rfrac }}}.
   Proof.
     iIntros (Φ) "#Hl HΦ". iLöb as "IH". wp_rec.
-    wp_apply (try_read_acquire_spec with "Hl"); auto. iIntros ([]).
+    wp_apply (try_read_wp_Mutex__Lock with "Hl"); auto. iIntros ([]).
     - iIntros "H". wp_pures. iApply "HΦ"; by iFrame.
     - iIntros "_". wp_pures. iApply ("IH" with "[HΦ]"). auto.
   Qed.
 
-  Lemma try_read_release_spec lk R :
+  Lemma try_read_wp_Mutex__Unlock lk R :
     {{{ is_rwlock lk R ∗ (R rfrac) }}} rwlock.try_read_release lk
     {{{ b, RET #b; if b is false then (R rfrac) else True }}}.
   Proof.
@@ -345,16 +345,16 @@ Section proof.
     - wp_pures. iModIntro. iApply "HΦ". eauto.
   Qed.
 
-  Lemma read_release_spec lk R :
+  Lemma read_wp_Mutex__Unlock lk R :
     {{{ is_rwlock lk R ∗ (R rfrac) }}} rwlock.read_release lk {{{ RET #(); True }}}.
   Proof.
     iIntros (Φ) "(#Hl&Hcb) HΦ". iLöb as "IH". wp_rec.
-    wp_apply (try_read_release_spec with "[$Hl $Hcb]"); auto. iIntros ([]).
+    wp_apply (try_read_wp_Mutex__Unlock with "[$Hl $Hcb]"); auto. iIntros ([]).
     - iIntros "H". wp_pures. iApply "HΦ"; by iFrame.
     - iIntros "H". wp_pures. iApply ("IH" with "[$] [HΦ]"). auto.
   Qed.
 
-  Lemma try_write_acquire_spec lk R :
+  Lemma try_write_wp_Mutex__Lock lk R :
     {{{ is_rwlock lk R }}} rwlock.try_write_acquire lk
     {{{ b, RET #b; if b is true then wlocked lk ∗ (R 1%Qp) else True }}}.
   Proof.
@@ -385,18 +385,18 @@ Section proof.
       wp_pures. by iApply "HΦ".
   Qed.
 
-  Lemma write_acquire_spec lk R :
+  Lemma write_wp_Mutex__Lock lk R :
     {{{ is_rwlock lk R }}}
       rwlock.write_acquire lk
     {{{ RET #(); wlocked lk ∗ (R 1%Qp)}}}.
   Proof.
     iIntros (Φ) "#Hl HΦ". iLöb as "IH". wp_rec.
-    wp_apply (try_write_acquire_spec with "Hl"); auto. iIntros ([]).
+    wp_apply (try_write_wp_Mutex__Lock with "Hl"); auto. iIntros ([]).
     - iIntros "[Hlked HR]". wp_pures. iApply "HΦ"; by iFrame.
     - iIntros "_". wp_pures. iApply ("IH" with "[HΦ]"). auto.
   Qed.
 
-  Lemma release_spec lk R :
+  Lemma wp_Mutex__Unlock lk R :
     {{{ is_rwlock lk R ∗ wlocked lk ∗ (R 1%Qp) }}}
       rwlock.write_release lk
     {{{ RET #(); True }}}.

--- a/src/goose_lang/lib/waitgroup/waitgroup.v
+++ b/src/goose_lang/lib/waitgroup/waitgroup.v
@@ -215,7 +215,7 @@ Proof.
   iDestruct "His" as (??) "(%HwgPair & Hlk)".
   rewrite HwgPair.
   wp_pures.
-  wp_apply (acquire_spec with "Hlk").
+  wp_apply (wp_Mutex__Lock with "Hlk").
   iIntros "[Hlocked Hown]".
   wp_pures.
   iNamed "Hown".
@@ -233,7 +233,7 @@ Proof.
     apply Hremaining in Hbad.
     word.
   }
-  iApply (release_spec with "[$Hlocked $Hlk Htotal HP Htoks Hv]").
+  iApply (wp_Mutex__Unlock with "[$Hlocked $Hlk Htotal HP Htoks Hv]").
   {
     iNext.
     iExists (remaining ∪ {[total]}).
@@ -328,14 +328,14 @@ Proof.
   rewrite HwgPair.
   wp_pures.
 
-  wp_apply (acquire_spec with "Hlk").
+  wp_apply (wp_Mutex__Lock with "Hlk").
   iIntros "[Hlocked Hown]".
   wp_pures.
   iNamed "Hown".
   wp_load.
   wp_store.
 
-  iApply (release_spec with "[$Hlocked $Hlk Htotal HP Htoks Hv Htok HPn]").
+  iApply (wp_Mutex__Unlock with "[$Hlocked $Hlk Htotal HP Htoks Hv Htok HPn]").
   {
     iNext.
     iExists (remaining ∖ {[n]}), total.
@@ -408,7 +408,7 @@ Proof.
   rewrite HwgPair.
   wp_pures.
 
-  wp_apply (acquire_spec with "Hlk").
+  wp_apply (wp_Mutex__Lock with "Hlk").
   iIntros "[Hlocked Hown]".
   wp_pures.
   iNamed "Hown".
@@ -419,7 +419,7 @@ Proof.
 
   iDestruct "HP" as "#HP".
 
-  wp_apply (release_spec with "[$Hlocked $Hlk Htotal Htoks Hv]").
+  wp_apply (wp_Mutex__Unlock with "[$Hlocked $Hlk Htotal Htoks Hv]").
   {
     iNext.
     iExists _, _. iFrame.  eauto.

--- a/src/program_proof/alloc/alloc_proof.v
+++ b/src/program_proof/alloc/alloc_proof.v
@@ -103,7 +103,7 @@ Proof.
   iIntros (Φ) "H HΦ". iNamed "H".
   wp_rec. wp_pures.
   wp_loadField.
-  wp_apply (acquire_spec with "[$]").
+  wp_apply (wp_Mutex__Lock with "[$]").
   iIntros "[Hlocked Hlinv]".
   wp_pures.
   iNamed "Hlinv".
@@ -117,7 +117,7 @@ Proof.
   iIntros "Hbits".
   wp_pures.
   wp_loadField.
-  wp_apply (release_spec with "[$His_lock $Hlocked next bitmap Hbits]").
+  wp_apply (wp_Mutex__Unlock with "[$His_lock $Hlocked next bitmap Hbits]").
   { rewrite -list_fmap_insert.
     iExists _, _, _; iFrame "∗%".
     rewrite length_insert.
@@ -218,7 +218,7 @@ Proof.
   iIntros (num_l) "num".
   wp_pures.
   wp_loadField.
-  wp_apply (acquire_spec with "His_lock").
+  wp_apply (wp_Mutex__Lock with "His_lock").
   iIntros "[Hlocked Hlinv]".
   wp_apply (wp_incNext with "Hlinv"); auto.
   iIntros (?) "[%Hnext_bound Hlinv]".
@@ -270,7 +270,7 @@ Proof.
   - iNamed 1.
     wp_pures.
     wp_loadField.
-    wp_apply (release_spec with "[$His_lock $Hlocked $Hlinv]").
+    wp_apply (wp_Mutex__Unlock with "[$His_lock $Hlocked $Hlinv]").
     wp_load.
     iApply "HΦ".
     iPureIntro; done.
@@ -286,7 +286,7 @@ Proof.
   iIntros (Φ) "H HΦ". iNamed "H".
   wp_rec. wp_pures.
   wp_loadField.
-  wp_apply (acquire_spec with "[$]").
+  wp_apply (wp_Mutex__Lock with "[$]").
   iIntros "[Hlocked Hlinv]".
   wp_pures.
   iNamed "Hlinv".
@@ -300,7 +300,7 @@ Proof.
   iIntros "Hbits".
   wp_pures.
   wp_loadField.
-  wp_apply (release_spec with "[$His_lock $Hlocked next bitmap Hbits]").
+  wp_apply (wp_Mutex__Unlock with "[$His_lock $Hlocked next bitmap Hbits]").
   { rewrite -list_fmap_insert.
     iExists _, _, _; iFrame "∗%".
     rewrite length_insert.
@@ -390,7 +390,7 @@ Proof.
   iIntros (Φ) "H HΦ". iNamed "H".
   wp_rec. wp_pures.
   wp_loadField.
-  wp_apply (acquire_spec with "[$]").
+  wp_apply (wp_Mutex__Lock with "[$]").
   iIntros "[Hlocked Hlinv]".
   wp_pures.
   iNamed "Hlinv".
@@ -426,7 +426,7 @@ Proof.
   - iIntros "[Hinv Hbits]". iNamed "Hinv".
     wp_pures.
     wp_loadField.
-    wp_apply (release_spec with "[$His_lock $Hlocked next bitmap Hbits]").
+    wp_apply (wp_Mutex__Unlock with "[$His_lock $Hlocked next bitmap Hbits]").
     { iExists _, _, _; iFrame "∗%". }
     wp_load.
     wp_pures.

--- a/src/program_proof/aof/proof.v
+++ b/src/program_proof/aof/proof.v
@@ -491,7 +491,7 @@ Proof.
     iClear "HlenCond HdurCond HoldDurCond HcloCond Hcrash_wand Hctx_inv".
     iNamed "His_aof".
     wp_loadField.
-    wp_apply (acquire_spec with "Hmu_inv").
+    wp_apply (wp_Mutex__Lock with "Hmu_inv").
     iIntros "[Hlocked Haof_own]".
     wp_pures.
     iAssert (∃ data',
@@ -540,7 +540,7 @@ Proof.
     wp_if_destruct.
     {
       wp_loadField.
-      wp_apply (wp_condWait with "[- closed2 Hfile_ctx]").
+      wp_apply (wp_Cond__Wait with "[- closed2 Hfile_ctx]").
       { by iFrame "HlenCond Hmu_inv ∗#". }
       iIntros "[Hlocked Haof_own]".
       wp_pures.
@@ -683,14 +683,14 @@ Proof.
       iCombine "HdurLen HdurableLength" as "HdurLen".
       wp_storeField.
       wp_loadField.
-      wp_apply (wp_condBroadcast).
+      wp_apply (wp_Cond__Broadcast).
       { iFrame "#". }
       wp_pures.
       iCombine "closed2 Hclosed" as "Hclosed".
       wp_storeField.
       iDestruct "Hclosed" as "(closed2&Hclosed)".
       wp_loadField.
-      wp_apply (wp_condBroadcast).
+      wp_apply (wp_Cond__Broadcast).
       { iFrame "#". }
       wp_pures.
       wp_loadField.
@@ -707,7 +707,7 @@ Proof.
         iFrame "∗#".
       }
 
-      wp_apply (release_spec with "[-Hlen closed2]").
+      wp_apply (wp_Mutex__Unlock with "[-Hlen closed2]").
       {
         iFrame "Hmu_inv Hcrash_wand Hlocked".
         iNext.
@@ -748,7 +748,7 @@ Proof.
     wp_storeField.
     wp_loadField.
 
-    wp_apply (release_spec with "[-Hfile_ctx Hpredur Hdur Hmembuf_fupd Hmembuf_sl HdurLen Hlen closed2]").
+    wp_apply (wp_Mutex__Unlock with "[-Hfile_ctx Hpredur Hdur Hmembuf_fupd Hmembuf_sl HdurLen Hlen closed2]").
     { iFrame "Hmu_inv Hlocked Hcrash_wand". iNext. iExists _, [], (predurableC ++ membufC),_, _, _.
       rewrite app_nil_r. iFrame "∗#".
       iSplitL ""; first done.
@@ -840,7 +840,7 @@ Proof.
 
     wp_pures.
     wp_loadField.
-    wp_apply (acquire_spec with "Hmu_inv").
+    wp_apply (wp_Mutex__Lock with "Hmu_inv").
     iIntros "[Hlocked Haof_own]".
     iRename "Hdurlen_lb" into "Hdurlen_lb_old".
     iClear "Hcrash_wand".
@@ -853,7 +853,7 @@ Proof.
     iCombine "HdurLen HdurableLength" as "HdurLen".
     wp_storeField.
 
-    wp_apply (wp_condBroadcast).
+    wp_apply (wp_Cond__Broadcast).
     { iFrame "#". }
     wp_pures.
     iLeft.
@@ -904,7 +904,7 @@ Proof.
   wp_pures.
 
   wp_loadField.
-  wp_apply (acquire_spec with "Hmu_inv").
+  wp_apply (wp_Mutex__Lock with "Hmu_inv").
   iIntros "[Hlocked Haof]".
   iNamed "Haof".
   iDestruct "Hpre" as "(HnewData & Haof_log & Hfupd)".
@@ -936,7 +936,7 @@ Proof.
   rewrite -HH in HnoOverflow.
   wp_pures.
   wp_loadField.
-  wp_apply (wp_condSignal).
+  wp_apply (wp_Cond__Signal).
   { iFrame "#". }
 
   wp_pures.
@@ -1154,7 +1154,7 @@ Proof.
   iMod "HH" as "[Hmembuf_fupd HfupdQ]".
 
   wp_loadField.
-  wp_apply (release_spec with "[-HΦ Haof_log HfupdQ Htok]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ Haof_log HfupdQ Htok]").
   {
     iFrame "Hmu_inv Hlocked Hcrash_wand".
     iNext.
@@ -1200,7 +1200,7 @@ Proof.
   wp_pures.
   iNamed "Haof".
   wp_loadField.
-  wp_apply (acquire_spec with "Hmu_inv").
+  wp_apply (wp_Mutex__Lock with "Hmu_inv").
   iIntros "[Hlocked Haof_own]".
   wp_pures.
   wp_apply wp_ref_of_zero.
@@ -1257,7 +1257,7 @@ Proof.
   {
     wp_pures.
     wp_load.
-    wp_apply (wp_condWait with "[- HΦ Hcond]").
+    wp_apply (wp_Cond__Wait with "[- HΦ Hcond]").
     {
       iFrame "His_cond Hmu_inv HdurableCond". by iFrame "∗#".
     }
@@ -1284,7 +1284,7 @@ Proof.
   wp_pures.
 
   wp_loadField.
-  wp_apply (release_spec with "[- HΦ]").
+  wp_apply (wp_Mutex__Unlock with "[- HΦ]").
   {
     by iFrame "Hmu_inv HdurableCond ∗#".
   }
@@ -1307,14 +1307,14 @@ Proof.
   wp_pures.
   iNamed "Haof".
   wp_loadField.
-  wp_apply (acquire_spec with "Hmu_inv").
+  wp_apply (wp_Mutex__Lock with "Hmu_inv").
   iIntros "[Hlocked Haof_own]".
   wp_pures.
   iNamed "Haof_own".
   iNamed "Hclose".
   wp_storeField.
   wp_loadField.
-  wp_apply (wp_condSignal).
+  wp_apply (wp_Cond__Signal).
   { iFrame "#". }
   wp_pures.
 
@@ -1339,7 +1339,7 @@ Proof.
   { (* aof not closed yet, keep looping *)
     wp_pures.
     wp_loadField.
-    wp_apply (wp_condWait with "[-Htok HΦ]").
+    wp_apply (wp_Cond__Wait with "[-Htok HΦ]").
     {
       iFrame "Hmu_inv HdurableCond HoldDurableCond Hclosed HcloseRequested".
       by iFrame "∗#".
@@ -1375,7 +1375,7 @@ Proof.
 
   wp_pures.
   wp_loadField.
-  wp_apply (release_spec with "[-HΦ Hf]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ Hf]").
   {
     iFrame "Hmu_inv HdurableCond ∗#%".
     by simpl.

--- a/src/program_proof/append_log_hocap.v
+++ b/src/program_proof/append_log_hocap.v
@@ -171,7 +171,7 @@ Proof.
   wpc_bind (lock.acquire _).
   wpc_frame "HΦ Hvs".
   { iLeft in "HΦ". iRight in "Hvs". do 2 iModIntro. by iApply "HΦ". }
-  wp_apply (crash_lock.acquire_spec with "His_lock"); first by set_solver+.
+  wp_apply (crash_lock.wp_Mutex__Lock with "His_lock"); first by set_solver+.
   iIntros "Hcrash_locked".
   iNamed 1.
 
@@ -221,7 +221,7 @@ Proof.
 
   wp_bind (struct.loadF _ _ _).
   wp_loadField.
-  wp_apply (crash_lock.release_spec with "[$]"); eauto.
+  wp_apply (crash_lock.wp_Mutex__Unlock with "[$]"); eauto.
   iIntros "(HQ&HΦ)".
   by iApply "HΦ".
 Qed.

--- a/src/program_proof/asyncfile/proof.v
+++ b/src/program_proof/asyncfile/proof.v
@@ -206,7 +206,7 @@ Proof.
   iNamed "H".
   iNamed "His".
   wp_loadField.
-  wp_apply (acquire_spec with "[$]").
+  wp_apply (wp_Mutex__Lock with "[$]").
   iIntros "[Hlocked Hown]".
   wp_pures.
 
@@ -217,7 +217,7 @@ Proof.
   wp_if_destruct.
   { (* case: wait *)
     wp_pures. wp_loadField.
-    wp_apply (wp_condWait with "[-Htok HΦ]").
+    wp_apply (wp_Cond__Wait with "[-Htok HΦ]").
     {
       iFrame "HdurableIndexCond_is HmuInv Hlocked".
       repeat iExists _; iFrame "∗#%".
@@ -235,7 +235,7 @@ Proof.
     wp_loadField.
     iDestruct (get_write_witness i with "[$]") as "#Hwit".
     { word. }
-    wp_apply (release_spec with "[-Htok HΦ]").
+    wp_apply (wp_Mutex__Unlock with "[-Htok HΦ]").
     {
       iFrame "HmuInv Hlocked".
       repeat iExists _; iFrame "∗#%".
@@ -367,7 +367,7 @@ Proof.
   iAssert (_) with "His" as "His2".
   iNamed "His2".
   wp_loadField.
-  wp_apply (acquire_spec with "[$]").
+  wp_apply (wp_Mutex__Lock with "[$]").
   iIntros "[Hlocked Hown]".
   iNamed "Hown".
   wp_pures.
@@ -383,11 +383,11 @@ Proof.
   { word. }
   iDestruct "H" as "(Hnoclose & Hdat & Hghost & Hesc & #Hinv)".
   iMod (readonly_alloc_1 with "Hdata_in") as "#Hdata_in".
-  wp_apply wp_condSignal.
+  wp_apply wp_Cond__Signal.
   { iFrame "#". }
   wp_pures.
   wp_loadField.
-  wp_apply (release_spec with "[-HΦ Hnoclose Hdat Hesc]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ Hnoclose Hdat Hesc]").
   {
     iFrame "HmuInv Hlocked".
     iNext.
@@ -477,7 +477,7 @@ Proof.
   wp_rec.
   iNamed "His".
   wp_loadField.
-  wp_apply (acquire_spec with "[$]").
+  wp_apply (wp_Mutex__Lock with "[$]").
   iIntros "[Hlocked Hown]".
   wp_pures.
   iAssert (∃ curdata curidx,
@@ -500,7 +500,7 @@ Proof.
   wp_if_destruct.
   {
     wp_loadField.
-    wp_apply (wp_condWait with "[-HΦ HH]").
+    wp_apply (wp_Cond__Wait with "[-HΦ HH]").
     {
       iFrame "HindexCond_is HmuInv Hlocked".
       repeat iExists _; iFrame "∗#%".
@@ -519,7 +519,7 @@ Proof.
   iNamed "HH".
   iMod (get_upd with "[$] [$] [$] [$]") as "H".
   iDestruct "H" as "(HpreData & HpreIdx & HdurIdx & Hupd & Hghost)".
-  wp_apply (release_spec with "[-HΦ HpreData HpreIdx HdurIdx Hupd Hfile]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ HpreData HpreIdx HdurIdx Hupd Hfile]").
   {
     iFrame "HmuInv Hlocked".
     repeat iExists _; iFrame "∗#%".
@@ -569,14 +569,14 @@ Proof.
 
   wp_pures.
   wp_loadField.
-  wp_apply (acquire_spec with "[$]").
+  wp_apply (wp_Mutex__Lock with "[$]").
   iIntros "[Hlocked Hown]".
   iClear "Hfilename Hdata HindexCond_is HdurableIndexCond_is".
   iNamed "Hown".
   wp_pures.
   wp_storeField.
   wp_loadField.
-  wp_apply wp_condBroadcast.
+  wp_apply wp_Cond__Broadcast.
   { iFrame "#". }
   wp_pures.
   iMod (update_durable_index with "[$] HnewWits [$]") as "[HdurIdx Hghost]".

--- a/src/program_proof/cachekv/proof.v
+++ b/src/program_proof/cachekv/proof.v
@@ -183,7 +183,7 @@ Proof.
   wp_pures.
   iNamed "Hkv".
   wp_loadField.
-  wp_apply (acquire_spec with "[$]").
+  wp_apply (wp_Mutex__Lock with "[$]").
   iIntros "[Hlocked Hown]".
   iNamed "Hown".
   wp_pures.
@@ -219,7 +219,7 @@ Proof.
     wp_if_destruct.
     2:{ exfalso. word. }
     wp_loadField.
-    wp_apply (release_spec with "[-HΦ]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ]").
     { iFrame "HmuInv∗". iNext.
       repeat iExists _; eauto with iFrame.
     }
@@ -245,7 +245,7 @@ Proof.
     iIntros "Hcache".
     wp_pures.
     wp_loadField.
-    wp_apply (release_spec with "[-Hau]").
+    wp_apply (wp_Mutex__Unlock with "[-Hau]").
     { iFrame "HmuInv∗". iNext.
       repeat iExists _.
       iFrame.
@@ -429,7 +429,7 @@ Proof.
     iIntros "_".
     wp_pures.
     wp_loadField.
-    wp_apply (acquire_spec with "[$]").
+    wp_apply (wp_Mutex__Lock with "[$]").
     iIntros "[Hlocked Hown]".
     iNamed "Hown".
     wp_pures.
@@ -450,7 +450,7 @@ Proof.
     rewrite /map_get /typed_map.map_insert lookup_insert /= in Hlookup.
     injection Hlookup as ? ?. subst.
     wp_loadField.
-    wp_apply (release_spec with "[-HΦ]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ]").
     {
       iFrame "HmuInv ∗".
       iNext.

--- a/src/program_proof/crash_lockmap_proof.v
+++ b/src/program_proof/crash_lockmap_proof.v
@@ -173,7 +173,7 @@ Proof.
 
   wp_rec. wp_pures.
   wp_loadField.
-  wp_apply (acquire_spec with "Hlock").
+  wp_apply (wp_Mutex__Lock with "Hlock").
   iIntros "[Hlocked Hinner]".
 
   wp_pures.
@@ -223,7 +223,7 @@ Proof.
 
         wp_untyped_load.
         wp_loadField.
-        wp_apply (lock.wp_condWait with "[-HΦloop Hstate Hacquired]").
+        wp_apply (lock.wp_Cond__Wait with "[-HΦloop Hstate Hacquired]").
         {
           iFrame "Hlock Hcond Hlocked".
           iExists _, _.
@@ -402,7 +402,7 @@ Proof.
   }
   iIntros "(Hinner & Hlocked & Hp & Haddrlocked)".
   wp_loadField.
-  wp_apply (release_spec with "[Hlocked Hinner]").
+  wp_apply (wp_Mutex__Unlock with "[Hlocked Hinner]").
   {
     iSplitR. { iApply "Hlock". }
     iFrame.
@@ -421,7 +421,7 @@ Proof.
   iNamed "Hls".
   wp_rec. wp_pures.
   wp_loadField.
-  wp_apply (acquire_spec with "Hlock").
+  wp_apply (wp_Mutex__Lock with "Hlock").
   iIntros "[Hlocked Hinner]".
   iDestruct "Hinner" as (m gm) "(Hmptr & Hghctx & Haddrs & Hcovered)".
 
@@ -452,12 +452,12 @@ Proof.
   {
     wp_pures.
     wp_loadField.
-    wp_apply (lock.wp_condSignal with "[$Hcond]").
+    wp_apply (lock.wp_Cond__Signal with "[$Hcond]").
 
     iMod (ghost_map_update false with "Hghctx Haddrlocked") as "[Hghctx Haddrlocked]".
 
     wp_loadField.
-    wp_apply (release_spec with "[-HΦ]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ]").
     {
       iFrame "Hlock Hlocked".
       iExists _, _.
@@ -550,7 +550,7 @@ Proof.
     iMod (ghost_map_delete with "Hghctx Haddrlocked") as "Hghctx".
 
     wp_loadField.
-    wp_apply (release_spec with "[-HΦ]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ]").
     {
       iFrame "∗ Hlock".
       iExists _, (delete addr gm).

--- a/src/program_proof/ctrexample/server.v
+++ b/src/program_proof/ctrexample/server.v
@@ -151,7 +151,7 @@ Proof.
   wp_rec.
   iNamed "Hsrv".
   wp_loadField.
-  wp_apply (acquire_spec with "HmuInv").
+  wp_apply (wp_Mutex__Lock with "HmuInv").
   { done. }
   iIntros "Hres".
   wp_pures.
@@ -225,7 +225,7 @@ Proof.
     iFrame.
   }
   iApply wp_wpc.
-  wp_apply (release_spec with "[Hres]").
+  wp_apply (wp_Mutex__Unlock with "[Hres]").
   { done. }
   { unfold crash_locked.
     iFrame.

--- a/src/program_proof/examples/alloc_crash_proof.v
+++ b/src/program_proof/examples/alloc_crash_proof.v
@@ -732,7 +732,7 @@ Proof.
 
   wp_bind (lock.acquire _).
   wp_loadField.
-  wp_apply (acquire_spec' with "His_lock"); first assumption.
+  wp_apply (wp_Mutex__Lock' with "His_lock"); first assumption.
   iIntros "(His_locked & Hinner)"; iNamed "Hinner".
 
   wp_loadField.
@@ -795,7 +795,7 @@ Proof.
     iModIntro.
     iIntros "(Hborrow&Hborrows)".
     wp_loadField.
-    wp_apply (release_spec' with "[Hfreeset_frag Hblocks Hborrows Hfreemap $His_locked $His_lock]");
+    wp_apply (wp_Mutex__Unlock' with "[Hfreeset_frag Hblocks Hborrows Hfreemap $His_locked $His_lock]");
       first assumption.
     { iExists _; iFrame.
       rewrite alloc_free_reserve. eauto.
@@ -819,7 +819,7 @@ Proof.
     { iNext. iExists _. iFrame. iPureIntro. eauto. }
 
     wp_loadField.
-    wp_apply (release_spec' with "[Hfreeset_frag Hblocks Hborrows Hfreemap $His_locked $His_lock]");
+    wp_apply (wp_Mutex__Unlock' with "[Hfreeset_frag Hblocks Hborrows Hfreemap $His_locked $His_lock]");
       first assumption.
     { iExists _; iFrame. rewrite Hk set_empty_difference. iFrame. }
     wp_pures.
@@ -1056,7 +1056,7 @@ Proof.
   iMod (readonly_load with "free") as (?) "free'".
   wp_rec. wp_pures.
   wp_loadField.
-  wp_apply (acquire_spec' with "His_lock").
+  wp_apply (wp_Mutex__Lock' with "His_lock").
   { auto. }
   iIntros "(Hlocked&Hinv)"; iNamed "Hinv".
   wp_loadField.
@@ -1108,7 +1108,7 @@ Proof.
     iIntros "($&$)". eauto. }
   wp_loadField.
   iIntros "Hborrows".
-  wp_apply (release_spec' with "[$His_lock $Hlocked Hmapsto Hfreemap Hfreeset_frag Hblocks Hborrows]").
+  wp_apply (wp_Mutex__Unlock' with "[$His_lock $Hlocked Hmapsto Hfreemap Hfreeset_frag Hblocks Hborrows]").
   { auto. }
   {
     iExists _. iFrame. 

--- a/src/program_proof/examples/alloc_proof.v
+++ b/src/program_proof/examples/alloc_proof.v
@@ -157,7 +157,7 @@ Proof.
   iIntros (Φ) "(Hinv&Hfupd) HΦ"; iNamed "Hinv".
   wp_rec. wp_pures.
   wp_loadField.
-  wp_apply (acquire_spec with "His_lock").
+  wp_apply (wp_Mutex__Lock with "His_lock").
   iIntros "(His_locked & Hinner)"; iNamed "Hinner".
   iNamed "Hlockinv".
   wp_loadField.
@@ -186,7 +186,7 @@ Proof.
     { apply lookup_gset_to_gmap_None.
       rewrite /alloc.free in Hk; set_solver. }
 
-    wp_apply (release_spec with "[-HΦ HQ Hbk His_used $His_lock $His_locked]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ HQ Hbk His_used $His_lock $His_locked]").
     { iExists _; iFrame.
       assert (alloc.wf (set alloc.used ({[k]} ∪.) σ)) as Hwf''.
       { rewrite /alloc.wf in Hwf |- *; set_solver. }
@@ -199,7 +199,7 @@ Proof.
         rewrite -gset_to_gmap_union_singleton //. }
     wp_pures.
     iApply "HΦ"; by iFrame.
-  - wp_apply (release_spec with "[-HΦ HQ $His_lock $His_locked]").
+  - wp_apply (wp_Mutex__Unlock with "[-HΦ HQ $His_lock $His_locked]").
     { iExists _; iFrame "∗ %". iNext.
       iExactEq "Hfreemap"; rewrite /named.
       f_equal.
@@ -258,7 +258,7 @@ Proof.
   iIntros (Φ) "(Halloc&Hb&Hused&Hfupd) HΦ"; iNamed "Halloc".
   wp_rec. wp_pures.
   wp_loadField.
-  wp_apply (acquire_spec with "His_lock").
+  wp_apply (wp_Mutex__Lock with "His_lock").
   iIntros "(Hlocked&Hinv)"; iNamed "Hinv".
   iNamed "Hlockinv".
   wp_loadField.
@@ -280,7 +280,7 @@ Proof.
   assert (alloc.wf (set alloc.used (λ used : gset u64, used ∖ {[a]}) σ)) as Hwf''.
   { set_solver. }
   iMod (ghost_map_delete with "Hallocated Hused") as "Hallocated".
-  wp_apply (release_spec with "[$His_lock $Hlocked Hb Hdurable Hfreemap Hallocated HP]").
+  wp_apply (wp_Mutex__Unlock with "[$His_lock $Hlocked Hb Hdurable Hfreemap Hallocated HP]").
   { iNamed "Hdurable".
     iExists _; iFrame "HP".
     iFrame "%".

--- a/src/program_proof/examples/alloc_proof_simple.v
+++ b/src/program_proof/examples/alloc_proof_simple.v
@@ -95,7 +95,7 @@ Proof.
   iIntros (Φ) "Hinv HΦ"; iNamed "Hinv".
   wp_rec. wp_pures.
   wp_loadField.
-  wp_apply (acquire_spec with "His_lock").
+  wp_apply (wp_Mutex__Lock with "His_lock").
   iIntros "(His_locked & Hinner)"; iNamed "Hinner".
   iNamed "Hlockinv".
   wp_loadField.
@@ -117,12 +117,12 @@ Proof.
     iApply wp_wpc.
     wp_loadField.
     iIntros "(HP&Hk)".
-    wp_apply (release_spec with "[-HΦ Hk $His_lock $His_locked]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ Hk $His_lock $His_locked]").
     { iNext. iExists _; iFrame. rewrite /map_del dom_delete_L. iPureIntro; congruence. }
     wp_pures.
     iApply "HΦ"; by iFrame.
   - wp_loadField.
-    wp_apply (release_spec with "[-HΦ $His_lock $His_locked]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ $His_lock $His_locked]").
     { iNext. iExists _; iFrame. rewrite /map_del dom_delete_L. subst.
       iPureIntro. rewrite Hdom. set_solver. }
     wp_pures.
@@ -151,7 +151,7 @@ Proof.
   iIntros (Φ) "(Halloc&Ha) HΦ"; iNamed "Halloc".
   wp_rec. wp_pures.
   wp_loadField.
-  wp_apply (acquire_spec with "His_lock").
+  wp_apply (wp_Mutex__Lock with "His_lock").
   iIntros "(Hlocked&Hinv)"; iNamed "Hinv".
   iNamed "Hlockinv".
   wp_loadField.
@@ -171,7 +171,7 @@ Proof.
   iApply wp_wpc.
   wp_loadField.
   iIntros "HP".
-  wp_apply (release_spec with "[$His_lock $Hlocked Hfreemap HP]").
+  wp_apply (wp_Mutex__Unlock with "[$His_lock $Hlocked Hfreemap HP]").
   { iExists _; iFrame "HP". eauto. }
   wp_pures.
   iApply ("HΦ" with "[$]").

--- a/src/program_proof/examples/async_inode_proof.v
+++ b/src/program_proof/examples/async_inode_proof.v
@@ -383,7 +383,7 @@ Proof.
   wpc_bind_seq.
   wpc_frame.
   wp_loadField.
-  wp_apply (crash_lock.acquire_spec with "Hlock"); first by set_solver.
+  wp_apply (crash_lock.wp_Mutex__Lock with "Hlock"); first by set_solver.
   iIntros "His_locked".
   iNamed 1.
   wpc_pures.
@@ -447,7 +447,7 @@ Proof.
     wpc_pures.
     wpc_frame "HQ".
     wp_loadField.
-    wp_apply (crash_lock.release_spec with "His_locked"); auto.
+    wp_apply (crash_lock.wp_Mutex__Unlock with "His_locked"); auto.
     wp_pures.
     iNamed 1.
     iRight in "HQ".
@@ -504,7 +504,7 @@ Proof.
       iCache with "HQ"; first by iLeft in "HQ".
       wpc_frame.
       wp_loadField.
-      wp_apply (crash_lock.release_spec with "His_locked"); auto.
+      wp_apply (crash_lock.wp_Mutex__Unlock with "His_locked"); auto.
       wp_pures.
       iNamed 1.
       iApply "HQ".
@@ -555,7 +555,7 @@ Proof.
       iCache with "HQ"; first by iLeft in "HQ".
       wpc_frame.
       wp_loadField.
-      wp_apply (crash_lock.release_spec with "His_locked"); auto.
+      wp_apply (crash_lock.wp_Mutex__Unlock with "His_locked"); auto.
       wp_pures.
       iNamed 1.
       iApply "HQ".
@@ -611,7 +611,7 @@ Proof.
   iCache with "Hfupd"; first by iLeft in "Hfupd".
   wpc_frame_seq.
   wp_loadField.
-  wp_apply (crash_lock.acquire_spec with "Hlock"); auto.
+  wp_apply (crash_lock.wp_Mutex__Lock with "Hlock"); auto.
   iIntros "His_locked".
   iNamed 1.
   wpc_pures.
@@ -663,7 +663,7 @@ Proof.
   wpc_pures.
   wpc_frame.
   wp_loadField.
-  wp_apply (crash_lock.release_spec with "His_locked"); auto.
+  wp_apply (crash_lock.wp_Mutex__Unlock with "His_locked"); auto.
   wp_pures.
   iNamed 1.
   by iRight in "HQ".
@@ -803,7 +803,7 @@ Proof.
   iCache with "Hfupd"; first by iLeft in "Hfupd".
   wpc_frame_seq.
   wp_loadField.
-  wp_apply (crash_lock.acquire_spec with "Hlock"); auto.
+  wp_apply (crash_lock.wp_Mutex__Lock with "Hlock"); auto.
   iIntros "His_locked".
   iNamed 1.
   wpc_pures.
@@ -841,7 +841,7 @@ Proof.
     wpc_pures.
     wpc_frame.
     wp_loadField.
-    wp_apply (crash_lock.release_spec with "His_locked"); auto.
+    wp_apply (crash_lock.wp_Mutex__Unlock with "His_locked"); auto.
     wp_pures.
     iNamed 1. iRight in "Hfupd". by iLeft in "Hfupd".
   - wp_loadField.
@@ -880,7 +880,7 @@ Proof.
     wpc_frame.
     wp_pures.
     wp_loadField.
-    wp_apply (crash_lock.release_spec with "His_locked"); auto.
+    wp_apply (crash_lock.wp_Mutex__Unlock with "His_locked"); auto.
     wp_pures.
     iNamed 1.
     by iRight in "HΦ".
@@ -1204,7 +1204,7 @@ Proof.
   iCache with "Hfupd"; first by iLeft in "Hfupd".
   wpc_frame_seq.
   wp_loadField.
-  wp_apply (crash_lock.acquire_spec with "Hlock"); auto.
+  wp_apply (crash_lock.wp_Mutex__Lock with "Hlock"); auto.
   iIntros "His_locked".
   iNamed 1.
   wpc_pures.
@@ -1352,7 +1352,7 @@ Proof.
     { by iLeft in "Hfupd". }
     wpc_frame.
     wp_loadField.
-    wp_apply (crash_lock.release_spec with "[$]"); auto.
+    wp_apply (crash_lock.wp_Mutex__Unlock with "[$]"); auto.
     wp_pures. iNamed 1.
     iRight in "Hfupd".
     eauto.
@@ -1383,7 +1383,7 @@ Proof.
     { by iLeft in "Hfupd". }
     wpc_frame.
     wp_loadField.
-    wp_apply (crash_lock.release_spec with "[$]"); auto.
+    wp_apply (crash_lock.wp_Mutex__Unlock with "[$]"); auto.
     wp_pures. iNamed 1.
     by iRight in "Hfupd".
     (* XXX track this down... *)

--- a/src/program_proof/examples/async_mem_alloc_inode_proof.v
+++ b/src/program_proof/examples/async_mem_alloc_inode_proof.v
@@ -375,7 +375,7 @@ Proof.
   wpc_bind_seq.
   wpc_frame.
   wp_loadField.
-  wp_apply (crash_lock.acquire_spec with "Hlock"); first by set_solver.
+  wp_apply (crash_lock.wp_Mutex__Lock with "Hlock"); first by set_solver.
   iIntros "His_locked".
   iNamed 1.
   wpc_pures.
@@ -426,7 +426,7 @@ Proof.
     wpc_pures.
     wpc_frame "HQ".
     wp_loadField.
-    wp_apply (crash_lock.release_spec with "His_locked"); auto.
+    wp_apply (crash_lock.wp_Mutex__Unlock with "His_locked"); auto.
     wp_pures. iModIntro.
     iNamed 1.
     iRight in "HQ".
@@ -474,7 +474,7 @@ Proof.
     iCache with "HQ"; first by iLeft in "HQ".
     wpc_frame.
     wp_loadField.
-    wp_apply (crash_lock.release_spec with "His_locked"); auto.
+    wp_apply (crash_lock.wp_Mutex__Unlock with "His_locked"); auto.
     wp_pures. iModIntro.
     iNamed 1.
     iApply "HQ".
@@ -534,7 +534,7 @@ Proof.
   iCache with "Hfupd"; first by iLeft in "Hfupd".
   wpc_frame_seq.
   wp_loadField.
-  wp_apply (crash_lock.acquire_spec with "Hlock"); auto.
+  wp_apply (crash_lock.wp_Mutex__Lock with "Hlock"); auto.
   iIntros "His_locked".
   iNamed 1.
   wpc_pures.
@@ -578,7 +578,7 @@ Proof.
   wpc_pures.
   wpc_frame.
   wp_loadField.
-  wp_apply (crash_lock.release_spec with "His_locked"); auto.
+  wp_apply (crash_lock.wp_Mutex__Unlock with "His_locked"); auto.
   wp_pures.
   iModIntro. iNamed 1.
   iRight in "HQ". by iApply "HQ".
@@ -801,7 +801,7 @@ Proof.
     wpc_frame_seq.
 
     wp_loadField.
-    wp_apply (crash_lock.acquire_spec with "Hlock"); auto.
+    wp_apply (crash_lock.wp_Mutex__Lock with "Hlock"); auto.
     iIntros "His_locked". iNamed 1.
     wpc_pures.
     wpc_bind_seq.
@@ -835,7 +835,7 @@ Proof.
       wpc_pures.
       wpc_frame_seq.
       wp_loadField.
-      wp_apply (crash_lock.release_spec with "His_locked"); auto.
+      wp_apply (crash_lock.wp_Mutex__Unlock with "His_locked"); auto.
       iNamed 1.
       wpc_pures.
       wpc_frame_seq.
@@ -1001,7 +1001,7 @@ Proof.
       wpc_pures.
       wpc_frame_seq.
       wp_loadField.
-      wp_apply (crash_lock.release_spec with "His_locked"); auto.
+      wp_apply (crash_lock.wp_Mutex__Unlock with "His_locked"); auto.
       iNamed 1.
       wpc_pures.
       (* RALF: we are throwing away an [is_block] here. *)

--- a/src/program_proof/examples/indirect_inode_proof.v
+++ b/src/program_proof/examples/indirect_inode_proof.v
@@ -925,7 +925,7 @@ Proof.
   iNamed "Hinode". iNamed "Hro_state".
   wp_rec. wp_pures.
   wp_loadField.
-  wp_apply (crash_lock.acquire_spec with "Hlock"); auto.
+  wp_apply (crash_lock.wp_Mutex__Lock with "Hlock"); auto.
   iIntros "His_locked".
   wp_pures.
 
@@ -944,7 +944,7 @@ Proof.
       word.
     }
     wp_loadField.
-    wp_apply (crash_lock.release_spec with "His_locked"); auto.
+    wp_apply (crash_lock.wp_Mutex__Unlock with "His_locked"); auto.
     wp_pures.
     change slice.nil with (slice_val Slice.nil).
     iApply "HΦ"; iFrame; auto.
@@ -979,7 +979,7 @@ Proof.
       wp_loadField.
       iMod ("Hfupd" $! σ σ with "[$HP]") as "[HP HQ]".
       { iPureIntro; eauto. }
-      wp_apply (crash_lock.release_spec with "His_locked"); auto.
+      wp_apply (crash_lock.wp_Mutex__Unlock with "His_locked"); auto.
       wp_pures.
       iApply "HΦ"; iFrame.
       rewrite lookup_take in Hlookup2; [ | word ].
@@ -1128,7 +1128,7 @@ Proof.
       iMod ("Hfupd" $! σ σ with "[$HP]") as "[HP HQ]".
       { iPureIntro; eauto. }
 
-      wp_apply (crash_lock.release_spec with "His_locked"); auto.
+      wp_apply (crash_lock.wp_Mutex__Unlock with "His_locked"); auto.
       wp_pures.
       iApply "HΦ"; iFrame.
 
@@ -1150,7 +1150,7 @@ Proof.
   iNamed "Hinode"; iNamed "Hro_state".
   wp_rec. wp_pures.
   wp_loadField.
-  wp_apply (crash_lock.acquire_spec with "Hlock"); auto.
+  wp_apply (crash_lock.wp_Mutex__Lock with "Hlock"); auto.
   iIntros "His_locked".
   wp_pures.
 
@@ -1165,7 +1165,7 @@ Proof.
     split; auto.
     unfold inode.size. word.
   }
-  wp_apply (crash_lock.release_spec with "His_locked"); auto.
+  wp_apply (crash_lock.wp_Mutex__Unlock with "His_locked"); auto.
   wp_pures.
   iApply ("HΦ" with "[$]").
 Admitted.

--- a/src/program_proof/examples/inode_proof.v
+++ b/src/program_proof/examples/inode_proof.v
@@ -357,7 +357,7 @@ Proof.
   wpc_bind_seq.
   wpc_frame.
   wp_loadField.
-  wp_apply (crash_lock.acquire_spec with "Hlock"); first by set_solver.
+  wp_apply (crash_lock.wp_Mutex__Lock with "Hlock"); first by set_solver.
   iIntros "His_locked".
   iNamed 1.
   wpc_pures.
@@ -407,7 +407,7 @@ Proof.
     wpc_pures.
     wpc_frame "HQ".
     wp_loadField.
-    wp_apply (crash_lock.release_spec with "His_locked"); auto.
+    wp_apply (crash_lock.wp_Mutex__Unlock with "His_locked"); auto.
     wp_pures. iModIntro.
     iNamed 1.
     iRight in "HQ".
@@ -453,7 +453,7 @@ Proof.
     iCache with "HQ"; first by iLeft in "HQ".
     wpc_frame.
     wp_loadField.
-    wp_apply (crash_lock.release_spec with "His_locked"); auto.
+    wp_apply (crash_lock.wp_Mutex__Unlock with "His_locked"); auto.
     wp_pures. iModIntro.
     iNamed 1.
     iApply "HQ".
@@ -513,7 +513,7 @@ Proof.
   iCache with "Hfupd"; first by iLeft in "Hfupd".
   wpc_frame_seq.
   wp_loadField.
-  wp_apply (crash_lock.acquire_spec with "Hlock"); auto.
+  wp_apply (crash_lock.wp_Mutex__Lock with "Hlock"); auto.
   iIntros "His_locked".
   iNamed 1.
   wpc_pures.
@@ -555,7 +555,7 @@ Proof.
   wpc_pures.
   wpc_frame.
   wp_loadField.
-  wp_apply (crash_lock.release_spec with "His_locked"); auto.
+  wp_apply (crash_lock.wp_Mutex__Unlock with "His_locked"); auto.
   wp_pures.
   iModIntro. iNamed 1.
   iRight in "HQ". by iApply "HQ".
@@ -750,7 +750,7 @@ Proof.
     wpc_pures.
     wpc_frame_seq.
     wp_loadField.
-    wp_apply (crash_lock.acquire_spec with "Hlock"); auto.
+    wp_apply (crash_lock.wp_Mutex__Lock with "Hlock"); auto.
     iIntros "His_locked". iNamed 1.
     wpc_pures.
     wpc_bind_seq.
@@ -780,7 +780,7 @@ Proof.
       wpc_pures.
       wpc_frame_seq.
       wp_loadField.
-      wp_apply (crash_lock.release_spec with "His_locked"); auto.
+      wp_apply (crash_lock.wp_Mutex__Unlock with "His_locked"); auto.
       iNamed 1.
       wpc_pures.
       wpc_frame_seq.
@@ -897,7 +897,7 @@ Proof.
       wpc_pures.
       wpc_frame_seq.
       wp_loadField.
-      wp_apply (crash_lock.release_spec with "His_locked"); auto.
+      wp_apply (crash_lock.wp_Mutex__Unlock with "His_locked"); auto.
       iNamed 1.
       wpc_pures.
       (* RALF: we are throwing away an [is_block] here. *)

--- a/src/program_proof/examples/replicated_block_proof.v
+++ b/src/program_proof/examples/replicated_block_proof.v
@@ -196,7 +196,7 @@ Section goose.
     wpc_pures.
     wpc_frame_seq.
     wp_loadField.
-    wp_apply (crash_lock.acquire_spec with "Hlock"); first by auto.
+    wp_apply (crash_lock.wp_Mutex__Lock with "Hlock"); first by auto.
     iIntros "His_locked"; iNamed 1.
     wpc_pures.
     wpc_bind (RepBlock__readAddr _ _); wpc_frame.
@@ -242,7 +242,7 @@ Section goose.
     wpc_frame.
 
     wp_loadField.
-    wp_apply (crash_lock.release_spec with "[$His_locked]"); auto.
+    wp_apply (crash_lock.wp_Mutex__Unlock with "[$His_locked]"); auto.
     wp_pures.
     iModIntro. iNamed 1.
     iRight in "HQ".
@@ -293,7 +293,7 @@ Section goose.
     wpc_pures.
     wpc_frame_seq.
     wp_loadField.
-    wp_apply (crash_lock.acquire_spec with "Hlock"); first by auto.
+    wp_apply (crash_lock.wp_Mutex__Lock with "Hlock"); first by auto.
     iIntros "His_locked".
     iNamed 1.
 
@@ -356,7 +356,7 @@ Section goose.
     wpc_pures.
     wpc_frame.
     wp_loadField.
-    wp_apply (crash_lock.release_spec with "[$His_locked]"); auto.
+    wp_apply (crash_lock.wp_Mutex__Unlock with "[$His_locked]"); auto.
     wp_pures. iModIntro.
     iNamed 1.
     iApply "HΦ"; iFrame.

--- a/src/program_proof/fencing/ctr_proof.v
+++ b/src/program_proof/fencing/ctr_proof.v
@@ -760,7 +760,7 @@ Proof.
   wp_pures.
   iNamed "His_srv".
   wp_loadField.
-  wp_apply (acquire_spec with "HmuInv").
+  wp_apply (wp_Mutex__Lock with "HmuInv").
   iIntros "[Hlocked Hown]".
   iNamed "Hown".
   wp_pures.
@@ -782,7 +782,7 @@ Proof.
     iModIntro.
     wp_pures.
     wp_loadField.
-    wp_apply (release_spec with "[$HmuInv $Hlocked Hv HlatestEpoch HghostLatestEpoch HghostV]").
+    wp_apply (wp_Mutex__Unlock with "[$HmuInv $Hlocked Hv HlatestEpoch HghostLatestEpoch HghostV]").
     {
       iNext.
       iExists _, _.
@@ -923,7 +923,7 @@ Proof.
       iModIntro.
       wp_pures.
       wp_loadField.
-      wp_apply (release_spec with "[$Hlocked $HmuInv Hv HlatestEpoch HghostV HghostLatestEpoch]").
+      wp_apply (wp_Mutex__Unlock with "[$Hlocked $HmuInv Hv HlatestEpoch HghostV HghostLatestEpoch]").
       {
         iNext.
         iExists _, _.
@@ -979,7 +979,7 @@ Proof.
         iModIntro.
         wp_pures.
         wp_loadField.
-        wp_apply (release_spec with "[$Hlocked $HmuInv Hv HlatestEpoch Hval Hlatest]").
+        wp_apply (wp_Mutex__Unlock with "[$Hlocked $HmuInv Hv HlatestEpoch Hval Hlatest]").
         {
           iNext.
           iExists _, _.
@@ -1003,7 +1003,7 @@ Proof.
         iModIntro.
         wp_pures.
         wp_loadField.
-        wp_apply (release_spec with "[$Hlocked $HmuInv Hv HlatestEpoch HghostV HghostLatestEpoch]").
+        wp_apply (wp_Mutex__Unlock with "[$Hlocked $HmuInv Hv HlatestEpoch HghostV HghostLatestEpoch]").
         {
           iNext.
           iExists _, _.
@@ -1056,7 +1056,7 @@ Proof.
   wp_pures.
   wp_loadField.
 
-  wp_apply (acquire_spec with "HmuInv").
+  wp_apply (wp_Mutex__Lock with "HmuInv").
   iIntros "[Hlocked Hown]".
   iNamed "Hown".
 
@@ -1099,7 +1099,7 @@ Proof.
     }
     iMod ("Hupd" with "Hlatest2") as "HΦclient".
     iModIntro.
-    wp_apply (release_spec with "[$Hlocked $HmuInv HlatestEpoch Hv HghostLatestEpoch HghostV]").
+    wp_apply (wp_Mutex__Unlock with "[$Hlocked $HmuInv HlatestEpoch Hv HghostLatestEpoch HghostV]").
     {
       iNext.
       iExists _, _.
@@ -1185,7 +1185,7 @@ Proof.
     iMod ("Hupd" with "Hlatest2") as "Hupd".
     iModIntro.
 
-    wp_apply (release_spec with "[$Hlocked $HmuInv Hv HlatestEpoch Hlatest Hval]").
+    wp_apply (wp_Mutex__Unlock with "[$Hlocked $HmuInv Hv HlatestEpoch Hlatest Hval]").
     {
       iNext.
       iExists _, _.

--- a/src/program_proof/fencing/frontend_proof.v
+++ b/src/program_proof/fencing/frontend_proof.v
@@ -92,7 +92,7 @@ Proof.
   wp_pures.
   iNamed "Hsrv".
   wp_loadField.
-  wp_apply (acquire_spec with "HmuInv").
+  wp_apply (wp_Mutex__Lock with "HmuInv").
   iIntros "[Hlocked Hown]".
   iNamed "Hown".
   wp_pures.
@@ -394,7 +394,7 @@ Proof.
       iIntros "Hck1_own".
       wp_pures.
       wp_loadField.
-      wp_apply (release_spec with "[$Hlocked $HmuInv Hck1 Hck2 Hck2_own Hck1_own Hval Hghost2]").
+      wp_apply (wp_Mutex__Unlock with "[$Hlocked $HmuInv Hck1 Hck2 Hck2_own Hck1_own Hval Hghost2]").
       {
         iNext.
         iExists _, _, _.
@@ -715,7 +715,7 @@ Proof.
       iIntros "Hck2_own".
       wp_pures.
       wp_loadField.
-      wp_apply (release_spec with "[$Hlocked $HmuInv Hck1 Hck2 Hck2_own Hck1_own Hval Hghost1]").
+      wp_apply (wp_Mutex__Unlock with "[$Hlocked $HmuInv Hck1 Hck2 Hck2_own Hck1_own Hval Hghost1]").
       {
         iNext.
         iExists _, _, _.

--- a/src/program_proof/grove_shared/erpc_proof.v
+++ b/src/program_proof/grove_shared/erpc_proof.v
@@ -139,7 +139,7 @@ Proof.
 
   iNamed "Hs".
   wp_loadField.
-  wp_apply (acquire_spec with "HmuInv").
+  wp_apply (wp_Mutex__Lock with "HmuInv").
   iIntros "[Hlocked Hown]". iNamed "Hown".
 
   wp_loadField.
@@ -207,7 +207,7 @@ Proof.
       { done. }
       iDestruct "HH" as "[Hrpc #Hstale]".
       wp_loadField.
-      wp_apply (release_spec with "[-HΦ Hsrv_val_sl Hrepptr]").
+      wp_apply (wp_Mutex__Unlock with "[-HΦ Hsrv_val_sl Hrepptr]").
       {
         iFrame "∗#".
         iNext.
@@ -230,7 +230,7 @@ Proof.
 
       (* prove that rid.(Req_CID) is in lastReplyMV (probably just add [∗ map] _ ↦ _;_ ∈ lastReplyMV ; lastSeq, True) *)
       wp_loadField.
-      wp_apply (release_spec with "[-HΦ Hsrv_val_sl Hrepptr]").
+      wp_apply (wp_Mutex__Unlock with "[-HΦ Hsrv_val_sl Hrepptr]").
       {
         iFrame "∗#".
         iNext.
@@ -276,7 +276,7 @@ Proof.
 
     wp_loadField.
     iMod (own_slice_small_persist with "Hrep") as "#Hrep".
-    wp_apply (release_spec with "[-HΦ Hrep Hrepptr]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ Hrep Hrepptr]").
     {
       iFrame "HmuInv Hlocked".
       iNext.
@@ -344,7 +344,7 @@ Proof.
   iIntros (Φ) "Hs HΦ". wp_rec.
   iNamed "Hs".
   wp_loadField.
-  wp_apply (acquire_spec with "HmuInv").
+  wp_apply (wp_Mutex__Lock with "HmuInv").
   iIntros "[Hlocked Hown]". iNamed "Hown".
 
   wp_loadField.
@@ -356,7 +356,7 @@ Proof.
   { set_solver. }
 
   wp_loadField.
-  wp_apply (release_spec with "[-HΦ Hcid]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ Hcid]").
   {
     iFrame "HmuInv Hlocked".
     iNext.

--- a/src/program_proof/grove_shared/urpc_proof.v
+++ b/src/program_proof/grove_shared/urpc_proof.v
@@ -471,7 +471,7 @@ Proof.
 
     (* Loop (MapIter) to wake up all waiting clients *)
     wp_loadField.
-    wp_apply (acquire_spec with "[$]").
+    wp_apply (wp_Mutex__Lock with "[$]").
     iIntros "(Hlked&Hlock_inner)".
     iNamed "Hlock_inner".
 
@@ -496,7 +496,7 @@ Proof.
       wp_loadField.
       wp_store.
       wp_loadField.
-      wp_apply (wp_condSignal with "Hcond").
+      wp_apply (wp_Cond__Signal with "Hcond").
       iDestruct ("Hreqs" with "[-HΦ]") as "Hreqs".
       { iExists _. iFrame "Hreg_entry HPost_saved". iLeft. iExists _, _, _, true. by iFrame "∗#". }
       iClear "Hcond". iThaw "HΦ". iApply "HΦ".
@@ -505,7 +505,7 @@ Proof.
     }
     iIntros "[Hmap [Hreqs _]]".
     wp_loadField.
-    wp_apply (release_spec with "[-]").
+    wp_apply (wp_Mutex__Unlock with "[-]").
     { iFrame "Hlked Hlk". iNext. iExists _, _, _, _, _. iFrame. eauto. }
     wp_pures. iRight. iModIntro. iSplit; first done. wp_pures. eauto.
   }
@@ -518,7 +518,7 @@ Proof.
   wp_pures.
 
   wp_loadField.
-  wp_apply (acquire_spec with "[$]").
+  wp_apply (wp_Mutex__Lock with "[$]").
   iIntros "(Hlked&Hlock_inner)".
   iNamed "Hlock_inner".
   wp_pures.
@@ -527,7 +527,7 @@ Proof.
   iIntros (v ok) "(%Hget&Hpending_map)".
   wp_pures.
   wp_if_destruct; last first.
-  { wp_pures. wp_loadField. wp_apply (release_spec with "[-]").
+  { wp_pures. wp_loadField. wp_apply (wp_Mutex__Unlock with "[-]").
     { iFrame "∗#". iNext. iExists _, _, _, _, _. iFrame.
       eauto. }
     wp_pures. eauto.
@@ -554,7 +554,7 @@ Proof.
     { econstructor. econstructor. }
     { iFrame. }
     iIntros "Hdone". wp_pures. wp_loadField.
-    wp_apply (wp_condSignal with "[$]").
+    wp_apply (wp_Cond__Signal with "[$]").
     iApply fupd_wp.
     iInv "HPost" as "HPost_inner" "Hclo''".
     iDestruct "HPost_inner" as "[HPost_val|>Hescrow']"; last first.
@@ -563,7 +563,7 @@ Proof.
     { iRight. eauto. }
     iModIntro. wp_pures.
     wp_loadField.
-    wp_apply (release_spec with "[-]"); last first.
+    wp_apply (wp_Mutex__Unlock with "[-]"); last first.
     { wp_pures. eauto. }
     iFrame "Hlk Hlked". iNext. iExists (delete seqno pending) , _, _, _, _.
     iFrame. iFrame "%".
@@ -782,7 +782,7 @@ Proof.
   iIntros "done'".
   wp_pures.
   wp_loadField.
-  wp_apply (acquire_spec with "[$]").
+  wp_apply (wp_Mutex__Lock with "[$]").
   iIntros "(Hlked&Hlock_inner)".
   iNamed "Hlock_inner".
   wp_pures.
@@ -808,7 +808,7 @@ Proof.
   { apply not_elem_of_dom. rewrite -Hdom_eq_es -Hdom_range. lia. }
   iMod (map_alloc n tt with "Hextracted_ctx") as "(Hextracted_ctx&Hextracted)".
   { apply not_elem_of_dom. rewrite -Hdom_eq_ex -Hdom_range. lia. }
-  wp_apply (release_spec with "[-Hslice Hhandler HΦ Hextracted]").
+  wp_apply (wp_Mutex__Unlock with "[-Hslice Hhandler HΦ Hextracted]").
   { iFrame "Hlk". iFrame "Hlked". iNext. iExists _, _, _, _, _.
     iFrame. rewrite ?dom_insert_L.
     replace (uint.Z (word.add n 1)) with (uint.Z n + 1)%Z by word.
@@ -913,7 +913,7 @@ Proof.
   wp_rec. wp_pures.
 
   wp_loadField.
-  wp_apply (acquire_spec with "[$]").
+  wp_apply (wp_Mutex__Lock with "[$]").
   iIntros "[Hi Hlockinv]".
   wp_pures.
   wp_loadField.
@@ -954,7 +954,7 @@ Proof.
                                   Client_lock_inner Γ cl_ptr lk mref)%I
    with "[Hi Hlockinv]").
   { case_bool_decide; wp_pures.
-    - wp_loadField. wp_apply (wp_condWaitTimeout with "[$cond' $Hi $Hlk $Hlockinv]").
+    - wp_loadField. wp_apply (wp_Cond__WaitTimeout with "[$cond' $Hi $Hlk $Hlockinv]").
       iIntros "(Hi&Hlockinv)". wp_pures.
       iFrame. eauto.
     - iFrame. eauto. }
@@ -978,7 +978,7 @@ Proof.
     rewrite bool_decide_false.
     2: by destruct aborted.
     wp_loadField.
-    wp_apply (release_spec with "[$Hlk $Hi H HPost_saved
+    wp_apply (wp_Mutex__Unlock with "[$Hlk $Hi H HPost_saved
                  Hpending_map Hmapping_ctx Hescrow_ctx Hextracted_ctx seq]").
     { iExists _, _, _, _, _. iFrame. eauto. }
     wp_pures.
@@ -1003,7 +1003,7 @@ Proof.
     { simpl. iExists _. iFrame "Hsaved Hreg". iRight. iRight.
       iSplit; eauto. }
     wp_loadField.
-    wp_apply (release_spec with "[$Hlk $Hi H HPost_saved
+    wp_apply (wp_Mutex__Unlock with "[$Hlk $Hi H HPost_saved
                  Hpending_map Hmapping_ctx Hescrow_ctx Hextracted_ctx seq]").
     { iExists _, _, _, _, _. iFrame. eauto. }
     wp_pures.

--- a/src/program_proof/jrnl_replication/jrnl_replication_proof.v
+++ b/src/program_proof/jrnl_replication/jrnl_replication_proof.v
@@ -84,7 +84,7 @@ Section goose_lang.
     iNamed "Hrb".
     wp_rec. wp_pures.
     wp_loadField.
-    wp_apply (lock.acquire_spec with "His_lock").
+    wp_apply (lock.wp_Mutex__Lock with "His_lock").
     iIntros "[Hlocked Hinv]".
     iNamed "Hinv".
     wp_pures.
@@ -130,7 +130,7 @@ Section goose_lang.
     destruct ok.
     - (* iDestruct "Hpost" as (txn_id') "[rb_rep #Hdurable]". *)
       iRename "Hpost" into "rb_rep".
-      wp_apply (release_spec with "[$His_lock $Hlocked rb_rep a0 a1 HP]").
+      wp_apply (wp_Mutex__Unlock with "[$His_lock $Hlocked rb_rep a0 a1 HP]").
       { iNext.
         iExists _, _, _.
         iFrame "∗#". }
@@ -139,7 +139,7 @@ Section goose_lang.
       by iFrame.
     - iRename "Hpost" into "rb_rep".
       iDestruct "rb_rep" as "[rb_rep _]".
-      wp_apply (release_spec with "[$His_lock $Hlocked rb_rep a0 a1 HP]").
+      wp_apply (wp_Mutex__Unlock with "[$His_lock $Hlocked rb_rep a0 a1 HP]").
       { iNext.
         iExists _, _, _.
         iFrame "∗#". }

--- a/src/program_proof/lockmap_proof.v
+++ b/src/program_proof/lockmap_proof.v
@@ -127,7 +127,7 @@ Proof.
 
   wp_rec. wp_pures.
   wp_loadField.
-  wp_apply (acquire_spec with "Hlock").
+  wp_apply (wp_Mutex__Lock with "Hlock").
   iIntros "[Hlocked Hinner]".
 
   wp_pures.
@@ -176,7 +176,7 @@ Proof.
 
         wp_untyped_load.
         wp_loadField.
-        wp_apply (lock.wp_condWait with "[-HΦloop Hstate Hacquired]").
+        wp_apply (lock.wp_Cond__Wait with "[-HΦloop Hstate Hacquired]").
         {
           iFrame "Hlock Hcond Hlocked".
           iExists _, _.
@@ -316,7 +316,7 @@ Proof.
 
   iIntros "(Hinner & Hlocked & Hp & Haddrlocked)".
   wp_loadField.
-  wp_apply (release_spec with "[Hlocked Hinner]").
+  wp_apply (wp_Mutex__Unlock with "[Hlocked Hinner]").
   {
     iSplitR. { iApply "Hlock". }
     iFrame.
@@ -335,7 +335,7 @@ Proof.
   iDestruct "Hls" as (shardlock mptr) "(#Hls_mu&#Hls_state&#Hlock)".
   wp_rec. wp_pures.
   wp_loadField.
-  wp_apply (acquire_spec with "Hlock").
+  wp_apply (wp_Mutex__Lock with "Hlock").
   iIntros "[Hlocked Hinner]".
   iDestruct "Hinner" as (m gm) "(Hmptr & Hghctx & Haddrs & Hcovered)".
 
@@ -366,12 +366,12 @@ Proof.
   {
     wp_pures.
     wp_loadField.
-    wp_apply (lock.wp_condSignal with "[$Hcond]").
+    wp_apply (lock.wp_Cond__Signal with "[$Hcond]").
 
     iMod (ghost_map_update false with "Hghctx Haddrlocked") as "[Hghctx Haddrlocked]".
 
     wp_loadField.
-    wp_apply (release_spec with "[-HΦ]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ]").
     {
       iFrame "Hlock Hlocked".
       iExists _, _.
@@ -406,7 +406,7 @@ Proof.
     iMod (ghost_map_delete with "Hghctx Haddrlocked") as "Hghctx".
 
     wp_loadField.
-    wp_apply (release_spec with "[-HΦ]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ]").
     {
       iFrame "∗ Hlock".
       iExists _, (delete addr gm).

--- a/src/program_proof/lockservice/aof_proof.v
+++ b/src/program_proof/lockservice/aof_proof.v
@@ -123,7 +123,7 @@ Proof.
     iNext.
     iNamed "His_aof".
     wp_loadField.
-    wp_apply (acquire_spec with "Hmu_inv").
+    wp_apply (wp_Mutex__Lock with "Hmu_inv").
     iIntros "[Hlocked Haof_own]".
     wp_pures.
     iAssert (∃ data', fname f↦ (data++data') ∗ aof_ctx (data++data') ∗ fmlist γ.(predurabledata) (1/2) (data ++ data')
@@ -141,7 +141,7 @@ Proof.
     wp_if_destruct.
     {
       wp_loadField.
-      wp_apply (wp_condWait with "[- Hfile_ctx]").
+      wp_apply (wp_Cond__Wait with "[- Hfile_ctx]").
       { iFrame "∗#". iExists _, _, _, _; iFrame "∗#". done. }
       iIntros "[Hlocked Haof_own]".
       wp_pures.
@@ -173,7 +173,7 @@ Proof.
     iMod (fmlist_update (predurableC ++ membufC) with "Hpredur") as "[Hpredur _]".
     { by apply prefix_app_r. }
     iDestruct "Hpredur" as "[Hpredur Hpredurable]".
-    wp_apply (release_spec with "[-Hfile Hctx Hpredur Hmembuf_fupd Hmembuf_sl HdurLen Hlen]").
+    wp_apply (wp_Mutex__Unlock with "[-Hfile Hctx Hpredur Hmembuf_fupd Hmembuf_sl HdurLen Hlen]").
     { iFrame "∗#". iNext. iExists _, [], (predurableC ++ membufC), _. iFrame "∗#".
       rewrite app_nil_r.
       iFrame.
@@ -196,7 +196,7 @@ Proof.
     wp_pures.
 
     wp_loadField.
-    wp_apply (acquire_spec with "Hmu_inv").
+    wp_apply (wp_Mutex__Lock with "Hmu_inv").
     iIntros "[Hlocked Haof_own]".
     iRename "Hdurlen_lb" into "Hdurlen_lb_old".
     iNamed "Haof_own".
@@ -212,7 +212,7 @@ Proof.
     iEval (rewrite mono_nat_auth_lb_op) in "Hlen".
     iDestruct "Hlen" as "[Hlen #Hlenlb]".
 
-    wp_apply (wp_condBroadcast).
+    wp_apply (wp_Cond__Broadcast).
     { iFrame "#". }
     wp_pures.
     iLeft.
@@ -262,7 +262,7 @@ Proof.
   wp_pures.
 
   wp_loadField.
-  wp_apply (acquire_spec with "Hmu_inv").
+  wp_apply (wp_Mutex__Lock with "Hmu_inv").
   iIntros "[Hlocked Haof]".
   iNamed "Haof".
   iDestruct "Hpre" as "(HnewData & Haof_log & Hfupd)".
@@ -314,7 +314,7 @@ Proof.
   wp_pures.
 
   wp_loadField.
-  wp_apply (wp_condSignal).
+  wp_apply (wp_Cond__Signal).
   { iFrame "#". }
 
   wp_pures.
@@ -592,7 +592,7 @@ Proof.
   iMod "HH" as "[Hmembuf_fupd HfupdQ]".
 
   wp_loadField.
-  wp_apply (release_spec with "[-HΦ Haof_log HfupdQ]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ Haof_log HfupdQ]").
   {
     iFrame "∗#".
     iNext.
@@ -643,7 +643,7 @@ Proof.
   wp_pures.
   iNamed "Haof".
   wp_loadField.
-  wp_apply (acquire_spec with "Hmu_inv").
+  wp_apply (wp_Mutex__Lock with "Hmu_inv").
   iIntros "[Hlocked Haof_own]".
   wp_pures.
   wp_apply (wp_forBreak_cond' with "[-]").
@@ -661,7 +661,7 @@ Proof.
   {
     wp_pures.
     wp_loadField.
-    wp_apply (wp_condWait with "[- HΦ]").
+    wp_apply (wp_Cond__Wait with "[- HΦ]").
     {
       iFrame "∗#".
       iExists _, _, _, _. iFrame "∗#".
@@ -689,7 +689,7 @@ Proof.
   wp_pures.
 
   wp_loadField.
-  wp_apply (release_spec with "[- HΦ]").
+  wp_apply (wp_Mutex__Unlock with "[- HΦ]").
   {
     iFrame "∗#".
     iExists _, _, _, _. iFrame "∗#".

--- a/src/program_proof/lockservice/kv_proof.v
+++ b/src/program_proof/lockservice/kv_proof.v
@@ -173,7 +173,7 @@ Proof.
   wp_pures.
   iNamed "Hls".
   wp_loadField.
-  wp_apply (acquire_spec with "[$His_rpc]").
+  wp_apply (wp_Mutex__Lock with "[$His_rpc]").
   iIntros "[Hlocked Hown]".
   iNamed "Hown".
   wp_pures.
@@ -203,7 +203,7 @@ Proof.
   iDestruct "HH" as (??) "(Hrpc_vol & Hrpc_ghost & Hreply & #Hpost & Hkv_own)".
   wp_pures.
   wp_loadField.
-  wp_apply (release_spec with "[$His_rpc $Hlocked Hrpc_vol Hrpc_ghost Hkv_own Hsv]").
+  wp_apply (wp_Mutex__Unlock with "[$His_rpc $Hlocked Hrpc_vol Hrpc_ghost Hkv_own Hsv]").
   {
     iNext.
     iDestruct "Hkv_own" as "[Hkv_own|Hkv_own]".

--- a/src/program_proof/lockservice/rpc_durable_proof.v
+++ b/src/program_proof/lockservice/rpc_durable_proof.v
@@ -275,7 +275,7 @@ Proof.
   iNamed "Hpre".
   iNamed "Hls".
   wp_loadField.
-  wp_apply (crash_lock.acquire_spec with "Hmu"); first done.
+  wp_apply (crash_lock.wp_Mutex__Lock with "Hmu"); first done.
   iIntros "Hlocked".
   wp_pures.
   iApply (wpc_wp _ _ _ _ _ True).
@@ -347,7 +347,7 @@ Proof.
     wpc_pures; first by iModIntro.
     iApply (wp_wpc).
     wp_loadField.
-    wp_apply (crash_lock.release_spec with "[$Hlocked]"); first done.
+    wp_apply (crash_lock.wp_Mutex__Unlock with "[$Hlocked]"); first done.
     wp_pures.
     iApply "HΦ".
     iExists _; iFrame.
@@ -483,7 +483,7 @@ Proof.
     wp_pures.
     wp_loadField.
     iApply wp_fupd.
-    wp_apply (crash_lock.release_spec with "Hlocked"); first eauto.
+    wp_apply (crash_lock.wp_Mutex__Unlock with "Hlocked"); first eauto.
     wp_pures.
     iApply "HΦ".
     iModIntro.

--- a/src/program_proof/lockservice/two_pc_example.v
+++ b/src/program_proof/lockservice/two_pc_example.v
@@ -604,7 +604,7 @@ Proof.
   wp_rec.
   wp_pures.
   wp_loadField.
-  wp_apply (acquire_spec with "Hmu_inv").
+  wp_apply (wp_Mutex__Lock with "Hmu_inv").
   iIntros "[Hmulocked Hps]".
   iNamed "Hps".
   wp_pures.
@@ -617,7 +617,7 @@ Proof.
     apply map_get_true in Hmapget.
     iDestruct (big_sepM_lookup_acc with "Htxns_prop_pers") as "[[Hprep Hunknown] _]".
     { done. }
-    wp_loadField. wp_apply (release_spec with "[$Hmu_inv $Hmulocked Hkvs Htxns HfinishedTxns HlockMap_ptr HkvsMap HtxnsMap HfinishedTxnsMap Hkvs_ctx Hfreshtxns Htxns_postcommit]").
+    wp_loadField. wp_apply (wp_Mutex__Unlock with "[$Hmu_inv $Hmulocked Hkvs Htxns HfinishedTxns HlockMap_ptr HkvsMap HtxnsMap HfinishedTxnsMap Hkvs_ctx Hfreshtxns Htxns_postcommit]").
     {
       iNext. iExists _, _, _,_,_,_,_; iFrame "∗#".
       done.
@@ -636,7 +636,7 @@ Proof.
   wp_pures.
   wp_if_destruct.
   { (* Transaction already finished *)
-    wp_loadField. wp_apply (release_spec with "[$Hmu_inv $Hmulocked Hkvs Htxns HfinishedTxns HlockMap_ptr HkvsMap HtxnsMap HfinishedTxnsMap Hkvs_ctx Hfreshtxns Htxns_postcommit]").
+    wp_loadField. wp_apply (wp_Mutex__Unlock with "[$Hmu_inv $Hmulocked Hkvs Htxns HfinishedTxns HlockMap_ptr HkvsMap HtxnsMap HfinishedTxnsMap Hkvs_ctx Hfreshtxns Htxns_postcommit]").
     {
       iNext. iExists _, _, _,_,_,_,_; iFrame "∗#".
       done.
@@ -664,7 +664,7 @@ Proof.
     (* Unsafe increase *)
     wp_loadField. wp_apply (wp_LockMap__Release with "[$HlockMap $Hkeylocked $Hktok]").
     wp_pures.
-    wp_loadField. wp_apply (release_spec with "[$Hmu_inv $Hmulocked Hkvs Htxns HfinishedTxns HlockMap_ptr HkvsMap HtxnsMap HfinishedTxnsMap Hkvs_ctx Hfreshtxns Htxns_postcommit]").
+    wp_loadField. wp_apply (wp_Mutex__Unlock with "[$Hmu_inv $Hmulocked Hkvs Htxns HfinishedTxns HlockMap_ptr HkvsMap HtxnsMap HfinishedTxnsMap Hkvs_ctx Hfreshtxns Htxns_postcommit]").
     {
       iNext. iExists _, _, _,_,_,_,_; iFrame "∗#".
       done.
@@ -726,7 +726,7 @@ Proof.
   iMod (participant_prepare with "Htxn [Hptsto] Hdoprep Hunfinish") as "[#His_prep Hunfinish]".
   { done. }
   { iNext. iExists _; iFrame "Hptsto". iFrame "Hunknown". }
-  wp_loadField. wp_apply (release_spec with "[$Hmu_inv $Hmulocked Hkvs Htxns HfinishedTxns HlockMap_ptr HkvsMap HtxnsMap HfinishedTxnsMap Hkvs_ctx Hfreshtxns Hktok Htxns_postcommit Hunfinish]").
+  wp_loadField. wp_apply (wp_Mutex__Unlock with "[$Hmu_inv $Hmulocked Hkvs Htxns HfinishedTxns HlockMap_ptr HkvsMap HtxnsMap HfinishedTxnsMap Hkvs_ctx Hfreshtxns Hktok Htxns_postcommit Hunfinish]").
   {
     iNext. iExists _, _, _,_,_,_,_; iFrame "HkvsMap HtxnsMap #∗".
     iSplitL "".
@@ -847,7 +847,7 @@ Proof.
   wp_pures.
   iNamed "His_part".
   wp_loadField.
-  wp_apply (acquire_spec with "Hmu_inv").
+  wp_apply (wp_Mutex__Lock with "Hmu_inv").
   iIntros "[Hmulocked Hps]".
   iNamed "Hps".
   wp_pures.
@@ -857,7 +857,7 @@ Proof.
   wp_pures.
   wp_if_destruct.
   { (* No pending transaction with that TID *)
-    wp_loadField. wp_apply (release_spec with "[- HΦ]").
+    wp_loadField. wp_apply (wp_Mutex__Unlock with "[- HΦ]").
     {
       iFrame "∗#".
       iNext. iExists _, _, _,_,_,_,_; iFrame "∗#".
@@ -902,7 +902,7 @@ Proof.
   { done. }
   iIntros "HfinishedTxnsMap".
   wp_pures.
-  wp_loadField. wp_apply (release_spec with "[- HΦ]").
+  wp_loadField. wp_apply (wp_Mutex__Unlock with "[- HΦ]").
   {
     iFrame "Hmu_inv Hmulocked".
     iNext. iExists _, _, _,_,_,_,_; iFrame "HtxnsMap HfinishedTxnsMap ∗#".
@@ -960,7 +960,7 @@ Proof.
   wp_pures.
   iNamed "His_part".
   wp_loadField.
-  wp_apply (acquire_spec with "Hmu_inv").
+  wp_apply (wp_Mutex__Lock with "Hmu_inv").
   iIntros "[Hmulocked Hps]".
   iNamed "Hps".
   wp_pures.
@@ -970,7 +970,7 @@ Proof.
   wp_pures.
   wp_if_destruct.
   { (* No pending transaction with that TID *)
-    wp_loadField. wp_apply (release_spec with "[- HΦ]").
+    wp_loadField. wp_apply (wp_Mutex__Unlock with "[- HΦ]").
     {
       iFrame "∗#".
       iNext. iExists _, _, _,_,_,_,_; iFrame "∗#".
@@ -1027,7 +1027,7 @@ Proof.
   { done. }
   iIntros "HfinishedTxnsMap".
   wp_pures.
-  wp_loadField. wp_apply (release_spec with "[- HΦ]").
+  wp_loadField. wp_apply (wp_Mutex__Unlock with "[- HΦ]").
   {
     iFrame "Hmu_inv Hmulocked".
     iNext. iExists _, _, _,_,_,_,_; iFrame "HtxnsMap HfinishedTxnsMap ∗#".

--- a/src/program_proof/memkv/connman_proof.v
+++ b/src/program_proof/memkv/connman_proof.v
@@ -72,7 +72,7 @@ Proof.
   iIntros (cl_ptr) "Hcl_ptr".
   wp_pures.
   wp_loadField.
-  wp_apply (acquire_spec with "Hinv").
+  wp_apply (wp_Mutex__Lock with "Hinv").
   iIntros "[Hlocked Hown]".
   wp_pures.
   wp_apply (wp_forBreak' with "[-]").
@@ -92,7 +92,7 @@ Proof.
     iModIntro. iRight. iSplitR; first done.
     wp_pures.
     wp_loadField.
-    wp_apply (release_spec with "[$Hinv $Hlocked HrpcCls Hmaking Hmaking_map Hcls_map]").
+    wp_apply (wp_Mutex__Unlock with "[$Hinv $Hlocked HrpcCls Hmaking Hmaking_map Hcls_map]").
     { rewrite /own_ConnMan. eauto 10 with iFrame. }
     wp_pures.
     wp_load.
@@ -108,7 +108,7 @@ Proof.
   { apply map_get_true in Hmk2.
     wp_pures.
     iDestruct (big_sepM_lookup with "HownMaking") as "Hcond"; first done.
-    wp_apply (wp_condWait with "[$Hinv $Hcond $Hlocked HrpcCls Hmaking Hmaking_map Hcls_map]").
+    wp_apply (wp_Cond__Wait with "[$Hinv $Hcond $Hlocked HrpcCls Hmaking Hmaking_map Hcls_map]").
     { rewrite /own_ConnMan. eauto 10 with iFrame. }
     iIntros "[Hlocked Hown]".
     wp_pures.
@@ -126,14 +126,14 @@ Proof.
   iDestruct (big_sepM_insert_2 with "[Hcond] HownMaking") as "{HownMaking} #HownMaking".
   { done. }
   wp_loadField.
-  wp_apply (release_spec with "[$Hinv $Hlocked HrpcCls Hmaking Hmaking_map Hcls_map]").
+  wp_apply (wp_Mutex__Unlock with "[$Hinv $Hlocked HrpcCls Hmaking Hmaking_map Hcls_map]").
   { rewrite /own_ConnMan. eauto 10 with iFrame. }
   wp_pures.
   wp_apply wp_MakeClient.
   iIntros (cl_new) "#Hcl_new".
   wp_store.
   wp_loadField.
-  wp_apply (acquire_spec with "Hinv").
+  wp_apply (wp_Mutex__Lock with "Hinv").
   iIntros "[Hlocked Hown]".
   iClear "HownRpcCls HownMaking". clear rpcCls making rpcClsM makingM cl1 mk2 Hcl1 Hmk2.
   wp_pures.
@@ -145,7 +145,7 @@ Proof.
   iDestruct (big_sepM_insert_2 with "[Hcl_new] HownRpcCls") as "{HownRpcCls} #HownRpcCls".
   { done. }
   wp_pures.
-  wp_apply (wp_condBroadcast with "Hcond").
+  wp_apply (wp_Cond__Broadcast with "Hcond").
   wp_pures.
   wp_loadField.
   wp_apply (wp_MapDelete with "Hmaking_map"). iIntros "Hmaking_map".
@@ -155,7 +155,7 @@ Proof.
   iModIntro. iRight. iSplitR; first done.
   wp_pures.
   wp_loadField.
-  wp_apply (release_spec with "[$Hinv $Hlocked HrpcCls Hmaking Hmaking_map Hcls_map]").
+  wp_apply (wp_Mutex__Unlock with "[$Hinv $Hlocked HrpcCls Hmaking Hmaking_map Hcls_map]").
   { rewrite /own_ConnMan. eauto 10 with iFrame. }
   wp_load.
   iApply "HΦ". done.
@@ -225,7 +225,7 @@ Proof.
     { (* ErrDisconnected *)
       wp_pures.
       wp_loadField.
-      wp_apply (acquire_spec with "Hinv").
+      wp_apply (wp_Mutex__Lock with "Hinv").
       iIntros "[Hlocked Hown]".
       iClear "Hcl".
       iNamed "Hown".
@@ -248,7 +248,7 @@ Proof.
           rewrite Hsucc. iFrame. }
       iIntros "H". iNamed "H". wp_pures.
       wp_loadField.
-      wp_apply (release_spec with "[$Hinv $Hlocked HrpcCls Hmaking Hmaking_map Hcls_map]").
+      wp_apply (wp_Mutex__Unlock with "[$Hinv $Hlocked HrpcCls Hmaking Hmaking_map Hcls_map]").
       { rewrite /own_ConnMan. iModIntro. do 4 iExists _. iFrame. iFrame "HownMaking".
         case_bool_decide as Heq.
         - iDestruct (big_sepM_subseteq with "HownRpcCls") as "$".

--- a/src/program_proof/memkv/memkv_clerk_proof.v
+++ b/src/program_proof/memkv/memkv_clerk_proof.v
@@ -36,7 +36,7 @@ Proof.
   wp_rec.
   iNamed "Hcck".
   wp_loadField.
-  wp_apply (acquire_spec with "Hinv").
+  wp_apply (wp_Mutex__Lock with "Hinv").
   iIntros "[Hlocked Hown]". iNamed "Hown".
   wp_pures.
   wp_loadField.
@@ -47,7 +47,7 @@ Proof.
     rewrite bool_decide_true; last first.
     { do 2 f_equal. word. }
     wp_loadField.
-    wp_apply (release_spec'' with "Hinv [-HΦ]").
+    wp_apply (wp_Mutex__Unlock'' with "Hinv [-HΦ]").
     { iFrame. }
     wp_pures.
     wp_apply (wp_MakeConnMan).
@@ -84,7 +84,7 @@ Proof.
     iDestruct "HfreeClerks_own" as "[HfreeClerks_own Hck]".
     wp_loadField.
     iDestruct ("HfreeClerks_close" with "HfreeClerks_sl") as "HfreeClerks_sl".
-    wp_apply (release_spec'' with "Hinv [$Hlocked HfreeClerks_own HfreeClerks_sl HfreeClerks]").
+    wp_apply (wp_Mutex__Unlock'' with "Hinv [$Hlocked HfreeClerks_own HfreeClerks_sl HfreeClerks]").
     { rewrite /own_KVClerk. iModIntro. iExists _, _. iFrame.
       (* FIXME need typed slice lemma *)
       iClear "#".
@@ -110,7 +110,7 @@ Proof.
   { iModIntro.
     iNamed "Hcck".
     wp_loadField.
-    wp_apply (acquire_spec with "Hinv").
+    wp_apply (wp_Mutex__Lock with "Hinv").
     iIntros "[Hlocked Hown]". iNamed "Hown".
     wp_loadField.
     wp_apply (wp_SliceAppend with "HfreeClerks_sl").
@@ -118,7 +118,7 @@ Proof.
     wp_bind (struct.storeF _ _ _ _).
     wp_storeField.
     wp_loadField.
-    wp_apply (release_spec'' with "Hinv [$Hlocked HfreeClerks_own HfreeClerks_sl HfreeClerks Hck]").
+    wp_apply (wp_Mutex__Unlock'' with "Hinv [$Hlocked HfreeClerks_own HfreeClerks_sl HfreeClerks Hck]").
     { rewrite /own_KVClerk. iModIntro. iExists _, _. iFrame.
       rewrite big_sepL_singleton. done. }
     done.

--- a/src/program_proof/memkv/memkv_conditional_put_proof.v
+++ b/src/program_proof/memkv/memkv_conditional_put_proof.v
@@ -31,7 +31,7 @@ Proof.
 
   iNamed "His_shard".
   wp_loadField.
-  wp_apply (acquire_spec with "[$HmuInv]").
+  wp_apply (wp_Mutex__Lock with "[$HmuInv]").
   iIntros "[Hlocked Hown]".
 
   iNamed "Hown".
@@ -140,7 +140,7 @@ Proof.
     iDestruct ("HshardMap_sl_close" with "HshardMap_sl") as "HshardMap_sl".
     iModIntro.
     wp_loadField.
-    wp_apply (release_spec with "[-HΦ HKey HErr HSucc Q]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ HKey HErr HSucc Q]").
     {
       iFrame "HmuInv Hlocked".
       iNext.
@@ -217,7 +217,7 @@ Proof.
 
     wp_loadField.
     iSpecialize ("HshardMap_sl_close" with "HshardMap_sl").
-    wp_apply (release_spec with "[-HΦ HKey HErr HSucc Hpre]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ HKey HErr HSucc Hpre]").
     {
       iFrame "HmuInv Hlocked".
       iNext.

--- a/src/program_proof/memkv/memkv_coord_start_proof.v
+++ b/src/program_proof/memkv/memkv_coord_start_proof.v
@@ -60,7 +60,7 @@ Proof.
   wp_pures.
   iNamed "His_memkv".
   wp_loadField.
-  wp_apply (acquire_spec with "[$HmuInv]").
+  wp_apply (wp_Mutex__Lock with "[$HmuInv]").
   iIntros "[Hlocked Hown]".
   iNamed "Hown".
   wp_pures.
@@ -110,7 +110,7 @@ Proof.
   wp_pures.
   iFreeze "IH".
   wp_if_destruct; last first.
-  { iClear "IH". wp_pures. wp_loadField. wp_apply (release_spec with "[-HΦ]").
+  { iClear "IH". wp_pures. wp_loadField. wp_apply (wp_Mutex__Unlock with "[-HΦ]").
     { iFrame "Hlocked HmuInv". iNext. iExists _, _, _, _, _.
       iDestruct ("HshardMap_clo" with "[$]") as "$".
       iFrame. iSplit; eauto. }
@@ -305,7 +305,7 @@ Proof.
       simpl.
       iNamed "His_memkv".
       wp_loadField.
-      wp_apply (acquire_spec with "[$HmuInv]").
+      wp_apply (wp_Mutex__Lock with "[$HmuInv]").
       iIntros "[Hlocked Hown]".
       iNamed "Hown".
       wp_pures.
@@ -324,7 +324,7 @@ Proof.
       iDestruct (own_slice_to_small with "Hdata") as "Hdata".
       wp_pures.
       wp_loadField.
-      wp_apply (release_spec with "[-HΦ Hrep Hdata]").
+      wp_apply (wp_Mutex__Unlock with "[-HΦ Hrep Hdata]").
       { iFrame "Hlocked HmuInv".
         iNext. iExists _, _, _, _, _. iFrame. iFrame "#". iFrame "%".
         iDestruct "H1" as %Hequiv. iApply Hequiv. iFrame. }

--- a/src/program_proof/memkv/memkv_get_proof.v
+++ b/src/program_proof/memkv/memkv_get_proof.v
@@ -60,7 +60,7 @@ Proof.
 
   iNamed "His_shard".
   wp_loadField.
-  wp_apply (acquire_spec with "[$HmuInv]").
+  wp_apply (wp_Mutex__Lock with "[$HmuInv]").
   iIntros "[Hlocked Hown]".
 
   iNamed "Hown".
@@ -168,7 +168,7 @@ Proof.
     iModIntro.
     wp_loadField.
     iApply wp_ncfupd.
-    wp_apply (release_spec with "[-HΦ Q HErr HValue]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ Q HErr HValue]").
     {
       iFrame "HmuInv Hlocked".
       iNext.
@@ -203,7 +203,7 @@ Proof.
     wp_loadField.
     iDestruct ("HshardMap_sl_close" with "HshardMap_sl") as "HshardMap_sl".
     iApply wp_ncfupd.
-    wp_apply (release_spec with "[> -HΦ Hpre HValue HErr]").
+    wp_apply (wp_Mutex__Unlock with "[> -HΦ Hpre HValue HErr]").
     {
       iFrame "HmuInv Hlocked".
       iModIntro. iNext.

--- a/src/program_proof/memkv/memkv_install_shard_proof.v
+++ b/src/program_proof/memkv/memkv_install_shard_proof.v
@@ -26,7 +26,7 @@ Proof.
   wp_pures.
   iNamed "His_shard".
   wp_loadField.
-  wp_apply (acquire_spec with "HmuInv").
+  wp_apply (wp_Mutex__Lock with "HmuInv").
   iIntros "[Hlocked Hown]".
   iNamed "Hown".
   wp_pures.
@@ -73,7 +73,7 @@ Proof.
   iCombine "Hkvss_sl Hkvss_small" as "Hkvss_sl".
 
   wp_loadField.
-  wp_apply (release_spec with "[-HΦ]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ]").
   {
     iFrame "HmuInv Hlocked".
     iNext.

--- a/src/program_proof/memkv/memkv_move_shard_proof.v
+++ b/src/program_proof/memkv/memkv_move_shard_proof.v
@@ -26,7 +26,7 @@ Proof.
   wp_pures.
   iNamed "His_shard".
   wp_loadField.
-  wp_apply (acquire_spec with "HmuInv").
+  wp_apply (wp_Mutex__Lock with "HmuInv").
   iIntros "[Hlocked Hown]".
   iNamed "Hown".
   wp_pures.
@@ -86,7 +86,7 @@ Proof.
   { (* don't have the shard, so we're not going to install it somewhere else *)
     iSpecialize ("HshardMap_sl" with "HshardMap_small").
     wp_loadField.
-    wp_apply (release_spec with "[-HΦ HSid]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ HSid]").
     {
       iFrame "HmuInv Hlocked".
       iNext.
@@ -169,7 +169,7 @@ Proof.
   wp_pures.
   wp_loadField.
   iSpecialize ("HshardMap_sl" with "HshardMap_small").
-  wp_apply (release_spec with "[- HΦ]").
+  wp_apply (wp_Mutex__Unlock with "[- HΦ]").
   {
     iFrame "HmuInv Hlocked".
     iNext.

--- a/src/program_proof/memkv/memkv_put_proof.v
+++ b/src/program_proof/memkv/memkv_put_proof.v
@@ -31,7 +31,7 @@ Proof.
 
   iNamed "His_shard".
   wp_loadField.
-  wp_apply (acquire_spec with "[$HmuInv]").
+  wp_apply (wp_Mutex__Lock with "[$HmuInv]").
   iIntros "[Hlocked Hown]".
 
   iNamed "Hown".
@@ -104,7 +104,7 @@ Proof.
 
     iDestruct ("HshardMap_sl_close" with "HshardMap_sl") as "HshardMap_sl".
     wp_loadField.
-    wp_apply (release_spec with "[> -HΦ Q HKey Hrep]").
+    wp_apply (wp_Mutex__Unlock with "[> -HΦ Q HKey Hrep]").
     {
       iFrame "HmuInv Hlocked".
       iModIntro. iNext.
@@ -172,7 +172,7 @@ Proof.
 
     wp_loadField.
     iSpecialize ("HshardMap_sl_close" with "HshardMap_sl").
-    wp_apply (release_spec with "[-HΦ Hpre HKey Hrep]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ Hpre HKey Hrep]").
     {
       iFrame "HmuInv Hlocked".
       iNext.

--- a/src/program_proof/minlease/proof.v
+++ b/src/program_proof/minlease/proof.v
@@ -163,7 +163,7 @@ Proof.
   wp_rec.
   wp_pures.
   wp_loadField.
-  wp_apply (acquire_spec with "HmuInv").
+  wp_apply (wp_Mutex__Lock with "HmuInv").
   iIntros "[Hlocked Hown]".
   iNamed "Hown".
   wp_pures.
@@ -176,7 +176,7 @@ Proof.
   { apply Qp.half_half. }
   iMod ("Hupd" with "Hval2") as "HΦ".
   iModIntro.
-  wp_apply (release_spec with "[-HΦ]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ]").
   {
     iFrame "HmuInv Hlocked".
     iNext.
@@ -198,7 +198,7 @@ Proof.
   wp_rec.
   wp_pures.
   wp_loadField.
-  wp_apply (acquire_spec with "HmuInv").
+  wp_apply (wp_Mutex__Lock with "HmuInv").
   iIntros "[Hlocked Hown]".
   iNamed "Hown".
   wp_pures.
@@ -210,7 +210,7 @@ Proof.
   iDestruct (ghost_var_valid_2 with "Hauth Hval2") as %[_ ->].
   iMod ("Hupd" with "Hval2") as "HΦ".
   iModIntro.
-  wp_apply (release_spec with "[-HΦ]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ]").
   {
     iFrame "HmuInv Hlocked".
     iNext.
@@ -274,7 +274,7 @@ Proof.
     iClear "Hmu HleaseExpiration".
     iNamed "Hsrv".
     wp_loadField.
-    wp_apply (acquire_spec with "HmuInv").
+    wp_apply (wp_Mutex__Lock with "HmuInv").
     iIntros "[Hlocked Hown]".
     wp_pures.
     wp_apply (wp_GetTimeRange).
@@ -316,7 +316,7 @@ Proof.
       iIntros "%Hoverflow".
       wp_storeField.
       wp_loadField.
-      wp_apply (release_spec with "[-Hlease Hlc1 Hlc2]").
+      wp_apply (wp_Mutex__Unlock with "[-Hlease Hlc1 Hlc2]").
       {
         iFrame "HmuInv Hlocked".
         repeat iExists _; iFrame "∗#%".
@@ -337,7 +337,7 @@ Proof.
     wp_if_destruct.
     2:{ exfalso. word. }
     wp_loadField.
-    wp_apply (release_spec with "[-Hlease]").
+    wp_apply (wp_Mutex__Unlock with "[-Hlease]").
     {
       iFrame "HmuInv Hlocked". iFrame.
     }

--- a/src/program_proof/mvcc/db_new_txn.v
+++ b/src/program_proof/mvcc/db_new_txn.v
@@ -20,7 +20,7 @@ Proof.
   (*@     db.latch.Lock()                                                     @*)
   (*@                                                                         @*)
   wp_loadField.
-  wp_apply (acquire_spec with "Hlock").
+  wp_apply (wp_Mutex__Lock with "Hlock").
   iIntros "[Hlocked HdbOwn]".
   iNamed "HdbOwn".
   wp_pures.
@@ -89,7 +89,7 @@ Proof.
   (*@     return txn                                                          @*)
   (*@ }                                                                       @*)
   wp_loadField.
-  wp_apply (release_spec with "[Hlocked Hsidcur]").
+  wp_apply (wp_Mutex__Unlock with "[Hlocked Hsidcur]").
   { iFrame "Hlock Hlocked".
     iNext.
     unfold own_db.

--- a/src/program_proof/mvcc/index_proof.v
+++ b/src/program_proof/mvcc/index_proof.v
@@ -86,7 +86,7 @@ Proof.
   (* tupleCur, ok := bucket.m[key]                           *)
   (***********************************************************)
   wp_loadField.
-  wp_apply (acquire_spec with "HlatchRP").
+  wp_apply (wp_Mutex__Lock with "HlatchRP").
   iIntros "[Hlocked HbktOwn]".
   iNamed "HbktOwn".
   wp_pures.
@@ -104,7 +104,7 @@ Proof.
   wp_if_destruct.
   { (* The tuple is already in the index. *)
     wp_loadField.
-    wp_apply (release_spec with "[-HΦ]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ]").
     { eauto 10 with iFrame . }
     wp_pures.
     iApply "HΦ".
@@ -138,7 +138,7 @@ Proof.
   iIntros "HlockmOwn".
   wp_pures.
   wp_loadField.
-  wp_apply (release_spec with "[-HΦ HtupleRP]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ HtupleRP]").
   { iFrame "Hlocked HlatchRP".
     iNext.
     rewrite /own_index_bucket.
@@ -221,7 +221,7 @@ Proof.
     rewrite list_lookup_fmap Hbkt_lookup in Hlookup.
     inversion Hlookup.
     wp_loadField.
-    wp_apply (acquire_spec with "HlatchRP").
+    wp_apply (wp_Mutex__Lock with "HlatchRP").
     iIntros "[Hlocked Hbkt]".
     wp_pures.
     iNamed "Hbkt".
@@ -251,7 +251,7 @@ Proof.
     iNamed "HP".
     wp_pures.
     wp_loadField.
-    wp_apply (release_spec with "[- HΦ HkeysR HkeysS]").
+    wp_apply (wp_Mutex__Unlock with "[- HΦ HkeysR HkeysS]").
     { (* Re-establish bucket lock invariant. *) eauto 10 with iFrame. }
     iApply "HΦ".
     eauto with iFrame.

--- a/src/program_proof/mvcc/tuple_append_version.v
+++ b/src/program_proof/mvcc/tuple_append_version.v
@@ -73,7 +73,7 @@ Proof.
   (***********************************************************)
   iNamed "Hlock".
   wp_loadField.
-  wp_apply (wp_condBroadcast with "[$HrcondC]").
+  wp_apply (wp_Cond__Broadcast with "[$HrcondC]").
 
   (***********************************************************)
   (* tuple.latch.Unlock()                                    *)
@@ -88,7 +88,7 @@ Proof.
   assert (HlenN : length phys = S (uint.nat tidlast)) by word.
   iAssert (⌜uint.Z tid < 2 ^ 64 - 1⌝)%I with "[Hactive]" as "%Htidmax".
   { iDestruct "Hactive" as "[_ %H]". iPureIntro. word. }
-  wp_apply (release_spec with "[-HΦ Hactive]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ Hactive]").
   { iFrame "Hlock Hlocked".
     iNext.
     erewrite extend_last_Some; last apply Hlast.

--- a/src/program_proof/mvcc/tuple_free.v
+++ b/src/program_proof/mvcc/tuple_free.v
@@ -20,7 +20,7 @@ Proof.
   (* tuple.latch.Lock()                                      *)
   (***********************************************************)
   wp_loadField.
-  wp_apply (acquire_spec with "Hlock").
+  wp_apply (wp_Mutex__Lock with "Hlock").
   iIntros "[Hlocked HtupleOwn]".
   iNamed "HtupleOwn".
   iNamed "Hphys".
@@ -35,7 +35,7 @@ Proof.
   (* tuple.rcond.Broadcast()                                 *)
   (***********************************************************)
   wp_loadField.
-  wp_apply (wp_condBroadcast with "[$HrcondC]").
+  wp_apply (wp_Cond__Broadcast with "[$HrcondC]").
   wp_pures.
 
   (***********************************************************)
@@ -43,7 +43,7 @@ Proof.
   (***********************************************************)
   wp_loadField.
   iNamed "Hrepr".
-  wp_apply (release_spec with "[-HΦ]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ]").
   { iFrame "Hlock Hlocked".
     iNext.
     iExists false.

--- a/src/program_proof/mvcc/tuple_kill_version.v
+++ b/src/program_proof/mvcc/tuple_kill_version.v
@@ -107,7 +107,7 @@ Proof.
   (***********************************************************)
   iNamed "Hlock".
   wp_loadField.
-  wp_apply (wp_condBroadcast with "[$HrcondC]").
+  wp_apply (wp_Cond__Broadcast with "[$HrcondC]").
   
   (***********************************************************)
   (* tuple.latch.Unlock()                                    *)
@@ -122,7 +122,7 @@ Proof.
   assert (HlenN : length phys = S (uint.nat tidlast)) by word.
   iAssert (⌜uint.Z tid < 2 ^ 64 - 1⌝)%I with "[Hactive]" as "%Htidmax".
   { iDestruct "Hactive" as "[_ %H]". iPureIntro. word. }
-  wp_apply (release_spec with "[-HΦ Hactive HretR]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ Hactive HretR]").
   { iFrame "Hlock Hlocked".
     iNext.
     erewrite extend_last_Some; last apply Hlast.

--- a/src/program_proof/mvcc/tuple_own.v
+++ b/src/program_proof/mvcc/tuple_own.v
@@ -32,7 +32,7 @@ Proof.
   (* tuple.latch.Lock()                                      *)
   (***********************************************************)
   wp_loadField.
-  wp_apply (acquire_spec with "Hlock").
+  wp_apply (wp_Mutex__Lock with "Hlock").
   iIntros "[Hlocked HtupleOwn]".
   iNamed "HtupleOwn".
   iNamed "Hphys".
@@ -47,7 +47,7 @@ Proof.
   wp_loadField.
   wp_if_destruct.
   { wp_loadField.
-    wp_apply (release_spec with "[-HΦ Hactive]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ Hactive]").
     { eauto 15 with iFrame. }
     wp_pures.
     iApply "HΦ".
@@ -63,7 +63,7 @@ Proof.
   wp_loadField.
   wp_if_destruct.
   { wp_loadField.
-    wp_apply (release_spec with "[-HΦ Hactive]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ Hactive]").
     { eauto 15 with iFrame. }
     wp_pures.
     iApply "HΦ".
@@ -81,7 +81,7 @@ Proof.
   wp_loadField.
   iNamed "Hrepr".
   iDestruct (vchain_split (1 / 4) (1 / 4) with "Hptuple") as "[Hptuple Hptuple']"; first compute_done.
-  wp_apply (release_spec with "[-HΦ Hactive Hptuple']").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ Hactive Hptuple']").
   { iFrame "Hlock Hlocked".
     iNext.
     iExists true.

--- a/src/program_proof/mvcc/tuple_read_version.v
+++ b/src/program_proof/mvcc/tuple_read_version.v
@@ -192,7 +192,7 @@ Proof.
   (* tuple.latch.Lock()                                      *)
   (***********************************************************)
   wp_loadField.
-  wp_apply (acquire_spec with "Hlock").
+  wp_apply (wp_Mutex__Lock with "Hlock").
   iIntros "[Hlocked HtupleOwn]".
   iNamed "HtupleOwn".
   wp_pures.
@@ -245,7 +245,7 @@ Proof.
     wp_pures.
     (* Evaluate the loop body. *)
     wp_loadField.
-    wp_apply (wp_condWait with "[-HΦ]").
+    wp_apply (wp_Cond__Wait with "[-HΦ]").
     { eauto 15 with iFrame. }
     iIntros "[Hlocked HtupleOwn]".
     iNamed "HtupleOwn".
@@ -479,7 +479,7 @@ Proof.
   (* tuple.latch.Unlock()                                    *)
   (***********************************************************)
   wp_loadField.
-  wp_apply (release_spec with "[-HΦ Hactive]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ Hactive]").
   { iFrame "Hlock Hlocked". eauto 25 with iFrame. }
   wp_pures.
   iModIntro.

--- a/src/program_proof/mvcc/tuple_remove_versions.v
+++ b/src/program_proof/mvcc/tuple_remove_versions.v
@@ -293,7 +293,7 @@ Proof.
   (* tuple.latch.Lock()                                      *)
   (***********************************************************)
   wp_loadField.
-  wp_apply (acquire_spec with "Hlock").
+  wp_apply (wp_Mutex__Lock with "Hlock").
   iIntros "[Hlocked Htuple]".
   iNamed "Htuple".
   iNamed "Hphys".
@@ -314,7 +314,7 @@ Proof.
     wp_pures.
     wp_loadField.
     iClear "Hgclb'".
-    wp_apply (release_spec with "[-HΦ]"); first eauto 25 with iFrame.
+    wp_apply (wp_Mutex__Unlock with "[-HΦ]"); first eauto 25 with iFrame.
     wp_pures.
     by iApply "HΦ".
   }
@@ -344,7 +344,7 @@ Proof.
   wp_loadField.
   destruct HtidGt as (verHead & Hin & HtidGt).
   destruct Hsuffix as (versPrefix & Hprefix & Hsuffix).
-  wp_apply (release_spec with "[-HΦ]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ]").
   { iFrame "Hlock Hlocked".
     iNext.
     do 2 iExists _.

--- a/src/program_proof/mvcc/tuple_write_lock.v
+++ b/src/program_proof/mvcc/tuple_write_lock.v
@@ -20,7 +20,7 @@ Proof.
   (***********************************************************)
   iNamed "Htuple".
   wp_loadField.
-  wp_apply (acquire_spec with "Hlock").
+  wp_apply (wp_Mutex__Lock with "Hlock").
   iIntros "[Hlocked HtupleOwn]".
   wp_pures.
 

--- a/src/program_proof/mvcc/txnsite_activate.v
+++ b/src/program_proof/mvcc/txnsite_activate.v
@@ -20,7 +20,7 @@ Proof.
   wp_rec. wp_pures.
   
   wp_loadField.
-  wp_apply (acquire_spec with "[$Hlock]").
+  wp_apply (wp_Mutex__Lock with "[$Hlock]").
   iIntros "[Hlocked HsiteOwn]".
   (* replace (W64 (Z.of_nat _)) with sid by word.  *)
   iNamed "HsiteOwn".
@@ -106,7 +106,7 @@ Proof.
   
   (*@     site.latch.Unlock()                                                 @*)
   (*@                                                                         @*)
-  wp_apply (release_spec with "[-HΦ HtidRef HactiveFrag]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ HtidRef HactiveFrag]").
   { iFrame "Hlock Hlocked".
     iNext.
     do 3 iExists _.

--- a/src/program_proof/mvcc/txnsite_deactivate.v
+++ b/src/program_proof/mvcc/txnsite_deactivate.v
@@ -242,7 +242,7 @@ Proof.
   (*@     site.latch.Lock()                                                   @*)
   (*@                                                                         @*)
   wp_loadField.
-  wp_apply (acquire_spec with "[$Hlock]").
+  wp_apply (wp_Mutex__Lock with "[$Hlock]").
   iIntros "[Hlocked HsiteOwn]".
   iNamed "HsiteOwn".
   iDestruct (own_slice_sz with "HactiveL") as "%HactiveSz".
@@ -304,7 +304,7 @@ Proof.
 
   (*@     site.latch.Unlock()                                                 @*)
   (*@ }                                                                       @*)
-  wp_apply (release_spec with "[-HΦ]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ]").
   { iFrame "Hlock Hlocked".
     iNext.
     set idxlast := (word.sub _ _).

--- a/src/program_proof/mvcc/txnsite_get_safe_ts.v
+++ b/src/program_proof/mvcc/txnsite_get_safe_ts.v
@@ -18,7 +18,7 @@ Proof.
   (*@     site.latch.Lock()                                                   @*)
   (*@                                                                         @*)
   wp_loadField.
-  wp_apply (acquire_spec with "[$Hlock]").
+  wp_apply (wp_Mutex__Lock with "[$Hlock]").
   iIntros "[Hlocked HsiteOwn]".
   iNamed "HsiteOwn".
   iDestruct (typed_slice.own_slice_sz with "HactiveL") as "%HtidsactiveSz".
@@ -182,7 +182,7 @@ Proof.
   (*@                                                                         @*)
   iDestruct ("HactiveC" with "HactiveS") as "HactiveL".
   wp_loadField.
-  wp_apply (release_spec with "[-HΦ HtidminRef]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ HtidminRef]").
   { eauto 10 with iFrame. }
   wp_pures.
 

--- a/src/program_proof/obj/commit_proof.v
+++ b/src/program_proof/obj/commit_proof.v
@@ -639,7 +639,7 @@ Proof using txnG0 Σ.
 
   wp_rec. wp_pures.
   wp_loadField.
-  wp_apply acquire_spec; eauto.
+  wp_apply wp_Mutex__Lock; eauto.
   iIntros "[Hlocked Htxnlocked]".
 
   wp_pures.
@@ -1182,7 +1182,7 @@ Proof using txnG0 Σ.
     iDestruct "Hnpos" as "[Hnpos Htxn_pos]".
     iNamed "Hnpos".
     iDestruct "Htxn_pos" as (txn_num) "#Htxn_pos".
-    wp_apply (release_spec with "[$Histxn_lock $Hlocked Hlockedheap Histxn_pos]").
+    wp_apply (wp_Mutex__Unlock with "[$Histxn_lock $Hlocked Hlockedheap Histxn_pos]").
     { iExists _, _, _. iFrame. }
 
     wp_pures.
@@ -1190,7 +1190,7 @@ Proof using txnG0 Σ.
   }
   {
     iNamed "Hnpos".
-    wp_apply (release_spec with "[$Histxn_lock $Hlocked Hlockedheap Histxn_pos]").
+    wp_apply (wp_Mutex__Unlock with "[$Histxn_lock $Hlocked Hlockedheap Histxn_pos]").
     { iExists _, _, _. iFrame. }
 
     wp_pures.

--- a/src/program_proof/pav/server.v
+++ b/src/program_proof/pav/server.v
@@ -168,7 +168,7 @@ Proof.
   iIntros (Φ) "H HΦ". iNamed "H". iNamed "His_serv".
 
   wp_loadField.
-  wp_apply (acquire_spec with "[$HmuR]").
+  wp_apply (wp_Mutex__Lock with "[$HmuR]").
   iIntros "[Hlocked Hown_serv]". iNamed "Hown_serv".
 
   (* error val. *)
@@ -182,7 +182,7 @@ Proof.
 
   (* check id len. *)
   wp_apply wp_slice_len. wp_if_destruct.
-  { wp_loadField. wp_apply (release_spec with "[-HΦ Hown_errReply]").
+  { wp_loadField. wp_apply (wp_Mutex__Unlock with "[-HΦ Hown_errReply]").
     { iFrame "HmuR Hlocked ∗#%". }
     wp_pures. iApply "HΦ". by iFrame. }
 
@@ -190,7 +190,7 @@ Proof.
   wp_apply (wp_StringFromBytes with "[$Hid]"). iIntros "Hid". wp_loadField.
   wp_apply (wp_MapGet with "[$Hown_updates]").
   iIntros (? ok) "[%Hmap_get Hown_updates]". destruct ok.
-  { wp_loadField. wp_apply (release_spec with "[-HΦ Hown_errReply]").
+  { wp_loadField. wp_apply (wp_Mutex__Unlock with "[-HΦ Hown_errReply]").
     { iFrame "HmuR Hlocked ∗#%". }
     wp_pures. iApply "HΦ". by iFrame. }
   wp_loadField.
@@ -277,7 +277,7 @@ Proof.
     rewrite bytes_to_string_to_bytes. word. }
   iEval (rewrite -kmap_insert) in "Hsl_updates". wp_loadField.
   (* release lock. *)
-  wp_apply (release_spec with "[-HΦ Hobj_sepPut Hmsg_putSig Hsl_sig_putSig]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ Hobj_sepPut Hmsg_putSig Hsl_sig_putSig]").
   { (* TODO: some props above would be cleaner if we could rewrite under the insert here. *)
     iFrame "Hlocked HmuR ∗#%". }
   wp_apply wp_allocStruct; [val_ty|]. iIntros (?) "Hown_putReply".
@@ -364,7 +364,7 @@ Lemma wp_server_updateEpoch ptr_serv obj_serv :
 Proof.
   rewrite /server__updateEpoch.
   iIntros (Φ) "H HΦ". iNamed "H". iNamed "His_serv". wp_loadField.
-  wp_apply (acquire_spec with "[$HmuR]").
+  wp_apply (wp_Mutex__Lock with "[$HmuR]").
   iIntros "[Hlocked Hown_serv]". iNamed "Hown_serv".
 
   (* index epochChain. *)
@@ -420,7 +420,7 @@ Proof.
     $Hsl_epochs $Hptr_epochs]"); [iFrame "#"|].
   iClear "His_epochChain". iIntros (?). iNamed 1.
   wp_apply wp_NewMap. iIntros (?) "Hown_new_updates".
-  wp_storeField. wp_loadField. wp_apply (release_spec with "[-HΦ]").
+  wp_storeField. wp_loadField. wp_apply (wp_Mutex__Unlock with "[-HΦ]").
   { iFrame "HmuR Hlocked ∗#%". iSplit.
     - iPureIntro. rewrite length_app. lia.
     - eauto. }

--- a/src/program_proof/reconnectclient/proof.v
+++ b/src/program_proof/reconnectclient/proof.v
@@ -37,7 +37,7 @@ Proof.
   iNamed "His".
   wp_rec. wp_pures.
   wp_loadField.
-  wp_apply (acquire_spec with "HmuInv").
+  wp_apply (wp_Mutex__Lock with "HmuInv").
   iIntros "[Hlocked Hown]".
   iNamed "Hown".
   wp_pures.
@@ -46,14 +46,14 @@ Proof.
   { (* there's already a client there *)
     wp_loadField.
     wp_loadField.
-    wp_apply (release_spec with "[- HΦ]").
+    wp_apply (wp_Mutex__Unlock with "[- HΦ]").
     { iFrame "HmuInv ∗ #". }
     wp_pures. by iApply "HΦ".
   }
 
   (* else make a new one *)
   wp_loadField.
-  wp_apply (release_spec with "[- HΦ]").
+  wp_apply (wp_Mutex__Unlock with "[- HΦ]").
   { iFrame "HmuInv ∗".
     repeat iExists _.
     iFrame "∗#".
@@ -90,7 +90,7 @@ Proof.
 
   wp_pures.
   wp_loadField.
-  wp_apply (acquire_spec with "HmuInv").
+  wp_apply (wp_Mutex__Lock with "HmuInv").
   iIntros "[Hlocked Hown]".
 
   wp_load.
@@ -103,7 +103,7 @@ Proof.
     wp_storeField.
     wp_loadField.
     iDestruct "Hnewcl" as "#Hnewcl".
-    wp_apply (release_spec with "[- HΦ HnewRpcCl Herr]").
+    wp_apply (wp_Mutex__Unlock with "[- HΦ HnewRpcCl Herr]").
     { iFrame "HmuInv ∗ #". }
 
     wp_load.
@@ -112,7 +112,7 @@ Proof.
     iApply "HΦ".
     by iFrame "#".
   - wp_loadField.
-    wp_apply (release_spec with "[- HΦ HnewRpcCl Herr]").
+    wp_apply (wp_Mutex__Unlock with "[- HΦ HnewRpcCl Herr]").
     { iFrame "HmuInv ∗ #". }
 
     wp_load.
@@ -168,7 +168,7 @@ Proof.
   {
     iNamed "Hre".
     wp_loadField.
-    wp_apply (acquire_spec with "HmuInv").
+    wp_apply (wp_Mutex__Lock with "HmuInv").
     iIntros "[Hlocked Hown]".
 
     iClear "Hcl".
@@ -177,7 +177,7 @@ Proof.
     wp_pures.
     wp_storeField.
     wp_loadField.
-    wp_apply (release_spec with "[Hlocked Hvalid HurpcCl]").
+    wp_apply (wp_Mutex__Unlock with "[Hlocked Hvalid HurpcCl]").
     {
       iFrame "HmuInv Hlocked".
       iNext. repeat iExists _.

--- a/src/program_proof/rsm/distx/program/replica.v
+++ b/src/program_proof/rsm/distx/program/replica.v
@@ -424,7 +424,7 @@ Section program.
     (*@                                                                         @*)
     iNamed "Hrp".
     wp_loadField.
-    wp_apply (acquire_spec with "Hlock").
+    wp_apply (wp_Mutex__Lock with "Hlock").
     iIntros "[Hlocked Hrp]".
     wp_pures.
     iNamed "Hrp". iNamed "Hst".
@@ -436,7 +436,7 @@ Section program.
     (*@     return status                                                       @*)
     (*@ }                                                                       @*)
     wp_loadField.
-    wp_apply (release_spec with "[-HΦ $Hlock $Hlocked]"); first by iFrame "∗ # %".
+    wp_apply (wp_Mutex__Unlock with "[-HΦ $Hlock $Hlocked]"); first by iFrame "∗ # %".
     wp_pures.
     iApply "HΦ".
     destruct (stm !! uint.nat ts) as [st |] eqn:Hst; last done.
@@ -476,7 +476,7 @@ Section program.
     (*@                                                                         @*)
     iNamed "Hrp".
     wp_loadField.
-    wp_apply (acquire_spec with "Hlock").
+    wp_apply (wp_Mutex__Lock with "Hlock").
     iIntros "[Hlocked Hrp]".
     wp_pures.
     iNamed "Hrp". iNamed "Hst".
@@ -505,7 +505,7 @@ Section program.
       apply elem_of_list_lookup_2 in Hloga.
       by eapply apply_cmds_elem_of_prepare.
     }
-    wp_apply (release_spec with "[-HΦ $Hlock $Hlocked]"); first by iFrame "∗ # %".
+    wp_apply (wp_Mutex__Unlock with "[-HΦ $Hlock $Hlocked]"); first by iFrame "∗ # %".
     wp_pures.
     destruct Hsome as [st Hst].
     rewrite Hst.
@@ -568,13 +568,13 @@ Section program.
     (*@                                                                         @*)
     iNamed "Hrp".
     wp_loadField.
-    wp_apply (acquire_spec with "Hlock").
+    wp_apply (wp_Mutex__Lock with "Hlock").
     iIntros "[Hlocked Hrp]".
     iNamed "Hrp". iNamed "Hst". iNamed "Hstm".
     wp_apply (wp_Replica__queryTxnTermination with "Htxntbl").
     iIntros (terminated) "[Htxntbl _]".
     wp_loadField.
-    wp_apply (release_spec with "[-HΦ $Hlock $Hlocked]"); first by iFrame "∗ # %".
+    wp_apply (wp_Mutex__Unlock with "[-HΦ $Hlock $Hlocked]"); first by iFrame "∗ # %".
 
     (*@     return terminated                                                   @*)
     (*@ }                                                                       @*)
@@ -611,13 +611,13 @@ Section program.
       wp_pures.
       iNamed "Hrp".
       wp_loadField.
-      wp_apply (acquire_spec with "Hlock").
+      wp_apply (wp_Mutex__Lock with "Hlock").
       iIntros "[Hlocked Hrp]".
       iNamed "Hrp". iNamed "Hlog".
       do 2 wp_loadField.
       (* Obtain a lower bound of [lsna]. *)
       iDestruct (lsn_applied_witness with "Hlsna") as "#Hlsnap".
-      wp_apply (release_spec with "[-HΦ $Hlock $Hlocked]"); first by iFrame "∗ # %".
+      wp_apply (wp_Mutex__Unlock with "[-HΦ $Hlock $Hlocked]"); first by iFrame "∗ # %".
       wp_if_destruct.
       { (* Weaken the lower bound. *)
         iDestruct (lsn_applied_lb_weaken (uint.nat lsn) with "Hlsnap") as "#Hlsn".
@@ -2046,7 +2046,7 @@ Section program.
     (*@                                                                         @*)
     iPoseProof "Hrp" as "Hrp'". iNamed "Hrp'".
     wp_loadField.
-    wp_apply (acquire_spec with "Hlock").
+    wp_apply (wp_Mutex__Lock with "Hlock").
     iIntros "[Hlocked HrpO]".
     wp_pures.
 
@@ -2144,10 +2144,10 @@ Section program.
     { (* Have applied all the commands known to be committed. *)
       wp_loadField.
       iClear "Hlb Hlbnew".
-      wp_apply (release_spec with "[-HΦ $Hlock $Hlocked]"); first by iFrame "∗ # %".
+      wp_apply (wp_Mutex__Unlock with "[-HΦ $Hlock $Hlocked]"); first by iFrame "∗ # %".
       wp_apply wp_Sleep.
       wp_loadField.
-      wp_apply (acquire_spec with "Hlock").
+      wp_apply (wp_Mutex__Lock with "Hlock").
       iIntros "[Hlocked HrpO]".
       wp_pures.
       iApply "HΦ".

--- a/src/program_proof/rsm/spaxos_propose.v
+++ b/src/program_proof/rsm/spaxos_propose.v
@@ -259,12 +259,12 @@ Proof.
   (*@ }                                                                       @*)
   iNamed "Hnode".
   wp_loadField.
-  wp_apply (acquire_spec with "[$Hlock]").
+  wp_apply (wp_Mutex__Lock with "[$Hlock]").
   iIntros "[Hlocked HpaxosOwn]".
   wp_pures.
   iNamed "HpaxosOwn".
   do 2 wp_loadField. wp_pures. wp_loadField.
-  wp_apply (release_spec with "[-HAU $Hlock $Hlocked]"); first eauto 15 with iFrame.
+  wp_apply (wp_Mutex__Unlock with "[-HAU $Hlock $Hlocked]"); first eauto 15 with iFrame.
   wp_pures.
 
   destruct learned eqn:Elearned; last first.
@@ -352,7 +352,7 @@ Proof.
   (*@                                                                         @*)
   iNamed "Hnode".
   wp_loadField.
-  wp_apply (acquire_spec with "[$Hlock]").
+  wp_apply (wp_Mutex__Lock with "[$Hlock]").
   iIntros "[Hlocked HpaxosOwn]".
   wp_pures.
 
@@ -365,7 +365,7 @@ Proof.
   wp_loadField.
   wp_if_destruct.
   { wp_loadField.
-    wp_apply (release_spec with "[-HΦ $Hlock $Hlocked]"); first by eauto 15 with iFrame.
+    wp_apply (wp_Mutex__Unlock with "[-HΦ $Hlock $Hlocked]"); first by eauto 15 with iFrame.
     wp_pures.
     by iApply "HΦ".
   }
@@ -402,7 +402,7 @@ Proof.
   (*@     px.mu.Unlock()                                                      @*)
   (*@                                                                         @*)
   wp_loadField.
-  wp_apply (release_spec with "[-HΦ $Hlock $Hlocked]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ $Hlock $Hlocked]").
   { do 5 iExists _. iFrame "∗ #".
     iPureIntro.
     split; first lia.
@@ -447,7 +447,7 @@ Proof.
   (*@                                                                         @*)
   iNamed "Hnode".
   wp_loadField.
-  wp_apply (acquire_spec with "[$Hlock]").
+  wp_apply (wp_Mutex__Lock with "[$Hlock]").
   iIntros "[Hlocked HpaxosOwn]".
   wp_pures.
 
@@ -492,7 +492,7 @@ Proof.
   (*@     px.mu.Unlock()                                                      @*)
   (*@                                                                         @*)
   wp_loadField.
-  wp_apply (release_spec with "[-HΦ $Hlock $Hlocked]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ $Hlock $Hlocked]").
   { do 5 iExists _. iFrame "∗ #".
     iPureIntro.
     split; first lia.
@@ -540,7 +540,7 @@ Proof.
   (*@                                                                         @*)
   iNamed "Hnode".
   wp_loadField.
-  wp_apply (acquire_spec with "[$Hlock]").
+  wp_apply (wp_Mutex__Lock with "[$Hlock]").
   iIntros "[Hlocked HpaxosOwn]".
   wp_pures.
 
@@ -553,7 +553,7 @@ Proof.
   wp_loadField.
   wp_if_destruct.
   { wp_loadField.
-    wp_apply (release_spec with "[-HΦ $Hlock $Hlocked]"); first by eauto 15 with iFrame.
+    wp_apply (wp_Mutex__Unlock with "[-HΦ $Hlock $Hlocked]"); first by eauto 15 with iFrame.
     wp_pures.
     by iApply "HΦ".
   }
@@ -566,7 +566,7 @@ Proof.
   wp_loadField.
   wp_if_destruct.
   { wp_loadField.
-    wp_apply (release_spec with "[-HΦ $Hlock $Hlocked]"); first by eauto 15 with iFrame.
+    wp_apply (wp_Mutex__Unlock with "[-HΦ $Hlock $Hlocked]"); first by eauto 15 with iFrame.
     wp_pures.
     by iApply "HΦ".
   }
@@ -620,7 +620,7 @@ Proof.
   iClear "Hproposed".
   iAssert (is_proposal_nz γ (uint.nat term) decree)%I as "#Hproposed".
   { unfold is_proposal_nz. case_decide; done. }
-  wp_apply (release_spec with "[-HΦ $Hlock $Hlocked]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ $Hlock $Hlocked]").
   { do 5 iExists _. iFrame "∗ #".
     iPureIntro.
     replace (uint.nat (word.add _ _)) with (S (uint.nat term)) by word.
@@ -684,7 +684,7 @@ Proof.
   (*@                                                                         @*)
   iNamed "Hnode".
   wp_loadField.
-  wp_apply (acquire_spec with "[$Hlock]").
+  wp_apply (wp_Mutex__Lock with "[$Hlock]").
   iIntros "[Hlocked HpaxosOwn]".
   wp_pures.
 
@@ -697,7 +697,7 @@ Proof.
   wp_loadField.
   wp_if_destruct.
   { wp_loadField.
-    wp_apply (release_spec with "[-HAU $Hlock $Hlocked]"); first by eauto 15 with iFrame.
+    wp_apply (wp_Mutex__Unlock with "[-HAU $Hlock $Hlocked]"); first by eauto 15 with iFrame.
     wp_pures.
     iInv "Hinv" as "> HinvO" "HinvC".
     iMod "HAU" as (vs) "[Hvs' HAU]".
@@ -720,7 +720,7 @@ Proof.
   wp_loadField.
   wp_if_destruct.
   { wp_loadField.
-    wp_apply (release_spec with "[-HAU $Hlock $Hlocked]"); first by eauto 15 with iFrame.
+    wp_apply (wp_Mutex__Unlock with "[-HAU $Hlock $Hlocked]"); first by eauto 15 with iFrame.
     wp_pures.
     iInv "Hinv" as "> HinvO" "HinvC".
     iMod "HAU" as (vs) "[Hvs' HAU]".
@@ -892,7 +892,7 @@ Proof.
   wp_loadField.
   iAssert (is_proposal_nz γ (uint.nat term) decree)%I as "#Hproposed".
   { unfold is_proposal_nz. destruct (decide (uint.nat term = _)); done. }
-  wp_apply (release_spec with "[-HΦ $Hlock $Hlocked]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ $Hlock $Hlocked]").
   { do 5 iExists _. iFrame "∗ #".
     iPureIntro.
     replace (uint.nat (word.add _ _)) with (S (uint.nat term)) by word.
@@ -1248,7 +1248,7 @@ Proof.
   (*@                                                                         @*)
   iNamed "Hnode".
   wp_loadField.
-  wp_apply (acquire_spec with "[$Hlock]").
+  wp_apply (wp_Mutex__Lock with "[$Hlock]").
   iIntros "[Hlocked HpaxosOwn]".
   wp_pures.
 
@@ -1261,7 +1261,7 @@ Proof.
   wp_loadField.
   wp_if_destruct.
   { wp_loadField.
-    wp_apply (release_spec with "[-HΦ $Hlock $Hlocked]"); first by eauto 15 with iFrame.
+    wp_apply (wp_Mutex__Unlock with "[-HΦ $Hlock $Hlocked]"); first by eauto 15 with iFrame.
     wp_pures.
     by iApply "HΦ".
   }
@@ -1316,7 +1316,7 @@ Proof.
   iClear "Hproposed".
   iAssert (is_proposal_nz γ (uint.nat term) decree)%I as "#Hproposed".
   { unfold is_proposal_nz. case_decide; done. }
-  wp_apply (release_spec with "[-HΦ $Hlock $Hlocked]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ $Hlock $Hlocked]").
   { do 5 iExists _. iFrame "∗ #".
     iPureIntro.
     replace (uint.nat (word.add _ _)) with (S (uint.nat term)) by word.

--- a/src/program_proof/single/single_proof.v
+++ b/src/program_proof/single/single_proof.v
@@ -76,7 +76,7 @@ Proof.
   iNamed "His".
 
   wp_loadField.
-  wp_apply (acquire_spec with "Hmu_inv").
+  wp_apply (wp_Mutex__Lock with "Hmu_inv").
   iIntros "[Hlocked Hown]".
   iNamed "Hown".
   wp_loadField.
@@ -103,7 +103,7 @@ Proof.
     wp_loadField.
     wp_storeField.
     wp_loadField.
-    wp_apply (release_spec with "[$Hmu_inv $Hlocked HpromisedPN HacceptedVal HacceptedPN Hundec Haccepted Hvotes HcommittedVal]").
+    wp_apply (wp_Mutex__Unlock with "[$Hmu_inv $Hlocked HpromisedPN HacceptedVal HacceptedPN Hundec Haccepted Hvotes HcommittedVal]").
     {
       iNext. iExists _, _, _, _.
       iFrame "∗#".
@@ -136,7 +136,7 @@ Proof.
   wp_pures.
   iNamed "His".
   wp_loadField.
-  wp_apply (acquire_spec with "Hmu_inv").
+  wp_apply (wp_Mutex__Lock with "Hmu_inv").
   iIntros "[Hlocked Hown]".
   iNamed "Hown".
 
@@ -156,7 +156,7 @@ Proof.
         wp_storeField.
         wp_storeField.
         wp_loadField.
-        wp_apply (release_spec with "[-HΦ]").
+        wp_apply (wp_Mutex__Unlock with "[-HΦ]").
         {
           iFrame "Hmu_inv Hlocked".
           iNext.
@@ -178,7 +178,7 @@ Proof.
       wp_storeField.
       wp_storeField.
       wp_loadField.
-      wp_apply (release_spec with "[-HΦ]").
+      wp_apply (wp_Mutex__Unlock with "[-HΦ]").
       {
         iFrame "Hmu_inv Hlocked".
         iNext.

--- a/src/program_proof/single/try_decide_proof.v
+++ b/src/program_proof/single/try_decide_proof.v
@@ -107,13 +107,13 @@ Proof.
   wp_pures.
   iNamed "His".
   wp_loadField.
-  wp_apply (acquire_spec with "Hmu_inv").
+  wp_apply (wp_Mutex__Lock with "Hmu_inv").
   iIntros "[Hlocked Hown]".
   wp_pures.
   iNamed "Hown".
   wp_loadField.
   wp_loadField.
-  wp_apply (release_spec with "[-HΦ Houtv]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ Houtv]").
   {
     iFrame "Hmu_inv Hlocked".
     iNext.
@@ -211,7 +211,7 @@ Proof.
       { (* got a promise *)
         iDestruct "Hpost" as "[%Hbad|#Hpost]".
         { exfalso. done. }
-        wp_apply (acquire_spec with "Hl_inv").
+        wp_apply (wp_Mutex__Lock with "Hl_inv").
         iIntros "[Hlocked Hown]".
         iNamed "Hown".
         wp_pures.
@@ -226,7 +226,7 @@ Proof.
           wp_loadField.
           wp_store.
           wp_pures.
-          wp_apply (release_spec with "[-]"); last done.
+          wp_apply (wp_Mutex__Unlock with "[-]"); last done.
           {
             iFrame "Hl_inv Hlocked".
             iNext.
@@ -321,7 +321,7 @@ Proof.
         }
         { (* not a higher PN; just use Hpost to update Hrejected *)
           wp_pures.
-          wp_apply (release_spec with "[-]").
+          wp_apply (wp_Mutex__Unlock with "[-]").
           {
             iFrame "Hl_inv Hlocked".
             iNext.
@@ -426,7 +426,7 @@ Proof.
 
   iIntros "_".
   wp_pures.
-  wp_apply (acquire_spec with "Hl_inv").
+  wp_apply (wp_Mutex__Lock with "Hl_inv").
   iIntros "[Hlocked Hown]".
   iNamed "Hown".
   wp_pures.
@@ -434,7 +434,7 @@ Proof.
   wp_pures.
   wp_load.
   wp_pures.
-  wp_apply (release_spec with "[$Hl_inv $Hlocked HnumPrepared HhighestPn HhighestVal Htoks]").
+  wp_apply (wp_Mutex__Unlock with "[$Hl_inv $Hlocked HnumPrepared HhighestPn HhighestVal Htoks]").
   { iNext. iExists _, _, _, _. iFrame "∗#". done. }
   wp_pures.
   wp_loadField.
@@ -536,14 +536,14 @@ Proof.
         wp_if_destruct.
         { (* accepted *)
           iDestruct "Hret" as "[%Hbad|#HacceptedReply]"; first by exfalso.
-          wp_apply (acquire_spec with "Hl2_inv").
+          wp_apply (wp_Mutex__Lock with "Hl2_inv").
           iIntros "[Hlocked Hown]".
           iRename "Haccepted" into "HacceptedServer".
           iNamed "Hown".
           wp_pures.
           wp_load.
           wp_store.
-          wp_apply (release_spec with "[$Hl2_inv $Hlocked HnumAccepted Hγtok Htoks]"); last done.
+          wp_apply (wp_Mutex__Unlock with "[$Hl2_inv $Hlocked HnumAccepted Hγtok Htoks]"); last done.
           {
             iNext.
             iExists _, ({[pid']} ∪ S).
@@ -620,14 +620,14 @@ Proof.
     iIntros "_".
     wp_pures.
 
-    wp_apply (acquire_spec with "Hl2_inv").
+    wp_apply (wp_Mutex__Lock with "Hl2_inv").
     iIntros "[Hlocked Hown]".
     iRename "Haccepted" into "HacceptedOld".
     iNamed "Hown".
     wp_pures.
     wp_load.
     wp_pures.
-    wp_apply (release_spec with "[-HΦ Houtv]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ Houtv]").
     { iFrame "Hl2_inv Hlocked". iNext; iExists _, _; iFrame "∗#"; done. }
     wp_pures.
     wp_loadField.

--- a/src/program_proof/tutorial/basics/full_proof.v
+++ b/src/program_proof/tutorial/basics/full_proof.v
@@ -136,7 +136,7 @@ Proof.
 
   Search lock.acquire.
 
-  wp_apply (acquire_spec with "[]").
+  wp_apply (wp_Mutex__Lock with "[]").
   { iApply "Ht_lock". }
   iIntros "[Hlocked Ht]".
   iNamed "Ht".
@@ -148,7 +148,7 @@ Proof.
 
   Search lock.release.
 
-  wp_apply (release_spec with "[Hlocked Ht_state]").
+  wp_apply (wp_Mutex__Unlock with "[Hlocked Ht_state]").
   { iFrame "Ht_lock". iFrame "Hlocked".
     iExists _. iFrame. }
   wp_pures.
@@ -169,7 +169,7 @@ Proof.
 
   Search lock.acquire.
 
-  wp_apply (acquire_spec with "[]").
+  wp_apply (wp_Mutex__Lock with "[]").
   { iApply "Ht_lock". }
   iIntros "[Hlocked Ht]".
   iNamed "Ht".
@@ -182,7 +182,7 @@ Proof.
 
   Search lock.release.
 
-  wp_apply (release_spec with "[Hlocked Ht_state]").
+  wp_apply (wp_Mutex__Unlock with "[Hlocked Ht_state]").
   { iFrame "Ht_lock". iFrame "Hlocked".
     iExists _. iFrame. }
   wp_pures.
@@ -200,7 +200,7 @@ Proof.
   iNamed "Ht".
   wp_rec. wp_pures.
   wp_loadField.
-  wp_apply (acquire_spec with "Ht_lock").
+  wp_apply (wp_Mutex__Lock with "Ht_lock").
   iIntros "[Hlocked Ht]".
   iNamed "Ht".
   wp_pures.
@@ -211,7 +211,7 @@ Proof.
   destruct b.
   {
     iDestruct "Hb" as "[Ht_state Hptsto]".
-    wp_apply (release_spec with "[Hlocked Ht_state]").
+    wp_apply (wp_Mutex__Unlock with "[Hlocked Ht_state]").
     { iFrame "Ht_lock". iFrame "Hlocked". iModIntro.
       iExists _. iFrame. }
     wp_pures.
@@ -220,7 +220,7 @@ Proof.
     iFrame.
   }
   {
-    wp_apply (release_spec with "[Hlocked Hb]").
+    wp_apply (wp_Mutex__Unlock with "[Hlocked Hb]").
     { iFrame "Ht_lock". iFrame "Hlocked". iModIntro.
       iExists _. iFrame. }
     wp_pures.

--- a/src/program_proof/tutorial/basics/proof.v
+++ b/src/program_proof/tutorial/basics/proof.v
@@ -102,7 +102,7 @@ Proof.
 
   (* Search lock.acquire. *)
 
-  wp_apply (acquire_spec with "[]").
+  wp_apply (wp_Mutex__Lock with "[]").
   { iApply "Ht_lock". }
   iIntros "[Hlocked Ht]".
   iNamed "Ht".
@@ -114,7 +114,7 @@ Proof.
 
   (* Search lock.release. *)
 
-  wp_apply (release_spec with "[Hlocked Ht_state]").
+  wp_apply (wp_Mutex__Unlock with "[Hlocked Ht_state]").
   { iFrame "Ht_lock". iFrame "Hlocked".
     iExists _. iFrame. }
   wp_pures.
@@ -132,7 +132,7 @@ Proof.
   iNamed "Ht".
   wp_rec. wp_pures.
   wp_loadField.
-  wp_apply (acquire_spec with "Ht_lock").
+  wp_apply (wp_Mutex__Lock with "Ht_lock").
   iIntros "[Hlocked Ht]".
   iNamed "Ht".
   wp_pures.
@@ -142,7 +142,7 @@ Proof.
   wp_loadField.
   destruct b.
   {
-    wp_apply (release_spec with "[Hlocked Hb]").
+    wp_apply (wp_Mutex__Unlock with "[Hlocked Hb]").
     { iFrame "Ht_lock". iFrame "Hlocked". iModIntro.
       iExists _. iFrame. }
     wp_pures.
@@ -150,7 +150,7 @@ Proof.
     done.
   }
   {
-    wp_apply (release_spec with "[Hlocked Hb]").
+    wp_apply (wp_Mutex__Unlock with "[Hlocked Hb]").
     { iFrame "Ht_lock". iFrame "Hlocked". iModIntro.
       iExists _. iFrame. }
     wp_pures.

--- a/src/program_proof/tutorial/kvservice/full_proof.v
+++ b/src/program_proof/tutorial/kvservice/full_proof.v
@@ -914,7 +914,7 @@ Proof.
   wp_pures.
   iNamed "Hsrv".
   wp_loadField.
-  wp_apply (acquire_spec with "[$]").
+  wp_apply (wp_Mutex__Lock with "[$]").
   iIntros "[Hlocked Hown]".
   repeat iNamed "Hown".
   wp_pures.
@@ -927,7 +927,7 @@ Proof.
   wp_loadField.
   iMod (ghost_getFreshNum with "Hspec Hghost") as "[Hghost Hspec]".
   { word. }
-  wp_apply (release_spec with "[-HΦ Hspec]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ Hspec]").
   {
     iFrame "∗#". iNext.
     repeat iExists _.
@@ -1005,7 +1005,7 @@ Proof.
   wp_pures.
   iNamed "Hsrv".
   wp_loadField.
-  wp_apply (acquire_spec with "[$]").
+  wp_apply (wp_Mutex__Lock with "[$]").
   iIntros "[Hlocked Hown]".
   repeat iNamed "Hown".
   wp_pures.
@@ -1021,7 +1021,7 @@ Proof.
     apply map_get_true in HlastReply.
     iDestruct (ghost_put_dup with "Hspec Hghost") as "[Hghost Hspec]".
     { done. }
-    wp_apply (release_spec with "[-HΦ Hspec]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ Hspec]").
     {
       iFrame "∗#". iNext.
       repeat iExists _; iFrame "Hghost".
@@ -1047,7 +1047,7 @@ Proof.
   wp_loadField.
   iMod (ghost_put with "Hlc Hspec Hghost") as "[Hghost Hspec]".
   { apply map_get_false in HlastReply as [? _]. done. }
-  wp_apply (release_spec with "[-HΦ Hspec]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ Hspec]").
   {
     iFrame "∗#". iNext.
     repeat iExists _; iFrame "Hghost".
@@ -1184,7 +1184,7 @@ Proof.
   wp_pures.
   iNamed "Hsrv".
   wp_loadField.
-  wp_apply (acquire_spec with "[$]").
+  wp_apply (wp_Mutex__Lock with "[$]").
   iIntros "[Hlocked Hown]".
   repeat iNamed "Hown".
   wp_pures.
@@ -1199,7 +1199,7 @@ Proof.
     wp_loadField.
     iDestruct (ghost_conditionalPut_dup with "Hspec Hghost") as "[Hghost Hspec]".
     { by apply map_get_true in HlastReply. }
-    wp_apply (release_spec with "[-HΦ Hspec]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ Hspec]").
     {
       iFrame "∗#". iNext.
       repeat iExists _; iFrame "Hghost".
@@ -1249,7 +1249,7 @@ Proof.
       by apply server.gauge_proper_default_lookup. }
     (* simplify by unfolding some of the cond_put stuff *)
 
-    wp_apply (release_spec with "[-HΦ Hspec Hret]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ Hspec Hret]").
     {
       iFrame "∗#". iNext.
       repeat iExists _; iFrame "Hghost".
@@ -1285,7 +1285,7 @@ Proof.
     by apply server.gauge_proper_default_lookup. }
   (* simplify by unfolding some of the cond_put stuff *)
 
-  wp_apply (release_spec with "[-HΦ Hspec Hret]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ Hspec Hret]").
   {
     iFrame "∗#". iNext.
     repeat iExists _; iFrame "Hghost".
@@ -1366,7 +1366,7 @@ Proof.
   wp_pures.
   iNamed "Hsrv".
   wp_loadField.
-  wp_apply (acquire_spec with "[$]").
+  wp_apply (wp_Mutex__Lock with "[$]").
   iIntros "[Hlocked Hown]".
   repeat iNamed "Hown".
   wp_pures.
@@ -1381,7 +1381,7 @@ Proof.
     wp_loadField.
     iDestruct (ghost_get_dup with "Hspec Hghost") as "[Hghost Hspec]".
     { by apply map_get_true in HlastReply. }
-    wp_apply (release_spec with "[-HΦ Hspec]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ Hspec]").
     {
       iFrame "∗#". iNext.
       repeat iExists _; iFrame "Hghost".
@@ -1410,7 +1410,7 @@ Proof.
   subst.
   (* FIXME: better map_get *)
   erewrite <- (server.gauge_proper_default_lookup _ _ st.(server.kvs) Hrel_phys).
-  wp_apply (release_spec with "[-HΦ Hspec]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ Hspec]").
   {
     iFrame "∗#". iNext.
     repeat iExists _; iFrame "Hghost".

--- a/src/program_proof/tutorial/kvservice/proof.v
+++ b/src/program_proof/tutorial/kvservice/proof.v
@@ -592,9 +592,9 @@ Proof.
   wp_start.
   iNamed "Hsrv".
   wp_auto.
-  wp_apply (acquire_spec with "[$]") as "[Hlocked Hown]"; iNamed "Hown"; wp_auto.
+  wp_apply (wp_Mutex__Lock with "[$]") as "[Hlocked Hown]"; iNamed "Hown"; wp_auto.
   wp_apply (wp_SumAssumeNoOverflow) as (Hoverflow) "".
-  wp_apply (release_spec with "[-HΦ Hspec]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ Hspec]").
   {
     iFrame "∗#". iNext.
     repeat iExists _.
@@ -620,13 +620,13 @@ Proof.
   wp_start.
   iNamed "Hsrv".
   wp_auto.
-  wp_apply (acquire_spec with "[$]") as "[Hlocked Hown]"; iNamed "Hown".
+  wp_apply (wp_Mutex__Lock with "[$]") as "[Hlocked Hown]"; iNamed "Hown".
   iNamed "Hargs".
   wp_auto.
   wp_apply (wp_MapGet with "HlastRepliesM") as (??) "[%HlastReply HlastRepliesM]".
   wp_if_destruct; wp_auto.
   { (* case: this is a duplicate request *)
-    wp_apply (release_spec with "[-HΦ Hspec]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ Hspec]").
     {
       iFrame "∗#". iNext.
       repeat iExists _.
@@ -637,7 +637,7 @@ Proof.
   }
   wp_apply (wp_MapInsert with "HkvsM") as "HkvsM"; first done.
   wp_apply (wp_MapInsert with "HlastRepliesM") as "HlastRepliesM"; first done.
-  wp_apply (release_spec with "[-HΦ Hspec]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ Hspec]").
   {
     iFrame "∗#". iNext.
     repeat iExists _.
@@ -660,13 +660,13 @@ Proof.
   wp_start.
   iNamed "Hsrv".
   wp_auto.
-  wp_apply (acquire_spec with "[$]") as "[Hlocked Hown]"; iNamed "Hown".
+  wp_apply (wp_Mutex__Lock with "[$]") as "[Hlocked Hown]"; iNamed "Hown".
   iNamed "Hargs".
   wp_auto.
   wp_apply (wp_MapGet with "HlastRepliesM") as (??) "[%HlastReply HlastRepliesM]".
   wp_if_destruct; wp_auto.
   { (* case: this is a duplicate request *)
-    wp_apply (release_spec with "[-HΦ Hspec]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ Hspec]").
     {
       iFrame "∗#". iNext.
       repeat iExists _.
@@ -684,7 +684,7 @@ Proof.
     (* FIXME: delete typed_map.map_insert *)
     rewrite /typed_map.map_insert.
     wp_apply (wp_MapInsert with "HlastRepliesM") as "HlastRepliesM"; first done.
-    wp_apply (release_spec with "[-HΦ Hspec Hret]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ Hspec Hret]").
     {
       iFrame "∗#". iNext.
       repeat iExists _.
@@ -696,7 +696,7 @@ Proof.
   }
 
   wp_apply (wp_MapInsert with "HlastRepliesM") as "HlastRepliesM"; first done.
-  wp_apply (release_spec with "[-HΦ Hspec Hret]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ Hspec Hret]").
   {
     iFrame "∗#". iNext.
     repeat iExists _.
@@ -722,13 +722,13 @@ Proof.
   wp_start.
   iNamed "Hsrv".
   wp_auto.
-  wp_apply (acquire_spec with "[$]") as "[Hlocked Hown]"; iNamed "Hown".
+  wp_apply (wp_Mutex__Lock with "[$]") as "[Hlocked Hown]"; iNamed "Hown".
   iNamed "Hargs".
   wp_auto.
   wp_apply (wp_MapGet with "HlastRepliesM") as (??) "[%HlastReply HlastRepliesM]".
   wp_if_destruct; wp_auto.
   { (* case: this is a duplicate request *)
-    wp_apply (release_spec with "[-HΦ Hspec]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ Hspec]").
     {
       iFrame "∗#". iNext.
       repeat iExists _.
@@ -740,7 +740,7 @@ Proof.
   }
   wp_apply (wp_MapGet with "HkvsM") as (??) "[%Hlookup HkvsM]".
   wp_apply (wp_MapInsert with "HlastRepliesM") as "HlastRepliesM"; first done.
-  wp_apply (release_spec with "[-HΦ Hspec]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ Hspec]").
   {
     iFrame "∗#". iNext.
     repeat iExists _.

--- a/src/program_proof/tutorial/lockservice/proof.v
+++ b/src/program_proof/tutorial/lockservice/proof.v
@@ -114,7 +114,7 @@ Next Obligation.
 Defined. *)
 Admitted.
 
-Program Definition release_spec :=
+Program Definition wp_Mutex__Unlock :=
   λ (enc_args:list u8), λne (Φ : list u8 -d> iPropO Σ) ,
   (∃ args,
    "%Henc" ∷ ⌜enc_args = u64_le args⌝ ∗
@@ -130,7 +130,7 @@ Definition is_lockserver_host host : iProp Σ :=
   ∃ γrpc,
   "#H1" ∷ is_urpc_spec_pred γrpc host (W64 0) getFreshNum_spec ∗
   "#H2" ∷ is_urpc_spec_pred γrpc host (W64 1) tryAcquire_spec ∗
-  "#H3" ∷ is_urpc_spec_pred γrpc host (W64 2) release_spec ∗
+  "#H3" ∷ is_urpc_spec_pred γrpc host (W64 2) wp_Mutex__Unlock ∗
   "#Hdom" ∷ is_urpc_dom γrpc {[ W64 0; W64 1; W64 2 ]}
   .
 

--- a/src/program_proof/tutorial/queue/proof.v
+++ b/src/program_proof/tutorial/queue/proof.v
@@ -336,7 +336,7 @@ Proof.
   wp_pures.
   iNamed "Pre".
   wp_loadField.
-  wp_apply acquire_spec.
+  wp_apply wp_Mutex__Lock.
   { iFrame "HlockC". }
   iIntros "[H0 H1]".
   wp_pures.
@@ -358,7 +358,7 @@ Proof.
       { iIntros "H1".
         wp_pures.
         wp_loadField.
-        wp_apply (release_spec with "[HlockC H0 Hqueue Hfirst Hcount H1 Helem]").
+        wp_apply (wp_Mutex__Unlock with "[HlockC H0 Hqueue Hfirst Hcount H1 Helem]").
         { iFrame "∗#". iNext. iExists _, _, _. iFrame. eauto. }
         wp_pures.
         iModIntro.
@@ -366,7 +366,7 @@ Proof.
         done.
       } }
   - wp_loadField.
-    wp_apply (release_spec with "[HlockC H0 Hqueue Hfirst Hcount isSlice Helem]").
+    wp_apply (wp_Mutex__Unlock with "[HlockC H0 Hqueue Hfirst Hcount isSlice Helem]").
     { iFrame "∗#". iNext. iExists _,_,_. iFrame. eauto. }
     wp_pures.
     iModIntro.
@@ -382,7 +382,7 @@ Proof.
   wp_pures.
   iNamed "Pre".
   wp_loadField.
-  wp_apply acquire_spec.
+  wp_apply wp_Mutex__Lock.
   {iFrame "HlockC". }
   iIntros "[H0 H1]".
   iNamed "H1".
@@ -418,7 +418,7 @@ Proof.
     wp_loadField.
     wp_if_destruct.
     + wp_loadField.
-      wp_apply (wp_condWait with "[H2 Hfirst Hcount isSlice Helem]").
+      wp_apply (wp_Cond__Wait with "[H2 Hfirst Hcount isSlice Helem]").
       { iFrame "# H2". iExists first1, count1, queue1. iFrame. eauto. }
       iIntros "[H0 H2]".
       wp_pures.
@@ -467,7 +467,7 @@ Proof.
     wp_loadField.
     wp_storeField.
     wp_loadField.
-    wp_apply (release_spec with "[H2 Hqueue Hfirst Hcount H4 Helem HP]").
+    wp_apply (wp_Mutex__Unlock with "[H2 Hqueue Hfirst Hcount H4 Helem HP]").
     { iFrame "HlockC". 
       iFrame "H2". iNext. iExists _, (word.add count1 1).
       iExists (<[uint.nat
@@ -500,7 +500,7 @@ Proof.
           word. }
     wp_pures.
     wp_loadField.
-    wp_apply (wp_condBroadcast with "HrcondC").
+    wp_apply (wp_Cond__Broadcast with "HrcondC").
     wp_pures.
     iModIntro.
     iApply "Post".
@@ -515,7 +515,7 @@ Proof.
   wp_pures.
   iNamed "Pre".
   wp_loadField.
-  wp_apply acquire_spec.
+  wp_apply wp_Mutex__Lock.
   { iFrame "HlockC". }
   iIntros "[H0 H1]".
   wp_pures.
@@ -550,7 +550,7 @@ Proof.
     wp_if_destruct.
     + wp_pures.
       wp_loadField.
-      wp_apply (wp_condWait with "[H2 Hfirst Hcount isSlice Helem]").
+      wp_apply (wp_Cond__Wait with "[H2 Hfirst Hcount isSlice Helem]").
       { iFrame "# H2". iExists first1, (W64 0), queue1. iFrame. eauto. }
       iIntros "[H2 H4]".
       wp_pures.
@@ -597,7 +597,7 @@ Proof.
     wp_loadField.
     erewrite (remove_one queue1 first1 count1); eauto; try word.
     iDestruct "Helem" as "[Hp Helem]". 
-    wp_apply (release_spec with "[HlockC H2 Hqueue Hfirst Hcount H3 Helem]").
+    wp_apply (wp_Mutex__Unlock with "[HlockC H2 Hqueue Hfirst Hcount H3 Helem]").
     { iFrame "∗#". 
       iNext.
       iExists _, (word.sub count1 1).
@@ -612,7 +612,7 @@ Proof.
     }
     wp_pures.
     wp_loadField.
-    wp_apply (wp_condBroadcast with "HrcondC").
+    wp_apply (wp_Cond__Broadcast with "HrcondC").
     wp_pures.
     iModIntro.
     iApply "Post".

--- a/src/program_proof/vrsm/apps/vkv/clerkpool_proof.v
+++ b/src/program_proof/vrsm/apps/vkv/clerkpool_proof.v
@@ -35,7 +35,7 @@ Proof.
   wp_rec.
   wp_pures.
   wp_loadField.
-  wp_apply (acquire_spec with "[$]").
+  wp_apply (wp_Mutex__Lock with "[$]").
   iIntros "[Hlocked Hown]".
   iNamed "Hown".
   wp_pures.
@@ -70,7 +70,7 @@ Proof.
     iDestruct (own_slice_cap_skip _ _ 1 with "[$]") as "?".
     { word. }
     rewrite skipn_cons drop_0.
-    wp_apply (release_spec with "[-HΦ Hcl_own Hl]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ Hcl_own Hl]").
     { iFrame "∗#". iNext. repeat iExists _. iFrame "∗#". }
     wp_pures.
     wp_load.
@@ -82,7 +82,7 @@ Proof.
     wp_loadField.
     iClear "Hhost".
     clear.
-    wp_apply (acquire_spec with "[$]").
+    wp_apply (wp_Mutex__Lock with "[$]").
     iIntros "[Hlocked Hown]".
     iNamed "Hown".
     wp_pures.
@@ -92,14 +92,14 @@ Proof.
     iIntros (?) "Hsl".
     wp_storeField.
     wp_loadField.
-    wp_apply (release_spec with "[-HΦ Hl]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ Hl]").
     { iFrame "∗#". iNext. repeat iExists _. iFrame "∗#". done. }
     wp_pures.
     iApply "HΦ".
   }
   {
     wp_loadField.
-    wp_apply (release_spec with "[-HΦ Hl]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ Hl]").
     { iFrame "∗#". iNext. repeat iExists _. iFrame "∗#". }
     wp_pures.
     wp_loadField.
@@ -114,7 +114,7 @@ Proof.
     iIntros (?) "[Hck HΦ]".
     wp_pures.
     wp_loadField.
-    wp_apply (acquire_spec with "[$]").
+    wp_apply (wp_Mutex__Lock with "[$]").
     iIntros "[Hlocked Hown]".
     iNamed "Hown".
     wp_pures.
@@ -124,7 +124,7 @@ Proof.
     iIntros (?) "Hsl".
     wp_storeField.
     wp_loadField.
-    wp_apply (release_spec with "[-HΦ Hl]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ Hl]").
     { iFrame "∗#". iNext. repeat iExists _. iFrame "∗#". done. }
     wp_pures.
     iApply "HΦ".

--- a/src/program_proof/vrsm/configservice/config_proof.v
+++ b/src/program_proof/vrsm/configservice/config_proof.v
@@ -1338,14 +1338,14 @@ Proof.
 
   iNamed "Hck".
   wp_loadField.
-  wp_apply (acquire_spec with "[$]").
+  wp_apply (wp_Mutex__Lock with "[$]").
   iIntros "[Hlocked Hown]".
   iNamed "Hown".
   wp_pures.
   wp_loadField.
   wp_pures.
   wp_loadField.
-  wp_apply (release_spec with "[Hlocked Hleader]").
+  wp_apply (wp_Mutex__Unlock with "[Hlocked Hleader]").
   { iFrame "∗#". iNext. iExists _; iFrame "∗%". }
   wp_pures.
   wp_apply wp_NewSlice.
@@ -1441,7 +1441,7 @@ Proof.
       wp_if_destruct.
       { (* case: ErrNotLeader, so retry *)
         wp_loadField.
-        wp_apply (acquire_spec with "[$]").
+        wp_apply (wp_Mutex__Lock with "[$]").
         iIntros "[Hlocked Hown]".
         wp_pures.
         iNamed "Hown".
@@ -1454,7 +1454,7 @@ Proof.
           wp_pures.
           wp_storeField.
           wp_loadField.
-          wp_apply (release_spec with "[Hlocked Hleader]").
+          wp_apply (wp_Mutex__Unlock with "[Hlocked Hleader]").
           {
             iFrame "∗#".
             iNext. repeat iExists _; iFrame.
@@ -1474,7 +1474,7 @@ Proof.
         }
         { (* case: don't increase leader idx *)
           wp_loadField.
-          wp_apply (release_spec with "[Hlocked Hleader]").
+          wp_apply (wp_Mutex__Unlock with "[Hlocked Hleader]").
           {
             iFrame "∗#".
             iNext. repeat iExists _; iFrame "∗%".
@@ -1645,14 +1645,14 @@ Proof.
 
   iNamed "Hck".
   wp_loadField.
-  wp_apply (acquire_spec with "[$]").
+  wp_apply (wp_Mutex__Lock with "[$]").
   iIntros "[Hlocked Hown]".
   iNamed "Hown".
   wp_pures.
   wp_loadField.
   wp_pures.
   wp_loadField.
-  wp_apply (release_spec with "[Hlocked Hleader]").
+  wp_apply (wp_Mutex__Unlock with "[Hlocked Hleader]").
   { iFrame "∗#". iNext. iExists _; iFrame "∗%". }
   wp_pures.
   wp_load.
@@ -1729,7 +1729,7 @@ Proof.
       wp_if_destruct.
       { (* case: ErrNotLeader, so retry *)
         wp_loadField.
-        wp_apply (acquire_spec with "[$]").
+        wp_apply (wp_Mutex__Lock with "[$]").
         iIntros "[Hlocked Hown]".
         wp_pures.
         iNamed "Hown".
@@ -1742,7 +1742,7 @@ Proof.
           wp_pures.
           wp_storeField.
           wp_loadField.
-          wp_apply (release_spec with "[Hlocked Hleader]").
+          wp_apply (wp_Mutex__Unlock with "[Hlocked Hleader]").
           {
             iFrame "∗#".
             iNext. repeat iExists _; iFrame.
@@ -1761,7 +1761,7 @@ Proof.
         }
         { (* case: don't increase leader idx *)
           wp_loadField.
-          wp_apply (release_spec with "[Hlocked Hleader]").
+          wp_apply (wp_Mutex__Unlock with "[Hlocked Hleader]").
           {
             iFrame "∗#".
             iNext. repeat iExists _; iFrame "∗%".
@@ -1835,14 +1835,14 @@ Proof.
 
   iNamed "Hck".
   wp_loadField.
-  wp_apply (acquire_spec with "[$]").
+  wp_apply (wp_Mutex__Lock with "[$]").
   iIntros "[Hlocked Hown]".
   iNamed "Hown".
   wp_pures.
   wp_loadField.
   wp_pures.
   wp_loadField.
-  wp_apply (release_spec with "[Hlocked Hleader]").
+  wp_apply (wp_Mutex__Unlock with "[Hlocked Hleader]").
   { iFrame "∗#". iNext. iExists _; iFrame "∗%". }
   wp_pures.
   wp_load.
@@ -1910,7 +1910,7 @@ Proof.
       wp_if_destruct.
       { (* case: ErrNotLeader, so retry *)
         wp_loadField.
-        wp_apply (acquire_spec with "[$]").
+        wp_apply (wp_Mutex__Lock with "[$]").
         iIntros "[Hlocked Hown]".
         wp_pures.
         iNamed "Hown".
@@ -1923,7 +1923,7 @@ Proof.
           wp_pures.
           wp_storeField.
           wp_loadField.
-          wp_apply (release_spec with "[Hlocked Hleader]").
+          wp_apply (wp_Mutex__Unlock with "[Hlocked Hleader]").
           {
             iFrame "∗#".
             iNext. repeat iExists _; iFrame.
@@ -1942,7 +1942,7 @@ Proof.
         }
         { (* case: don't increase leader idx *)
           wp_loadField.
-          wp_apply (release_spec with "[Hlocked Hleader]").
+          wp_apply (wp_Mutex__Unlock with "[Hlocked Hleader]").
           {
             iFrame "∗#".
             iNext. repeat iExists _; iFrame "∗%".

--- a/src/program_proof/vrsm/paxos/becomeleader_proof.v
+++ b/src/program_proof/vrsm/paxos/becomeleader_proof.v
@@ -27,7 +27,7 @@ Proof.
   wp_rec. wp_pures.
   iNamed "Hsrv".
   wp_loadField.
-  wp_apply (acquire_spec with "HmuInv").
+  wp_apply (wp_Mutex__Lock with "HmuInv").
   iIntros "[Hlocked Hown]".
   iNamed "Hown".
 
@@ -38,7 +38,7 @@ Proof.
   wp_if_destruct.
   { (* already leader, no need to do anything *)
     wp_loadField.
-    wp_apply (release_spec with "[-HΦ HΨ]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ HΨ]").
     {
       do 2 iFrame "∗#%". by rewrite Heqb.
     }
@@ -54,7 +54,7 @@ Proof.
   iIntros (args_ptr) "Hargs".
   wp_pures.
   wp_loadField.
-  wp_apply (release_spec with "[-HΦ Hargs HΨ]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ Hargs HΨ]").
   {
     do 2 iFrame "∗#%". by rewrite Heqb.
   }
@@ -91,7 +91,7 @@ Proof.
                                                 True)
                                   ))
                 )%I).
-  wp_apply (newlock_spec N _ replyInv with "[HnumReplies Hreplies_sl]").
+  wp_apply (wp_newMutex N _ replyInv with "[HnumReplies Hreplies_sl]").
   {
     iNext.
     iExists _, _.
@@ -164,7 +164,7 @@ Proof.
       iIntros (reply_ptr reply) "Hreply".
       wp_pures.
 
-      wp_apply (acquire_spec with "HmuReplyInv").
+      wp_apply (wp_Mutex__Lock with "HmuReplyInv").
       iIntros "[Hlocked Hown]".
       iNamed "Hown".
       wp_pures.
@@ -186,12 +186,12 @@ Proof.
       wp_apply (wp_If_optional _ _ (True%I)).
       {
         iIntros (?) "_ HΦ'".
-        wp_apply (wp_condSignal with "HnumReplies_cond").
+        wp_apply (wp_Cond__Signal with "HnumReplies_cond").
         wp_pures.
         by iApply "HΦ'".
       }
       (* iMod (readonly_alloc_1 with "Hreply") as "Hreply". *)
-      wp_apply (release_spec with "[-]").
+      wp_apply (wp_Mutex__Unlock with "[-]").
       {
         iFrame "# Hlocked".
         iNext.
@@ -232,7 +232,7 @@ Proof.
   iIntros "_".
   wp_pures.
 
-  wp_apply (acquire_spec with "HmuReplyInv").
+  wp_apply (wp_Mutex__Lock with "HmuReplyInv").
   iIntros "[Hlocked Hown]".
   wp_pures.
 
@@ -243,7 +243,7 @@ Proof.
   wp_if_destruct.
   { (* continue waiting for there to be enough replies *)
     wp_pures.
-    wp_apply (wp_condWait with "[$HnumReplies_cond $HmuReplyInv $Hlocked Hreplies_sl Hreplies HnumReplies]").
+    wp_apply (wp_Cond__Wait with "[$HnumReplies_cond $HmuReplyInv $Hlocked Hreplies_sl Hreplies HnumReplies]").
     {
       iExists _, _.
       iFrame "∗#%".
@@ -1169,7 +1169,7 @@ Proof.
         word.
       }
       wp_pures.
-      wp_apply (release_spec with "[-HΦ HΨ]").
+      wp_apply (wp_Mutex__Unlock with "[-HΦ HΨ]").
       {
         iFrame "HmuReplyInv Hlocked".
         iNext.
@@ -1192,7 +1192,7 @@ Proof.
       iIntros "$ !#".
       Transparent own_paxosState_ghost.
       wp_pures.
-      wp_apply (release_spec with "[-HΦ HΨ]").
+      wp_apply (wp_Mutex__Unlock with "[-HΦ HΨ]").
       {
         iFrame "HmuReplyInv Hlocked".
         iNext.
@@ -1205,7 +1205,7 @@ Proof.
     }
   }
   { (* case: not enough replies *)
-    wp_apply (release_spec with "[-HΦ HΨ]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ HΨ]").
     {
       iFrame "HmuReplyInv Hlocked".
       iNext.

--- a/src/program_proof/vrsm/paxos/tryacquire_proof.v
+++ b/src/program_proof/vrsm/paxos/tryacquire_proof.v
@@ -79,7 +79,7 @@ Proof.
   wp_pures.
   iNamed "Hsrv".
   wp_loadField.
-  wp_apply (acquire_spec with "[$]").
+  wp_apply (wp_Mutex__Lock with "[$]").
   iIntros "[Hlocked Hown]".
   iNamed "Hown".
   iNamed "Hvol".
@@ -90,7 +90,7 @@ Proof.
   wp_if_destruct.
   { (* case: not leader *)
     wp_loadField.
-    wp_apply (release_spec with "[-HΦ Hlc1 Hlc2]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ Hlc1 Hlc2]").
     {
       do 2 iFrame "∗#%".
     }
@@ -163,7 +163,7 @@ Proof.
     iIntros (?) "[Hfile Hwp]".
     wp_pures.
     wp_loadField.
-    wp_apply (release_spec with "[-Hwp]").
+    wp_apply (wp_Mutex__Unlock with "[-Hwp]").
     { iFrame "HmuInv Hlocked". iNext. repeat iExists _.
       iFrame "∗#%". iPureIntro. by left.
     }
@@ -283,7 +283,7 @@ Proof.
                                                      True
                                          ))
                 )%I).
-  wp_apply (newlock_spec N _ replyInv with "[HnumReplies Hreplies_sl]").
+  wp_apply (wp_newMutex N _ replyInv with "[HnumReplies Hreplies_sl]").
   {
     iNext.
     iExists _, _.
@@ -338,7 +338,7 @@ Proof.
       iIntros (reply_ptr reply) "Hreply".
       wp_pures.
 
-      wp_apply (acquire_spec with "HreplyMuInv").
+      wp_apply (wp_Mutex__Lock with "HreplyMuInv").
       iIntros "[Hlocked Hown]".
       iNamed "Hown".
       wp_pures.
@@ -358,11 +358,11 @@ Proof.
       wp_apply (wp_If_optional _ _ (True%I)).
       {
         iIntros (?) "_ HΦ'".
-        wp_apply (wp_condSignal with "HnumReplies_cond").
+        wp_apply (wp_Cond__Signal with "HnumReplies_cond").
         wp_pures.
         by iApply "HΦ'".
       }
-      wp_apply (release_spec with "[-]").
+      wp_apply (wp_Mutex__Unlock with "[-]").
       {
         iFrame "# Hlocked".
         iNext.
@@ -395,7 +395,7 @@ Proof.
   iIntros "_".
   wp_pures.
 
-  wp_apply (acquire_spec with "[$HreplyMuInv]").
+  wp_apply (wp_Mutex__Lock with "[$HreplyMuInv]").
   iIntros "[Hlocked Hown]".
   wp_pures.
 
@@ -407,7 +407,7 @@ Proof.
   wp_if_destruct.
   { (* not enough replies, wait for cond *)
     wp_pures.
-    wp_apply (wp_condWait with "[-HΦ Herr]").
+    wp_apply (wp_Cond__Wait with "[-HΦ Herr]").
     {
       iFrame "∗#".
       iExists _, _.

--- a/src/program_proof/vrsm/paxos/weakread_proof.v
+++ b/src/program_proof/vrsm/paxos/weakread_proof.v
@@ -24,14 +24,14 @@ Proof.
   wp_rec. wp_pures.
   iNamed "Hsrv".
   wp_loadField.
-  wp_apply (acquire_spec with "[$]").
+  wp_apply (wp_Mutex__Lock with "[$]").
   iIntros "[Hlocked Hown]".
   iNamed "Hown".
   iNamed "Hvol".
   wp_loadField.
   wp_loadField.
   wp_loadField.
-  wp_apply (release_spec with "[-HΦ]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ]").
   {
     do 2 iFrame "∗#%".
   }

--- a/src/program_proof/vrsm/paxos/withlock_proof.v
+++ b/src/program_proof/vrsm/paxos/withlock_proof.v
@@ -47,7 +47,7 @@ Proof.
   wp_pures.
   iNamed "Hsrv".
   wp_loadField.
-  wp_apply (acquire_spec with "[$]").
+  wp_apply (wp_Mutex__Lock with "[$]").
   iIntros "[Hlocked Hown]".
   iNamed "Hown".
   wp_pures.
@@ -84,7 +84,7 @@ Proof.
   iIntros (?) "[Hfile Hwp]".
   wp_pures.
   wp_loadField.
-  wp_apply (release_spec with "[-Hwp]").
+  wp_apply (wp_Mutex__Unlock with "[-Hwp]").
   {
     iFrame "HmuInv Hlocked".
     iNext.

--- a/src/program_proof/vrsm/replica/apply_proof.v
+++ b/src/program_proof/vrsm/replica/apply_proof.v
@@ -401,7 +401,7 @@ Proof.
   wp_storeField.
 
   wp_loadField.
-  wp_apply (acquire_spec with "HmuInv").
+  wp_apply (wp_Mutex__Lock with "HmuInv").
   iIntros "[Hlocked Hown]".
   iNamed "Hown".
   iNamed "Hvol".
@@ -413,7 +413,7 @@ Proof.
   wp_if_destruct.
   { (* return error "not primary" *)
     wp_loadField.
-    wp_apply (release_spec with "[-HΦ Err Reply Hcred1 Hcred2 Hcred3]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ Err Reply Hcred1 Hcred2 Hcred3]").
     {
       iFrame "HmuInv Hlocked".
       iNext.
@@ -441,7 +441,7 @@ Proof.
   wp_if_destruct.
   { (* return ESealed *)
     wp_loadField.
-    wp_apply (release_spec with "[-HΦ Err Reply Hcred1 Hcred2 Hcred3]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ Err Reply Hcred1 Hcred2 Hcred3]").
     {
       iFrame "HmuInv Hlocked".
       iNext.
@@ -519,7 +519,7 @@ Proof.
   wp_pures.
   wp_loadField.
 
-  wp_apply (release_spec with "[-HΦ Hreply Err Reply Hcred1 Hcred2 Hcred3 HwaitSpec]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ Hreply Err Reply Hcred1 Hcred2 Hcred3 HwaitSpec]").
   {
     iFrame "HmuInv Hlocked".
     iNext.
@@ -878,7 +878,7 @@ Proof.
     wp_pures.
 
     wp_loadField.
-    wp_apply (acquire_spec with "[$]").
+    wp_apply (wp_Mutex__Lock with "[$]").
     iIntros "[Hlocked Hown]".
     iNamed "Hown".
     iClear "HopAppliedConds_conds HcommittedNextIndex_is_cond HisSm HisPrimary_is_cond".
@@ -889,7 +889,7 @@ Proof.
       wp_storeField.
       wp_loadField.
       iDestruct (become_backup with "HghostEph") as "HghostEph".
-      wp_apply (release_spec with "[-HΦ Hreply Err Reply Hcred1 Hcred2 Hcred3]").
+      wp_apply (wp_Mutex__Unlock with "[-HΦ Hreply Err Reply Hcred1 Hcred2 Hcred3]").
       { iFrame "∗#".
         repeat iExists _; iSplitR "HghostEph"; last iFrame.
         repeat iExists _; iFrame "∗#".
@@ -902,7 +902,7 @@ Proof.
       rewrite decide_False; last naive_solver. done.
     }
     wp_loadField.
-    wp_apply (release_spec with "[-HΦ Hreply Err Reply Hcred1 Hcred2 Hcred3]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ Hreply Err Reply Hcred1 Hcred2 Hcred3]").
     { iFrame "∗#".
       repeat iExists _; iSplitR "HghostEph"; last iFrame.
       repeat iExists _; iFrame "∗#".

--- a/src/program_proof/vrsm/replica/applybackup_proof.v
+++ b/src/program_proof/vrsm/replica/applybackup_proof.v
@@ -291,7 +291,7 @@ Proof.
   iNamed "HisSrv".
   wp_rec. wp_pures.
   wp_loadField.
-  wp_apply (acquire_spec with "HmuInv").
+  wp_apply (wp_Mutex__Lock with "HmuInv").
   iIntros "[Hlocked Hown]".
   wp_pures.
 
@@ -373,7 +373,7 @@ Proof.
       apply map_get_true in Hlookup.
       iDestruct (big_sepM_lookup_acc with "HopAppliedConds_conds") as "[His_cond _]".
       { done. }
-      wp_apply (wp_condWait with "[-HΦ HΨ Hargs_op Hargs_op_sl Hargs_index Hargs_epoch]").
+      wp_apply (wp_Cond__Wait with "[-HΦ HΨ Hargs_op Hargs_op_sl Hargs_index Hargs_epoch]").
       {
         iFrame "His_cond".
         iFrame "HmuInv Hlocked".
@@ -403,7 +403,7 @@ Proof.
   wp_if_destruct.
   { (* return error: sealed *)
     wp_loadField.
-    wp_apply (release_spec with "[-HΦ HΨ]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ HΨ]").
     {
       iFrame "HmuInv Hlocked".
       iNext.
@@ -427,7 +427,7 @@ Proof.
   wp_if_destruct.
   { (* return error: stale *)
     wp_loadField.
-    wp_apply (release_spec with "[-HΦ HΨ]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ HΨ]").
     {
       iFrame "Hlocked HmuInv".
       iNext.
@@ -453,7 +453,7 @@ Proof.
   { (* return error: out-of-order; TODO: we never actually need to return this
        error, if something is out of order that means we already applied it *)
     wp_loadField.
-    wp_apply (release_spec with "[-HΦ HΨ]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ HΨ]").
     {
       iFrame "Hlocked HmuInv".
       iNext.
@@ -539,7 +539,7 @@ Proof.
     apply map_get_true in Hlookup.
     iDestruct (big_sepM_lookup_acc with "HopAppliedConds_conds") as "[Hiscond _]".
     { done. }
-    wp_apply (wp_condSignal with "Hiscond").
+    wp_apply (wp_Cond__Signal with "Hiscond").
     wp_pures.
     wp_loadField.
     wp_loadField.
@@ -556,7 +556,7 @@ Proof.
   wp_pures.
 
   wp_loadField.
-  wp_apply (release_spec with "[-HΨ HΦ HwaitSpec Hargs_epoch]").
+  wp_apply (wp_Mutex__Unlock with "[-HΨ HΦ HwaitSpec Hargs_epoch]").
   {
     iFrame "Hlocked HmuInv".
     iNext.

--- a/src/program_proof/vrsm/replica/becomeprimary_proof.v
+++ b/src/program_proof/vrsm/replica/becomeprimary_proof.v
@@ -140,7 +140,7 @@ Proof.
   iNamed "His_srv".
   wp_rec. wp_pures.
   wp_loadField.
-  wp_apply (acquire_spec with "[$HmuInv]").
+  wp_apply (wp_Mutex__Lock with "[$HmuInv]").
   iIntros "[Hlocked Hown]".
   wp_pures.
   iNamed "Hown".
@@ -168,7 +168,7 @@ Proof.
   { (* stale epoch or unable to become primary *)
     wp_loadField.
     unfold BecomePrimary_core_spec.
-    wp_apply (release_spec with "[-HΦ HΨ]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ HΨ]").
     {
       iFrame "HmuInv Hlocked".
       iNext.
@@ -189,7 +189,7 @@ Proof.
     (* Double for loop to make slice of slices of clerks *)
     replace (#32) with (#numClerks); last done.
     wp_loadField.
-    wp_apply (wp_condSignal with "[$]").
+    wp_apply (wp_Cond__Signal with "[$]").
     wp_storeField.
     wp_apply (wp_NewSlice).
     iIntros (new_clerkss_sl) "Hnew_clerkss_sl".
@@ -540,7 +540,7 @@ Proof.
     iModIntro.
 
     wp_loadField.
-    wp_apply (release_spec with "[-HΦ HΨ Hargs_epoch]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ HΨ Hargs_epoch]").
     {
       iFrame "HmuInv Hlocked".
       iNext.

--- a/src/program_proof/vrsm/replica/getstate_proof.v
+++ b/src/program_proof/vrsm/replica/getstate_proof.v
@@ -204,7 +204,7 @@ Proof.
   wp_rec. wp_pures.
   iNamed "His_srv".
   wp_loadField.
-  wp_apply (acquire_spec with "HmuInv").
+  wp_apply (wp_Mutex__Lock with "HmuInv").
   iIntros "[Hlocked Hown]".
   iNamed "Hown".
   wp_pures.
@@ -215,7 +215,7 @@ Proof.
   wp_if_destruct.
   { (* reply with error *)
     wp_loadField.
-    wp_apply (release_spec with "[-HΦ HΨ]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ HΨ]").
     {
       iFrame "HmuInv Hlocked".
       iNext.
@@ -289,7 +289,7 @@ Proof.
     iIntros.
     iIntros (?) "!# [_ #Hpre] HΦ".
     wp_pures.
-    wp_apply (wp_condSignal with "Hpre").
+    wp_apply (wp_Cond__Signal with "Hpre").
     iApply "HΦ".
     iFrame "#".
     instantiate (1:=(λ _ _, True)%I).
@@ -302,10 +302,10 @@ Proof.
   iIntros (opAppliedConds_loc_new) "Hmapnew".
   wp_storeField.
   wp_loadField.
-  wp_apply (wp_condBroadcast with "[]").
+  wp_apply (wp_Cond__Broadcast with "[]").
   { done. }
   wp_loadField.
-  wp_apply (release_spec with "[-Hsnap_sl HΨ HΦ]").
+  wp_apply (wp_Mutex__Unlock with "[-Hsnap_sl HΨ HΦ]").
   {
     iFrame "HmuInv Hlocked".
     iNext.

--- a/src/program_proof/vrsm/replica/increasecommit_proof.v
+++ b/src/program_proof/vrsm/replica/increasecommit_proof.v
@@ -144,7 +144,7 @@ Proof.
   wp_rec. wp_pures.
   iNamed "His_srv".
   wp_loadField.
-  wp_apply (acquire_spec with "HmuInv").
+  wp_apply (wp_Mutex__Lock with "HmuInv").
   iIntros "[Hlocked Hown]".
   iNamed "Hown".
   wp_pure_credit "Hlc".
@@ -172,10 +172,10 @@ Proof.
     { unfold no_overflow. word. }
     wp_storeField.
     wp_loadField.
-    wp_apply (wp_condBroadcast with "[]").
+    wp_apply (wp_Cond__Broadcast with "[]").
     { iFrame "#". }
     wp_loadField.
-    wp_apply (release_spec with "[-HΦ HΨ]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ HΨ]").
     {
       iFrame "HmuInv Hlocked".
       iNext.
@@ -194,7 +194,7 @@ Proof.
   }
   {
     wp_loadField.
-    wp_apply (release_spec with "[-HΦ HΨ]").
+    wp_apply (wp_Mutex__Unlock with "[-HΦ HΨ]").
     {
       iFrame "HmuInv Hlocked".
       iNext. repeat (iExists _).

--- a/src/program_proof/vrsm/replica/leaserenewal_proof.v
+++ b/src/program_proof/vrsm/replica/leaserenewal_proof.v
@@ -78,7 +78,7 @@ Proof.
     iNamed 1.
     wp_pures.
     wp_loadField.
-    wp_apply (acquire_spec with "[$]").
+    wp_apply (wp_Mutex__Lock with "[$]").
     iIntros "[Hlocked Hown]".
     iNamed "Hown".
     iNamed "Hvol".
@@ -96,7 +96,7 @@ Proof.
       injection Heqb as Heqb.
       subst.
       iDestruct (lease_renewal_step with "[$] [$] [$] HghostEph") as "HghostEph".
-      wp_apply (release_spec with "[- HlatestEpoch]").
+      wp_apply (wp_Mutex__Unlock with "[- HlatestEpoch]").
       {
         iFrame "# Hlocked".
         iNext.
@@ -118,7 +118,7 @@ Proof.
       wp_loadField.
       wp_store.
       wp_loadField.
-      wp_apply (release_spec with "[- HlatestEpoch]").
+      wp_apply (wp_Mutex__Unlock with "[- HlatestEpoch]").
       {
         iFrame "# Hlocked".
         iNext. repeat iExists _. iFrame "HghostEph".
@@ -129,7 +129,7 @@ Proof.
     }
     (* no new epoch. Sleep a bit and try again later. *)
     wp_loadField.
-    wp_apply (release_spec with "[- HlatestEpoch]").
+    wp_apply (wp_Mutex__Unlock with "[- HlatestEpoch]").
     {
       iFrame "# Hlocked".
       iNext. repeat iExists _. iFrame "HghostEph".
@@ -145,7 +145,7 @@ Proof.
     iIntros (??). iNamed 1.
     wp_pures.
     wp_loadField.
-    wp_apply (acquire_spec with "[$]").
+    wp_apply (wp_Mutex__Lock with "[$]").
     iIntros "[Hlocked Hown]".
     iNamed "Hown".
     iNamed "Hvol".
@@ -164,7 +164,7 @@ Proof.
       wp_loadField.
       wp_store.
       wp_loadField.
-      wp_apply (release_spec with "[- HlatestEpoch]").
+      wp_apply (wp_Mutex__Unlock with "[- HlatestEpoch]").
       {
         iFrame "# Hlocked".
         iNext. repeat iExists _. iFrame "HghostEph".
@@ -175,7 +175,7 @@ Proof.
     }
     (* no new epoch. Sleep a bit and try again later. *)
     wp_loadField.
-    wp_apply (release_spec with "[- HlatestEpoch]").
+    wp_apply (wp_Mutex__Unlock with "[- HlatestEpoch]").
     {
       iFrame "# Hlocked".
       iNext. repeat iExists _. iFrame "HghostEph".

--- a/src/program_proof/vrsm/replica/roapply_proof.v
+++ b/src/program_proof/vrsm/replica/roapply_proof.v
@@ -423,7 +423,7 @@ Proof.
   wp_storeField.
 
   wp_loadField.
-  wp_apply (acquire_spec with "HmuInv").
+  wp_apply (wp_Mutex__Lock with "HmuInv").
   iIntros "[Hlocked Hown]".
   iNamed "Hown".
   iNamed "Hvol".
@@ -432,7 +432,7 @@ Proof.
   wp_if_destruct.
   { (* lease invalid *)
     wp_loadField.
-    wp_apply (release_spec with "[-Hlc1 Hlc2 Hlc3 Hupd Err Reply]").
+    wp_apply (wp_Mutex__Unlock with "[-Hlc1 Hlc2 Hlc3 Hupd Err Reply]").
     {
       iFrame "HmuInv Hlocked".
       iNext.
@@ -536,7 +536,7 @@ Proof.
       iModIntro. iSplitR; first done.
       wp_pures.
       wp_loadField.
-      wp_apply (release_spec with "[-Err Reply Hrep_sl]").
+      wp_apply (wp_Mutex__Unlock with "[-Err Reply Hrep_sl]").
       {
         iFrame "HmuInv Hlocked".
         iNext.
@@ -577,7 +577,7 @@ Proof.
       iModIntro. iSplitR; first done.
       wp_pures.
       wp_loadField.
-      wp_apply (release_spec with "[-HΨ Err Reply Hrep_sl]").
+      wp_apply (wp_Mutex__Unlock with "[-HΨ Err Reply Hrep_sl]").
       {
         iFrame "HmuInv Hlocked".
         iNext.
@@ -613,7 +613,7 @@ Proof.
     wp_loadField.
     iClear "HopAppliedConds_conds HcommittedNextIndex_is_cond".
     iNamed "Hvol".
-    wp_apply (wp_condWait with "[-Err Reply Hrep_sl HlastModified]").
+    wp_apply (wp_Cond__Wait with "[-Err Reply Hrep_sl HlastModified]").
     {
       iFrame "#".
       iFrame "Hlocked".
@@ -635,7 +635,7 @@ Proof.
     wp_if_destruct.
     2:{ exfalso. word. }
     wp_loadField.
-    wp_apply (release_spec with "[-Err Reply HlastModified Hrep_sl]").
+    wp_apply (wp_Mutex__Unlock with "[-Err Reply HlastModified Hrep_sl]").
     {
       iFrame "HmuInv Hlocked".
       iNext.

--- a/src/program_proof/vrsm/replica/sendcommitthread_proof.v
+++ b/src/program_proof/vrsm/replica/sendcommitthread_proof.v
@@ -50,7 +50,7 @@ Proof.
   wp_pures.
 
   wp_loadField.
-  wp_apply (acquire_spec with "[$]").
+  wp_apply (wp_Mutex__Lock with "[$]").
   iIntros "[Hlocked Hown]".
   wp_pures.
   wp_forBreak_cond.
@@ -62,7 +62,7 @@ Proof.
   { rewrite HnotPrim.
     wp_pures.
     wp_loadField.
-    wp_apply (wp_condWait with "[- HΦ]").
+    wp_apply (wp_Cond__Wait with "[- HΦ]").
     {
       iFrame "# Hlocked".
       repeat iExists _; iSplitR "HghostEph"; last iFrame.
@@ -98,7 +98,7 @@ Proof.
   { (* not the primary/no clerks; wait and try again later *)
     wp_pures.
     wp_loadField.
-    wp_apply (wp_condWait with "[- HΦ]").
+    wp_apply (wp_Cond__Wait with "[- HΦ]").
     {
       iFrame "# Hlocked".
       iFrame "∗#%".
@@ -119,7 +119,7 @@ Proof.
   iDestruct (get_commitIndex_facts with "HghostEph") as "#Hpre".
   wp_pures.
   wp_loadField.
-  wp_apply (release_spec with "[-HΦ]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ]").
   {
     iFrame "HmuInv Hlocked".
     iFrame "∗#%".

--- a/src/program_proof/vrsm/replica/setstate_proof.v
+++ b/src/program_proof/vrsm/replica/setstate_proof.v
@@ -240,7 +240,7 @@ Proof.
   iNamed "His_srv".
   wp_rec. wp_pures.
   wp_loadField.
-  wp_apply (acquire_spec with "[$HmuInv]").
+  wp_apply (wp_Mutex__Lock with "[$HmuInv]").
   iIntros "[Hlocked Hown]".
   wp_pures.
   iNamed "Hown".
@@ -254,7 +254,7 @@ Proof.
     unfold SetState_core_spec.
     iDestruct "HΨ" as (?) "(_ & _ & _ & _ & _ & _ & HΨ)".
     iRight in "HΨ".
-    wp_apply (release_spec with "[-HΨ HΦ]").
+    wp_apply (wp_Mutex__Unlock with "[-HΨ HΦ]").
     {
       iFrame "HmuInv Hlocked".
       iNext.
@@ -278,7 +278,7 @@ Proof.
       iDestruct (get_epoch_eph with "HghostEph") as "#Heph_lb".
       iDestruct "HΨ" as (?) "(_ & _ & _ & _ & _ & _ & _ & _ & HΨ)".
       iLeft in "HΨ".
-      wp_apply (release_spec with "[-HΨ HΦ]").
+      wp_apply (wp_Mutex__Unlock with "[-HΨ HΦ]").
       {
         iFrame "HmuInv Hlocked".
         iNext.
@@ -341,7 +341,7 @@ Proof.
       iIntros.
       iIntros (?) "!# [_ #Hpre] HΦ".
       wp_pures.
-      wp_apply (wp_condSignal with "Hpre").
+      wp_apply (wp_Cond__Signal with "Hpre").
       iApply "HΦ".
       iFrame "#".
       instantiate (1:=(λ _ _, True)%I).
@@ -349,14 +349,14 @@ Proof.
     }
     iIntros "(HopAppliedConds_map & _ & _)".
     wp_loadField.
-    wp_apply (wp_condBroadcast with "[]").
+    wp_apply (wp_Cond__Broadcast with "[]").
     { done. }
     wp_apply (wp_NewMap).
     iIntros (opAppliedConds_loc_new) "Hmapnew".
     wp_storeField.
 
     wp_loadField.
-    wp_apply (release_spec with "[-HΨ HΦ Hargs_committed_next_index]").
+    wp_apply (wp_Mutex__Unlock with "[-HΨ HΦ Hargs_committed_next_index]").
     {
       iFrame "HmuInv Hlocked".
       iNext.

--- a/src/program_proof/wal/flush_proof.v
+++ b/src/program_proof/wal/flush_proof.v
@@ -384,9 +384,9 @@ Proof.
 
   wp_apply util_proof.wp_DPrintf.
   wp_loadField.
-  wp_apply (acquire_spec with "lk"). iIntros "(Hlocked&Hlkinv)".
+  wp_apply (wp_Mutex__Lock with "lk"). iIntros "(Hlocked&Hlkinv)".
   wp_loadField.
-  wp_apply (wp_condBroadcast with "cond_logger").
+  wp_apply (wp_Cond__Broadcast with "cond_logger").
   wp_loadField.
 
   wp_apply (wp_load_some_nextDiskEnd with "Hlkinv"); iIntros (x) "Hlkinv".
@@ -418,7 +418,7 @@ Proof.
     wp_pures.
     wp_if_destruct.
     - wp_loadField.
-      wp_apply (wp_condWait with "[-HΦ $cond_logger $lk $Hlocked]").
+      wp_apply (wp_Cond__Wait with "[-HΦ $cond_logger $lk $Hlocked]").
       { by iFrame "∗ #". }
       iIntros "(Hlocked&Hlockin)".
       wp_pures.
@@ -459,7 +459,7 @@ Proof.
   { iNext. iExists _. iFrame. }
 
   wp_loadField.
-  wp_apply (release_spec with "[-HQ HΦ]").
+  wp_apply (wp_Mutex__Unlock with "[-HQ HΦ]").
   { iFrame "lk". iFrame "Hlocked". iNext. iExists _.
     iFrame "Hfields HdiskEnd_circ Hstart_circ".
     iExists _, _, _, _, _, _, _.

--- a/src/program_proof/wal/installer_proof.v
+++ b/src/program_proof/wal/installer_proof.v
@@ -923,7 +923,7 @@ Proof.
 
   iModIntro.
   wp_loadField.
-  wp_apply (release_spec with "[$lk $His_locked Hlinv
+  wp_apply (wp_Mutex__Unlock with "[$lk $His_locked Hlinv
     HdiskEnd_exactly Hstart_exactly
     His_memLog HmemLog HdiskEnd Hshutdown Hnthread]").
   {
@@ -1181,7 +1181,7 @@ Proof.
   iNamed "Hpost".
 
   wp_loadField.
-  wp_apply (acquire_spec with "lk").
+  wp_apply (wp_Mutex__Lock with "lk").
   iIntros "(His_locked&Hlkinv)".
 
   iDestruct "Hlkinv" as (σ') "Hlkinv".
@@ -1220,7 +1220,7 @@ Proof.
   1: lia.
   iIntros "His_memLog".
   wp_loadField.
-  wp_apply (wp_condBroadcast with "cond_install").
+  wp_apply (wp_Cond__Broadcast with "cond_install").
   wp_pures.
 
   iApply "HΦ".
@@ -1340,7 +1340,7 @@ Proof.
   iNamed "Hmem".
   iNamed "Hstfields".
   wp_loadField.
-  wp_apply (acquire_spec with "lk").
+  wp_apply (wp_Mutex__Lock with "lk").
   iIntros "[Hlocked Hlockinv]".
   wp_apply (wp_inc_nthread with "[$Hlockinv $st]"); iIntros "Hlockinv".
   wp_pures.
@@ -1365,7 +1365,7 @@ Proof.
       { wp_apply util_proof.wp_DPrintf; wp_pures.
         iApply ("HΦ" with "[$]"). }
       wp_loadField.
-      wp_apply (wp_condWait with "[$cond_install $lk $His_locked $Hlkinv]").
+      wp_apply (wp_Cond__Wait with "[$cond_install $lk $His_locked $Hlkinv]").
       iIntros "[His_locked Hlkinv]".
       wp_pures.
       iApply ("HΦ" with "[$]").
@@ -1374,9 +1374,9 @@ Proof.
   wp_apply util_proof.wp_DPrintf.
   wp_apply (wp_dec_nthread with "[$Hlockinv $st]"); iIntros "Hlockinv".
   wp_loadField.
-  wp_apply (wp_condSignal with "[$cond_shut]").
+  wp_apply (wp_Cond__Signal with "[$cond_shut]").
   wp_loadField.
-  wp_apply (release_spec with "[$lk $Hlocked $Hlockinv]").
+  wp_apply (wp_Mutex__Unlock with "[$lk $Hlocked $Hlockinv]").
   wp_pures. by iApply ("HΦ" with "[$]").
 Qed.
 

--- a/src/program_proof/wal/logger_proof.v
+++ b/src/program_proof/wal/logger_proof.v
@@ -66,7 +66,7 @@ Proof.
     change (uint.Z (word.divu (word.sub 4096 8) 8)) with LogSz.
     wp_if_destruct.
     - wp_loadField.
-      wp_apply (wp_condWait with "[-HΦ]"); [ iFrame "His_cond2 His_lock Hlocked" | ].
+      wp_apply (wp_Cond__Wait with "[-HΦ]"); [ iFrame "His_cond2 His_lock Hlocked" | ].
       { by iFrame "∗ #". }
       iIntros "(Hlocked&Hlkinv)".
       wp_pures.
@@ -348,7 +348,7 @@ Proof.
   (* use this to also strip a later, which the [wp_loadField] tactic does not do *)
   wp_apply (wp_loadField_ro with "HmemLock").
   iDestruct "Htxns_are" as "#Htxns_are".
-  wp_apply (release_spec with "[
+  wp_apply (wp_Mutex__Unlock with "[
     -HΦ HareLogging HdiskEnd_is Happender Hbufs $His_lock $Hlocked
     HownLoggerPos_logger HownLoggerTxn_logger
     HownDiskEndMem_logger HownDiskEndMemTxn_logger
@@ -547,7 +547,7 @@ Proof.
   rewrite -> subslice_length by word.
   iIntros "(Hpost&Hupds&Hcirc_appender&HdiskEnd_is)"; iNamed "Hpost".
   wp_loadField.
-  wp_apply (acquire_spec with "His_lock").
+  wp_apply (wp_Mutex__Lock with "His_lock").
   iIntros "(His_locked&Hlockinv)".
   iNamed "Hlockinv".
   iNamed "Hfields".
@@ -714,9 +714,9 @@ Proof.
   wp_apply wp_slice_len.
   wp_loadField. wp_storeField.
   wp_loadField.
-  wp_apply (wp_condBroadcast with "His_cond1").
+  wp_apply (wp_Cond__Broadcast with "His_cond1").
   wp_loadField.
-  wp_apply (wp_condBroadcast with "His_cond2").
+  wp_apply (wp_Cond__Broadcast with "His_cond2").
   wp_pures.
   iApply "HΦ".
   iFrame "His_locked".
@@ -797,7 +797,7 @@ Proof.
   iNamed "Hmem".
   iNamed "Hstfields".
   wp_loadField.
-  wp_apply (acquire_spec with "[$]").
+  wp_apply (wp_Mutex__Lock with "[$]").
   iIntros "(Hlk_held&Hlkinv)".
   wp_pures.
 
@@ -817,7 +817,7 @@ Proof.
       wp_pures.
       wp_if_destruct.
       + wp_loadField.
-        wp_apply (wp_condWait with "[$cond_logger $lk $Hlkinv $Hlk_held]").
+        wp_apply (wp_Cond__Wait with "[$cond_logger $lk $Hlkinv $Hlk_held]").
         iIntros "(Hlk_held&Hlkinv)".
         wp_pures.
         iApply ("HΦ" with "[$]").
@@ -828,9 +828,9 @@ Proof.
   wp_apply util_proof.wp_DPrintf.
   wp_apply (wp_dec_nthread with "[$st $Hlkinv]"); iIntros "Hlkinv".
   wp_loadField.
-  wp_apply (wp_condSignal with "cond_shut").
+  wp_apply (wp_Cond__Signal with "cond_shut").
   wp_loadField.
-  wp_apply (release_spec with "[$lk $Hlk_held $Hlkinv]").
+  wp_apply (wp_Mutex__Unlock with "[$lk $Hlk_held $Hlkinv]").
   wp_pures. by iApply ("HΦ" with "[//]").
 Qed.
 

--- a/src/program_proof/wal/read_proof.v
+++ b/src/program_proof/wal/read_proof.v
@@ -389,7 +389,7 @@ Proof.
   iIntros (Φ) "[#Hwal Hfupd] HΦ".
   destruct_is_wal.
   wp_loadField.
-  wp_apply (acquire_spec with "lk"). iIntros "(Hlocked&Hlkinv)".
+  wp_apply (wp_Mutex__Lock with "lk"). iIntros "(Hlocked&Hlkinv)".
   wp_loadField.
   iNamed "Hlkinv".
   wp_apply (wp_WalogState__readMem with "[$Hfields $HmemLog_linv]").
@@ -413,7 +413,7 @@ Proof.
     iSplitL "Hinner HP".
     { iExists _. iFrame. }
     wp_loadField.
-    wp_apply (release_spec with "[$lk $Hlocked HmemLog_linv Hfields HdiskEnd_circ Hstart_circ]").
+    wp_apply (wp_Mutex__Unlock with "[$lk $Hlocked HmemLog_linv Hfields HdiskEnd_circ Hstart_circ]").
     { iExists _; iFrame. }
     wp_pures.
     iApply "HΦ".
@@ -426,7 +426,7 @@ Proof.
     iModIntro.
     iFrame "Hinv".
     wp_loadField.
-    wp_apply (release_spec with "[$lk $Hlocked HmemLog_linv Hfields HdiskEnd_circ Hstart_circ]").
+    wp_apply (wp_Mutex__Unlock with "[$lk $Hlocked HmemLog_linv Hfields HdiskEnd_circ Hstart_circ]").
     { iExists _; iFrame. }
     wp_pures.
     iApply "HΦ".

--- a/src/program_proof/wal/write_proof.v
+++ b/src/program_proof/wal/write_proof.v
@@ -722,7 +722,7 @@ Proof.
     iNamed "Hmem".
     iNamed "Hstfields".
     wp_loadField.
-    wp_apply (acquire_spec with "lk"); iIntros "(Hlocked&Hlockinv)".
+    wp_apply (wp_Mutex__Lock with "lk"); iIntros "(Hlocked&Hlockinv)".
     wp_loadField.
     wp_pures.
     wp_bind (For _ _ _).
@@ -902,16 +902,16 @@ Proof.
         wp_apply (wp_endGroupTxn with "Hlockinv").
         iIntros "Hlockinv".
         wp_loadField.
-        wp_apply (wp_condBroadcast with "[$cond_logger]").
+        wp_apply (wp_Cond__Broadcast with "[$cond_logger]").
         wp_loadField.
-        wp_apply (wp_condWait with "[$cond_logger $Hlocked $lk $Hlockinv]").
+        wp_apply (wp_Cond__Wait with "[$cond_logger $Hlocked $lk $Hlockinv]").
         iIntros "(Hlocked&Hlockinv)".
         wp_pures.
         iApply "HΦ".
         iExists _, _; by iFrame. }
     iNamed 1.
     wp_loadField.
-    wp_apply (release_spec with "[$lk $Hlocked $Hlockinv]").
+    wp_apply (wp_Mutex__Unlock with "[$lk $Hlocked $Hlockinv]").
     wp_pures.
     wp_load. wp_load.
     wp_pures.

--- a/src/program_proof/wp_auto/experiments.v
+++ b/src/program_proof/wp_auto/experiments.v
@@ -128,7 +128,7 @@ Proof.
   wp_rec. wp_pures.
   wp_loadField.
 
-  wp_apply (acquire_spec with "[$]").
+  wp_apply (wp_Mutex__Lock with "[$]").
   iIntros "[Hlocked Ht]".
   iNamed "Ht".
   wp_apply (wp_lookupLocked with "[$]").
@@ -137,7 +137,7 @@ Proof.
   wp_pures.
   wp_loadField.
 
-  iDestruct release_spec as "-#HH".
+  iDestruct wp_Mutex__Unlock as "-#HH".
   notypeclasses refine (coq_tactics.tac_specialize_frame _ "HH" _ false _ _ _ _ _ _ _ _ _ _ _).
   { done. }
   { tc_solve. }
@@ -156,7 +156,7 @@ Proof.
   wp_pures.
 
   (*
-  wp_apply (release_spec with "[Hlocked Ht_state]").
+  wp_apply (wp_Mutex__Unlock with "[Hlocked Ht_state]").
   { iFrame "Ht_lock". iFrame "Hlocked".
     iExists _. iFrame. } *)
   wp_pures.


### PR DESCRIPTION
Previously, the names acquire/release and acquire_spec/release_spec came from HeapLang, and mutexes were the only place this convention was used.

For consistency with how we typically name functions and specs (and to match Go), this commit renames to `Mutex__Lock` and `wp_Mutex__Lock`, and similarly for Unlock. At the same time we make the Cond methods more consistent with this convention, although its specs already used the `wp_` naming style.