### PR TITLE
Add various specs for slice skip/take

### DIFF
--- a/src/goose_lang/lib/slice/slice.v
+++ b/src/goose_lang/lib/slice/slice.v
@@ -739,6 +739,40 @@ Proof.
   word.
 Qed.
 
+Lemma own_slice_cap_take s t n vs :
+  uint.Z n ≤ uint.Z s.(Slice.sz) →
+  own_slice_small (slice_skip s t n) t (DfracOwn 1) (drop (uint.nat n) vs) ∗
+    own_slice_cap s t -∗
+  own_slice_cap (slice_take s n) t.
+Proof.
+  iIntros (Hn) "[Hskip Hcap]".
+  iDestruct (own_slice_cap_wf with "Hcap") as %Hwf.
+  rewrite /own_slice_cap /own_slice_small.
+  iDestruct "Hskip" as "[Hskip [%Hvs_len %Hskip_wf]]".
+  simpl in Hvs_len, Hskip_wf.
+  rewrite -> !word.unsigned_sub_nowrap in * by word.
+  rewrite length_drop in Hvs_len.
+  iDestruct "Hcap" as (extra Hextra_len) "Hcap".
+  iExists (drop (uint.nat n) vs ++ extra).
+  iSplit.
+  { iPureIntro.
+    simpl.
+    rewrite length_app length_drop.
+    word. }
+  simpl.
+  rewrite array_app.
+  iFrame "Hskip".
+
+  iExactEq "Hcap".
+  rewrite length_drop.
+  rewrite loc_add_assoc.
+  f_equal.
+  f_equal.
+  rewrite -Z.mul_add_distr_l.
+  f_equal.
+  word.
+Qed.
+
 (** We have full ownership, and take into the capacity.
 Cannot be typed, since [extra] might not be valid at this type. *)
 Lemma wp_SliceTake_full_cap {stk E s} t vs (n: u64):

--- a/src/program_proof/std_proof.v
+++ b/src/program_proof/std_proof.v
@@ -190,6 +190,24 @@ Proof.
   word.
 Qed.
 
+Lemma wp_SliceSplit_full s dq (xs: list w8) (n: w64) :
+  {{{ own_slice s byteT dq xs ∗ ⌜uint.Z n < Z.of_nat (length xs)⌝ }}}
+    SliceSplit (to_val s) #n
+  {{{ RET (to_val (slice_take s n), to_val (slice_skip s byteT n));
+      own_slice_small (slice_take s n) byteT dq (take (uint.nat n) xs) ∗
+      own_slice (slice_skip s byteT n) byteT dq (drop (uint.nat n) xs)
+  }}}.
+Proof.
+  iIntros (Φ) "[Hs %Hn] HΦ".
+  iDestruct (own_slice_sz with "Hs") as %Hsz.
+  iDestruct (own_slice_split_1 with "Hs") as "[Hs Hcap]".
+  wp_apply (wp_SliceSplit with "[$Hs]"); [ done | ].
+  iIntros "[Htake Hskip]".
+  iApply "HΦ". iFrame "Htake".
+  iApply own_slice_split; iFrame "Hskip".
+  iApply (own_slice_cap_skip with "Hcap"). word.
+Qed.
+
 Lemma wp_SumNoOverflow (x y : u64) stk E :
   ∀ Φ : val → iProp Σ,
     Φ #(bool_decide (uint.Z (word.add x y) = (uint.Z x + uint.Z y)%Z)) -∗


### PR DESCRIPTION
We had several low-level specs, especially in the untyped library, but the typed library was missing many things that seem obvious in retrospect.

There are six variants based on how ownership is divided, and it makes sense to provide all of these specs since they are not obvious consequences of more general specs:

1. SliceTake with `own_slice_small`. Straightforward.
2. SliceSkip with `own_slice_small`. Straightforward.
3. SliceTake with `own_slice`. Consumes the remainder of the slice to become the capacity of the prefix. This is the most distant from the code; it is not obvious that the original slice should no longer be used, even for reads.
4. SliceSkip with `own_slice`. The capacity is retained as-is.
5. std.SliceSplit with `own_slice_small`. This is a function in the Goose standard library that makes it easy to specify that doing `s[:n]` and `s[n:]` at the same time splits ownership, in a straightforward way. It is possible but more awkward to do this by directly writing `s[:n]` and `s[n:]` in the code.
6. std.SliceSplit with `own_slice`. Similar to the `own_slice_small` spec, because the capacity of the original slice is identical to the capacity of the skipped part. Splitting in this case allows using the original capacity as the capacity of the `s[n:]` end, while not allowing appending to the `s[:n]` end since this capacity aliases the `s[n:]`.