### PR TITLE
Adapt to https://github.com/coq/coq/pull/19530

### DIFF
--- a/src/Helpers/LittleEndian.v
+++ b/src/Helpers/LittleEndian.v
@@ -2,7 +2,7 @@
 
 https://github.com/mit-plv/coqutil/blob/f3209a5b2c22eb36c3c1a8688b2a18b0d40fd476/src/coqutil/Word/LittleEndian.v
  *)
-From Coq Require Import ZArith.ZArith.
+From Coq Require Import ZArith.
 From coqutil Require Import Z.Lia.
 From coqutil Require Import Word.Interface Datatypes.HList Datatypes.PrimitivePair.
 From coqutil Require Import Word.Properties.

--- a/src/goose_lang/lang.v
+++ b/src/goose_lang/lang.v
@@ -1,4 +1,4 @@
-From Coq Require Import Program.Equality.
+From Coq.Program Require Import Equality.
 From RecordUpdate Require Import RecordSet.
 From stdpp Require Export binders strings.
 From stdpp Require Import gmap.


### PR DESCRIPTION
Adapt to https://github.com/coq/coq/pull/19530
This is an adaptation in anticipation of the day the temporary backward compatibility introduced in the upstream PR will be removed (probably a few years in the future).
Merging this is not required for the upstream PR, you can do whatever you want with it.
