### PR TITLE
Add Goose code/Proof for queue new function

### DIFF
--- a/external/Goose/github_com/mit_pdos/gokv/tutorial/queue.v
+++ b/external/Goose/github_com/mit_pdos/gokv/tutorial/queue.v
@@ -16,7 +16,18 @@ Definition NewQueue: val :=
   rec: "NewQueue" "queue_size" :=
     let: "lock" := newMutex #() in
     struct.mk Queue [
-      "queue" ::= NewSliceWithCap uint64T "queue_size" "queue_size";
+      "queue" ::= NewSlice uint64T "queue_size";
+      "cond" ::= NewCond "lock";
+      "lock" ::= "lock";
+      "first" ::= #0;
+      "count" ::= #0
+    ].
+
+Definition NewQueueRef: val :=
+  rec: "NewQueueRef" "queue_size" :=
+    let: "lock" := newMutex #() in
+    struct.new Queue [
+      "queue" ::= NewSlice uint64T "queue_size";
       "cond" ::= NewCond "lock";
       "lock" ::= "lock";
       "first" ::= #0;


### PR DESCRIPTION
This is the Goose output and proof for the associated change in https://github.com/mit-pdos/gokv/pull/9. This will provide an example for how to initiate ghost state for a new HOCAP specified data structure in Perennial and removes the unnecessary handling of the slice capacity which was not being used in the original code or proof. 