### PR TITLE
Speed up proving persistence of is_pkg_init

### DIFF
--- a/new/golang/theory/pkg.v
+++ b/new/golang/theory/pkg.v
@@ -19,11 +19,14 @@ incomparable ones.
 Class IsPkgInit (pkg_name: go_string) {PROP: bi} :=
   {
     is_pkg_init_def : PROP ;
+    #[global]
     is_pkg_init_persistent :: Persistent is_pkg_init_def;
   }.
 
 #[global]
 Arguments is_pkg_init_def (pkg_name) {_ _}.
+#[global]
+Typeclasses Opaque is_pkg_init_def.
 
 (* XXX: To avoid printing the IsPkgInit instances when printing [is_pkg_init]
    See https://github.com/coq/coq/issues/9814 for a description of the problem. *)
@@ -41,6 +44,7 @@ Ltac prove_is_pkg_init :=
 Class IsPkgDefined (pkg_name: go_string) {PROP: bi} :=
   {
     is_pkg_defined_def : PROP;
+    #[global]
     is_pkg_defined_persistent :: Persistent is_pkg_defined_def;
   }.
 

--- a/new/proof/grove_ffi.v
+++ b/new/proof/grove_ffi.v
@@ -94,7 +94,8 @@ Section grove.
     {{{ l, RET #l; is_Listener l host }}}.
   Proof.
     wp_start as "#Hdef".
-    rewrite to_val_unseal. simpl. wp_bind (ExternalOp _ _).
+    rewrite to_val_unseal. cbn [to_val_def into_val_loc into_val_w64].
+    wp_bind (ExternalOp _ _).
     iApply wp_ListenOp; first done.
     iIntros "!# _".
     iApply wp_fupd.


### PR DESCRIPTION
In even some simple cases this is noticeably slow without these improvements to typeclass resolution.