### PR TITLE
Add iPersist tactic

### DIFF
--- a/new/golang/defn/pkg.v
+++ b/new/golang/defn/pkg.v
@@ -1,5 +1,5 @@
 From Perennial.goose_lang Require Import notation.
-From New.golang.theory Require Import proofmode.
+From New.golang.defn Require Import typing.
 
 (** [PkgInfo] associates a pkg_name to its static information. *)
 Class PkgInfo (pkg_name: go_string) `{ffi_syntax} := {

--- a/new/golang/theory/mem.v
+++ b/new/golang/theory/mem.v
@@ -180,6 +180,17 @@ Section goose_lang.
     iApply (heap_pointsto_persist with "[$]").
   Qed.
 
+  #[global]
+  Instance typed_pointsto_update_persist l dq v :
+    UpdateIntoPersistently (l ↦{dq} v) (l ↦□ v).
+  Proof.
+    rewrite /UpdateIntoPersistently.
+    iIntros "H".
+    iMod (typed_pointsto_persist with "H") as "#H".
+    iFrame "H".
+    done.
+  Qed.
+
   Lemma typed_pointsto_not_null l dq v :
     go_type_size t > 0 →
     l ↦{dq} v -∗ ⌜ l ≠ null ⌝.

--- a/new/golang/theory/proofmode.v
+++ b/new/golang/theory/proofmode.v
@@ -1,5 +1,5 @@
 From Perennial.program_logic Require Export weakestpre.
-From Perennial.goose_lang Require Export lang lifting.
+From Perennial.goose_lang Require Export lang lifting ipersist.
 From Perennial.Helpers Require Export ipm.
 From iris.proofmode Require Import coq_tactics.
 From New.golang.theory Require Export typing.

--- a/new/proof/asyncfile.v
+++ b/new/proof/asyncfile.v
@@ -650,8 +650,8 @@ Proof.
   iNamed "Hl".
   wp_auto.
 
-  iMod (typed_pointsto_persist with "Hmu") as "#Hmu".
-  iMod (typed_pointsto_persist with "Hfilename") as "#Hfilename".
+  iPersist "Hmu".
+  iPersist "Hfilename".
   iMod (own_slice_persist with "Hdata_new") as "#Hdata_new".
   iMod (alloc_ghost N P data fname) as (γ) "H".
   iNamed "H".

--- a/new/proof/go_etcd_io/etcd/client/v3/concurrency.v
+++ b/new/proof/go_etcd_io/etcd/client/v3/concurrency.v
@@ -116,9 +116,7 @@ Proof.
   wp_alloc s as "Hs".
   wp_auto.
   wp_bind (Fork _).
-  iMod (typed_pointsto_persist with "cancel") as "#cancel".
-  iMod (typed_pointsto_persist with "donec") as "#donec".
-  iMod (typed_pointsto_persist with "keepAlive") as "#keepAlive".
+  iPersist "cancel donec keepAlive".
   iApply (wp_fork with "[Hdonec Hcancel]").
   {
     iNext.
@@ -165,8 +163,7 @@ Proof.
   iNext.
   iDestruct (struct_fields_split with "Hs") as "hs".
   simpl. iClear "Hctx". iNamed "hs".
-  iMod (typed_pointsto_persist with "Hclient") as "#?".
-  iMod (typed_pointsto_persist with "Hid") as "#?".
+  iPersist "Hclient Hid".
   wp_auto.
   iApply "HΦ".
   rewrite decide_True //.

--- a/new/proof/lock.v
+++ b/new/proof/lock.v
@@ -68,7 +68,7 @@ Proof.
   wp_alloc l as "l".
   iDestruct (struct_fields_split with "l") as "l".
   iNamed "l".
-  iMod (typed_pointsto_persist with "Hkv") as "#Hkv".
+  iPersist "Hkv".
   wp_auto. iApply "HΦ". iFrame "∗#%".
 Qed.
 

--- a/new/proof/std.v
+++ b/new/proof/std.v
@@ -104,8 +104,7 @@ Proof.
   wp_apply (wp_NewCond with "[#]") as "%cond #His_cond".
   wp_alloc jh_l as "jh".
   iApply struct_fields_split in "jh". simpl. iNamed "jh".
-  iMod (typed_pointsto_persist with "Hmu") as "Hmu".
-  iMod (typed_pointsto_persist with "Hcond") as "Hcond".
+  iPersist "Hmu Hcond".
   iMod (init_Mutex (∃ (done_b: bool),
          "done_b" ∷ jh_l ↦s[std.JoinHandle :: "done"] done_b ∗
          "HP" ∷ if done_b then P else True)
@@ -117,7 +116,7 @@ Proof.
   wp_auto.
   iApply "HΦ".
   rewrite /is_JoinHandle.
-  iFrame "His_cond". iFrame.
+  iFrame "His_cond #". iFrame.
 Qed.
 
 Lemma wp_JoinHandle__finish l (P: iProp Σ) :
@@ -147,8 +146,7 @@ Proof.
   wp_start as "Hwp".
   wp_auto.
   wp_apply (wp_newJoinHandle P) as "%l #Hhandle".
-  iMod (typed_pointsto_persist with "[$]") as "#?".
-  iMod (typed_pointsto_persist with "[$]") as "#?".
+  iPersist "f h".
   wp_bind (Fork _).
   iApply (wp_fork with "[Hwp]").
   - iModIntro. wp_auto.

--- a/new/proof/sync.v
+++ b/new/proof/sync.v
@@ -225,7 +225,7 @@ Proof.
 
   iDestruct (struct_fields_split with "Hc") as "Hl".
   iNamed "Hl".
-  iMod (typed_pointsto_persist with "HL") as "$".
+  iPersist "HL".
   iFrame "#". done.
 Qed.
 

--- a/src/goose_lang/ipersist.v
+++ b/src/goose_lang/ipersist.v
@@ -1,0 +1,64 @@
+From iris.proofmode Require Import coq_tactics reduction intro_patterns.
+From Perennial.Helpers Require Export ipm.
+From Perennial.program_logic Require Export weakestpre.
+Set Default Proof Using "Type".
+
+Class UpdateIntoPersistently {M} (P Q : uPred M) :=
+  update_into_persistently : P ⊢ |==> □ Q.
+Arguments UpdateIntoPersistently {_} _%I _%I.
+Arguments update_into_persistently {_} _%I _%I {_}.
+#[global]
+Hint Mode UpdateIntoPersistently + ! - : typeclass_instances.
+
+Lemma tac_update_into_persistently {M} (Δ: envs (uPred M)) i j p P P' Q Q' :
+  envs_lookup i Δ = Some (p, P) →
+  UpdateIntoPersistently P P' →
+  ElimModal True p false (|==> □ P') (□ P') Q Q' →
+  match envs_replace i p true (Esnoc Enil j P') Δ with
+  | None => False
+  | Some Δ' => envs_entails Δ' Q'
+  end →
+  envs_entails Δ Q.
+Proof.
+  destruct (envs_replace _ _ _ _ _) as [Δ'|] eqn:Hrep; last done.
+  rewrite envs_entails_unseal=> Hget HPP' Hmodal HQ. rewrite envs_replace_singleton_sound //=.
+  rewrite HPP' HQ.
+  iIntros "[HP HQ]".
+  iApply elim_modal; [ eassumption | done | ].
+  iFrame "HP HQ".
+Qed.
+
+Tactic Notation "iPersist_hyp" constr(H) constr(H') :=
+  eapply tac_update_into_persistently with H H' _ _ _ _;
+  [ reduction.pm_reflexivity || fail "iPersist:" H "not  found"
+  | tc_solve ||
+    lazymatch goal with
+    | |- UpdateIntoPersistently ?P _ =>
+      fail "iPersist: could not turn" P "into something persistent"
+    end
+  | tc_solve ||
+    fail "iPersist: could not eliminate update modality"
+  | reduction.pm_reduce;
+     lazymatch goal with
+     | |- False =>
+       let H' := pretty_ident H' in
+       fail "iPersist:" H' "not fresh"
+     | _ => reduction.pm_prettify (* subgoal *)
+     end
+  ].
+
+Ltac iPersist_one H := iPersist_hyp H H.
+
+Ltac iPersist_list Hlist :=
+  let Hs := (eval cbv in (String.words Hlist)) in
+  let rec go xs :=
+    match xs with
+    | cons ?H ?xs' => iPersist_hyp H H; go xs'
+    | nil => idtac
+    end in
+  go Hs.
+
+Tactic Notation "iPersist" constr(H) := iPersist_list H.
+Tactic Notation "iPersist" constr(H) "as" constr(ipat) :=
+  let Htmp := iFresh in
+  iPersist_hyp H Htmp; iDestruct Htmp as ipat.


### PR DESCRIPTION
This automates `iMod (typed_pointsto_persist with "H") as "H"`. This works for free on struct field points-tos since they're just notation around a typed points-to. Eventually (using some typeclass instances) we can extend it to other dfrac-based propositions, like slices and ghost state, and even user `own_` propositions.

I only applied this to new goose but it could also be used in old goose just as well.

I wrote this only because I wanted to avoid remembering the name of the persistence lemma. This solution is admittedly heavyweight for that, and we could just have the typeclass and use it directly with `iMod`.