### PR TITLE
Automate solving Program obligations

### DIFF
--- a/new/golang/defn/exception.v
+++ b/new/golang/defn/exception.v
@@ -6,11 +6,11 @@ Section defn.
 Context `{!ffi_syntax}.
 
 Definition execute_val_def (v : val) : val := (#"execute", v).
-Program Definition execute_val := unseal (_:seal (@execute_val_def)). Obligation 1. by eexists. Qed.
+Program Definition execute_val := unseal (_:seal (@execute_val_def)).
 Definition execute_val_unseal : execute_val = _ := seal_eq _.
 
 Definition return_val_def (v : val) : val := (#"return", v).
-Program Definition return_val := unseal (_:seal (@return_val_def)). Obligation 1. by eexists. Qed.
+Program Definition return_val := unseal (_:seal (@return_val_def)).
 Definition return_val_unseal : return_val = _ := seal_eq _.
 
 (* "Exception" monad *)
@@ -18,7 +18,7 @@ Local Definition do_execute_def : val :=
   λ: "v", (#"execute", Var "v")
 .
 
-Program Definition do_execute := unseal (_:seal (@do_execute_def)). Obligation 1. by eexists. Qed.
+Program Definition do_execute := unseal (_:seal (@do_execute_def)).
 Definition do_execute_unseal : do_execute = _ := seal_eq _.
 
 (* Handle "execute" computations by dropping the final value and running the
@@ -30,19 +30,19 @@ Local Definition exception_seq_def : val :=
     else
       "s1"
 .
-Program Definition exception_seq := unseal (_:seal (@exception_seq_def)). Obligation 1. by eexists. Qed.
+Program Definition exception_seq := unseal (_:seal (@exception_seq_def)).
 Definition exception_seq_unseal : exception_seq = _ := seal_eq _.
 
 Local Definition do_return_def : val :=
   λ: "v", (#"return", Var "v")
 .
-Program Definition do_return := unseal (_:seal (@do_return_def)). Obligation 1. by eexists. Qed.
+Program Definition do_return := unseal (_:seal (@do_return_def)).
 Definition do_return_unseal : do_return = _ := seal_eq _.
 
 Definition exception_do_def : val :=
   λ: "v", Snd "v"
 .
-Program Definition exception_do := unseal (_:seal (@exception_do_def)). Obligation 1. by eexists. Qed.
+Program Definition exception_do := unseal (_:seal (@exception_do_def)).
 Definition exception_do_unseal : exception_do = _ := seal_eq _.
 
 End defn.

--- a/new/golang/defn/globals.v
+++ b/new/golang/defn/globals.v
@@ -9,14 +9,14 @@ Definition unwrap_def : val :=
             NONE => #() #()
           | SOME "x" => "x"
           end.
-Program Definition unwrap := unseal (_:seal (@unwrap_def)). Obligation 1. by eexists. Qed.
+Program Definition unwrap := unseal (_:seal (@unwrap_def)).
 Definition unwrap_unseal : unwrap = _ := seal_eq _.
 
 Definition get_def : val :=
   λ: "pkg_name" "var_name",
     let: (("varAddrs", "functions"), "typeToMethodSets") := unwrap $ GlobalGet "pkg_name" in
     unwrap $ alist_lookup "var_name" "varAddrs".
-Program Definition get := unseal (_:seal (@get_def)). Obligation 1. by eexists. Qed.
+Program Definition get := unseal (_:seal (@get_def)).
 Definition get_unseal : get = _ := seal_eq _.
 
 (* XXX: unsealed because user has to prove WPs for this by unfolding. *)
@@ -40,7 +40,7 @@ Definition package_init_def (pkg_name : go_string) `{!PkgInfo pkg_name} : val :=
         GlobalPut #pkg_name ("var_addrs", functions_val, msets_val) ;;
         "init" #()
     end.
-Program Definition package_init := unseal (_:seal (@package_init_def)). Obligation 1. by eexists. Qed.
+Program Definition package_init := unseal (_:seal (@package_init_def)).
 Definition package_init_unseal : package_init = _ := seal_eq _.
 #[global]
 Arguments package_init pkg_name {PkgInfo0}.
@@ -55,7 +55,7 @@ Definition func_call_def : val :=
   λ: "pkg_name" "func_name",
     let: (("varAddrs", "functions"), "typeToMethodSets") := globals.unwrap $ GlobalGet "pkg_name" in
     globals.unwrap $ alist_lookup "func_name" "functions".
-Program Definition func_call := unseal (_:seal (@func_call_def)). Obligation 1. by eexists. Qed.
+Program Definition func_call := unseal (_:seal (@func_call_def)).
 Definition func_call_unseal : func_call = _ := seal_eq _.
 
 Definition method_call_def : val :=
@@ -63,7 +63,7 @@ Definition method_call_def : val :=
     let: (("varAddrs", "functions"), "typeToMethodSets") := globals.unwrap $ GlobalGet "pkg_name" in
     let: "methodSet" := globals.unwrap $ alist_lookup "type_name" "typeToMethodSets" in
     globals.unwrap $ alist_lookup "method_name" "methodSet".
-Program Definition method_call := unseal (_:seal (@method_call_def)). Obligation 1. by eexists. Qed.
+Program Definition method_call := unseal (_:seal (@method_call_def)).
 Definition method_call_unseal : method_call = _ := seal_eq _.
 
 End defns.

--- a/new/golang/defn/interface.v
+++ b/new/golang/defn/interface.v
@@ -10,12 +10,12 @@ Definition get_def : val :=
     let: (("pkg_name", "type_name"), "val") := globals.unwrap "v" in
     method_call "pkg_name" "type_name" "method_name" "val".
 
-Program Definition get := unseal (_:seal (@get_def)). Obligation 1. by eexists. Qed.
+Program Definition get := unseal (_:seal (@get_def)).
 Definition get_unseal : get = _ := seal_eq _.
 
 Local Definition make_def : val :=
   λ: "pkg_name" "type_name" "v", SOME ("pkg_name", "type_name", "v").
-Program Definition make := unseal (_:seal (@make_def)). Obligation 1. by eexists. Qed.
+Program Definition make := unseal (_:seal (@make_def)).
 Definition make_unseal : make = _ := seal_eq _.
 
 Definition eq : val :=

--- a/new/golang/defn/list.v
+++ b/new/golang/defn/list.v
@@ -6,11 +6,11 @@ Section defn.
   Context `{ffi_syntax}.
 
   Definition Nil_def : val := InjLV #().
-  Program Definition Nil := unseal (_:seal (@Nil_def)). Obligation 1. by eexists. Qed.
+  Program Definition Nil := unseal (_:seal (@Nil_def)).
   Definition Nil_unseal : Nil = _ := seal_eq _.
 
   Definition Cons_def : val := λ: "h" "tl", InjR ("h", "tl").
-  Program Definition Cons := unseal (_:seal (@Cons_def)). Obligation 1. by eexists. Qed.
+  Program Definition Cons := unseal (_:seal (@Cons_def)).
   Definition Cons_unseal : Cons = _ := seal_eq _.
 
   Definition Match_def : val :=
@@ -18,7 +18,7 @@ Section defn.
       Match "l"
         <> ("nilCase" #())
         "x" (let: ("hd", "tl") := "x" in "consCase" "hd" "tl").
-  Program Definition Match := unseal (_:seal (@Match_def)). Obligation 1. by eexists. Qed.
+  Program Definition Match := unseal (_:seal (@Match_def)).
   Definition Match_unseal : Match = _ := seal_eq _.
 
   Definition Length : val :=
@@ -48,7 +48,7 @@ Fixpoint alist_val_def (m : list (go_string * val)) : val :=
   | [] => InjLV #()
   | (f, v) :: tl => InjRV ((#f, v), alist_val_def tl)
   end.
-Program Definition alist_val := unseal (_:seal (@alist_val_def)). Obligation 1. by eexists. Qed.
+Program Definition alist_val := unseal (_:seal (@alist_val_def)).
 Definition alist_val_unseal : alist_val = _ := seal_eq _.
 
 End defn.

--- a/new/golang/defn/loop.v
+++ b/new/golang/defn/loop.v
@@ -5,19 +5,19 @@ Section goose_lang.
 Context {ext: ffi_syntax}.
 
 Definition break_val_def : val := (#"break", #()).
-Program Definition break_val := unseal (_:seal (@break_val_def)). Obligation 1. by eexists. Qed.
+Program Definition break_val := unseal (_:seal (@break_val_def)).
 Definition break_val_unseal : break_val = _ := seal_eq _.
 
 Definition continue_val_def : val := (#"continue", #()).
-Program Definition continue_val := unseal (_:seal (@continue_val_def)). Obligation 1. by eexists. Qed.
+Program Definition continue_val := unseal (_:seal (@continue_val_def)).
 Definition continue_val_unseal : continue_val = _ := seal_eq _.
 
 Definition do_break_def : val := λ: "v", (#"break", Var "v").
-Program Definition do_break := unseal (_:seal (@do_break_def)). Obligation 1. by eexists. Qed.
+Program Definition do_break := unseal (_:seal (@do_break_def)).
 Definition do_break_unseal : do_break = _ := seal_eq _.
 
 Definition do_continue_def : val := λ: "v", (#"continue", Var "v").
-Program Definition do_continue := unseal (_:seal (@do_continue_def)). Obligation 1. by eexists. Qed.
+Program Definition do_continue := unseal (_:seal (@do_continue_def)).
 Definition do_continue_unseal : do_continue = _ := seal_eq _.
 
 Local Definition do_for_def : val :=
@@ -32,7 +32,7 @@ Local Definition do_for_def : val :=
      return: Var "b"
   ).
 
-Program Definition do_for := unseal (_:seal (@do_for_def)). Obligation 1. by eexists. Qed.
+Program Definition do_for := unseal (_:seal (@do_for_def)).
 Definition do_for_unseal : do_for = _ := seal_eq _.
 
 Definition do_loop_def: val :=
@@ -45,7 +45,7 @@ Definition do_loop_def: val :=
      return: Var "b"
   )) #().
 
-Program Definition do_loop := unseal (_:seal (@do_loop_def)). Obligation 1. by eexists. Qed.
+Program Definition do_loop := unseal (_:seal (@do_loop_def)).
 Definition do_loop_unseal : do_loop = _ := seal_eq _.
 
 End goose_lang.

--- a/new/golang/defn/mem.v
+++ b/new/golang/defn/mem.v
@@ -5,7 +5,7 @@ Section go_lang.
   Context `{ffi_syntax}.
 
   Definition ref_ty_def (t : go_type) : val := λ: "v", ref (Var "v").
-  Program Definition ref_ty := unseal (_:seal (@ref_ty_def)). Obligation 1. by eexists. Qed.
+  Program Definition ref_ty := unseal (_:seal (@ref_ty_def)).
   Definition ref_ty_unseal : ref_ty = _ := seal_eq _.
 
   Fixpoint load_ty_def (t : go_type) : val :=
@@ -24,7 +24,7 @@ Section go_lang.
           end) n
     | _ => (λ: "l", !(Var "l"))%V
     end.
-  Program Definition load_ty := unseal (_:seal (@load_ty_def)). Obligation 1. by eexists. Qed.
+  Program Definition load_ty := unseal (_:seal (@load_ty_def)).
   Definition load_ty_unseal : load_ty = _ := seal_eq _.
 
   Fixpoint store_ty_def (t : go_type): val :=
@@ -48,7 +48,7 @@ Section go_lang.
           end) n
     | _ => (λ: "p" "v", "p" <- "v")%V
     end.
-  Program Definition store_ty := unseal (_:seal (@store_ty_def)). Obligation 1. by eexists. Qed.
+  Program Definition store_ty := unseal (_:seal (@store_ty_def)).
   Definition store_ty_unseal : store_ty = _ := seal_eq _.
 
 End go_lang.

--- a/new/golang/defn/notation.v
+++ b/new/golang/defn/notation.v
@@ -1,1 +1,2 @@
 From Perennial.goose_lang Require Export lang notation.
+From Perennial.Helpers Require Export ProgramAuto.

--- a/new/golang/defn/pkg.v
+++ b/new/golang/defn/pkg.v
@@ -1,5 +1,5 @@
 From Perennial.goose_lang Require Import notation.
-From New.golang.defn Require Import typing.
+From New.golang.defn Require Export typing.
 
 (** [PkgInfo] associates a pkg_name to its static information. *)
 Class PkgInfo (pkg_name: go_string) `{ffi_syntax} := {

--- a/new/golang/defn/string.v
+++ b/new/golang/defn/string.v
@@ -25,7 +25,7 @@ Section defn.
       if: (IsNoStringOverflow "s") then
         to_bytes_aux (StringLength "s") "s"
       else "f".
-  Program Definition to_bytes := unseal (_:seal (@to_bytes_def)). Obligation 1. by eexists. Qed.
+  Program Definition to_bytes := unseal (_:seal (@to_bytes_def)).
   Definition to_bytes_unseal : to_bytes = _ := seal_eq _.
 
   Definition from_bytes : val :=

--- a/new/golang/defn/struct.v
+++ b/new/golang/defn/struct.v
@@ -61,7 +61,7 @@ Definition make_def (t : go_type) : val :=
          end) d
   | _ => LitV $ LitPoison
   end.
-Program Definition make := unseal (_:seal (@make_def)). Obligation 1. by eexists. Qed.
+Program Definition make := unseal (_:seal (@make_def)).
 Definition make_unseal : make = _ := seal_eq _.
 
 End goose_lang.

--- a/new/golang/defn/typing.v
+++ b/new/golang/defn/typing.v
@@ -1,4 +1,5 @@
 From Perennial.goose_lang Require Export lang notation.
+From Perennial.Helpers Require Export ProgramAuto.
 
 Definition go_string := byte_string.
 Delimit Scope byte_string_scope with go.
@@ -46,7 +47,7 @@ Class IntoVal `{ffi_syntax} (V : Type) :=
     to_val_def : V → val;
   }.
 
-Program Definition to_val := unseal (_:seal (@to_val_def)). Obligation 1. by eexists. Qed.
+Program Definition to_val := unseal (_:seal (@to_val_def)).
 Definition to_val_unseal : to_val = _ := seal_eq _.
 Arguments to_val {_ _ _} v.
 (* Disable Notation "# l". *)
@@ -156,7 +157,7 @@ Section val_types.
      to deal with it in a proof, then something in Goose must have gone
      wrong. *)
   Definition badT_def := ptrT.
-  Program Definition badT := unseal (_:seal (@badT_def)). Obligation 1. by eexists. Qed.
+  Program Definition badT := unseal (_:seal (@badT_def)).
   Definition badT_unseal : badT = _ := seal_eq _.
 
   Definition byteT := uint8T.
@@ -182,7 +183,7 @@ Section val_types.
     | funcT => #func.nil
     | interfaceT => #interface.nil
     end.
-  Program Definition zero_val := unseal (_:seal (@zero_val_def)). Obligation 1. by eexists. Qed.
+  Program Definition zero_val := unseal (_:seal (@zero_val_def)).
   Definition zero_val_unseal : zero_val = _ := seal_eq _.
 
   Fixpoint go_type_size_def (t : go_type) : nat :=
@@ -197,7 +198,7 @@ Section val_types.
     | arrayT n e => n * (go_type_size_def e)
     | _ => 1
     end.
-  Program Definition go_type_size := unseal (_:seal (@go_type_size_def)). Obligation 1. by eexists. Qed.
+  Program Definition go_type_size := unseal (_:seal (@go_type_size_def)).
   Definition go_type_size_unseal : go_type_size = _ := seal_eq _.
 End val_types.
 

--- a/new/golang/theory/chan.v
+++ b/new/golang/theory/chan.v
@@ -116,7 +116,7 @@ Definition for_chan_postcondition_def P Φ bv : iProp Σ :=
             (∃ (v : val), ⌜ bv = execute_val v ⌝ ∗ P) ∨
             ⌜ bv = break_val ⌝ ∗ Φ (execute_val #()) ∨
             (∃ (v : val), ⌜ bv = return_val v ⌝ ∗ Φ bv).
-Program Definition for_chan_postcondition := unseal (_:seal (@for_chan_postcondition_def)). Obligation 1. by eexists. Qed.
+Program Definition for_chan_postcondition := unseal (_:seal (@for_chan_postcondition_def)).
 Definition for_chan_postcondition_unseal : for_chan_postcondition = _ := seal_eq _.
 
 Lemma wp_for_chan_range P ch (body : func.t) :

--- a/new/golang/theory/globals.v
+++ b/new/golang/theory/globals.v
@@ -2,6 +2,9 @@ From New.golang.theory Require Import exception mem typing list.
 From New.golang.defn Require Import globals.
 From iris.base_logic.lib Require Import ghost_map ghost_var.
 From Coq Require Import Ascii Equality.
+From Perennial.Helpers Require Export ProgramAuto.
+
+Set Default Proof Using "Type".
 
 Section wps.
 Context `{sem: ffi_semantics} `{!ffi_interp ffi} `{!heapGS Σ}.
@@ -135,7 +138,7 @@ Definition own_globals_tok_def (pending_packages : gset go_string)
   "#Hinited" ∷ □ ([∗ set] pkg_name ∈ pkg_initialized,
                   default False (pkg_postconds !! pkg_name)
     ).
-Program Definition own_globals_tok := unseal (_:seal (@own_globals_tok_def)). Obligation 1. by eexists. Qed.
+Program Definition own_globals_tok := unseal (_:seal (@own_globals_tok_def)).
 Definition own_globals_tok_unseal : own_globals_tok = _ := seal_eq _.
 
 End definitions_and_lemmas.

--- a/new/golang/theory/loop.v
+++ b/new/golang/theory/loop.v
@@ -46,7 +46,7 @@ Definition for_postcondition_def stk E (post : val) P Φ bv : iProp Σ :=
             (∃ v, ⌜ bv = execute_val v ⌝ ∗ WP post #() @ stk; E {{ _, P }}) ∨
             ⌜ bv = break_val ⌝ ∗ Φ (execute_val #()) ∨
             (∃ v, ⌜ bv = return_val v ⌝ ∗ Φ bv).
-Program Definition for_postcondition := unseal (_:seal (@for_postcondition_def)). Obligation 1. by eexists. Qed.
+Program Definition for_postcondition := unseal (_:seal (@for_postcondition_def)).
 Definition for_postcondition_unseal : for_postcondition = _ := seal_eq _.
 
 Lemma wp_for P stk E (cond body post : val) Φ :

--- a/new/golang/theory/map.v
+++ b/new/golang/theory/map.v
@@ -27,7 +27,7 @@ Definition own_map_def mptr dq (m : gmap K V) : iProp Σ :=
     heap_pointsto mptr dq v ∗
     ⌜ is_comparable_go_type kt = true ⌝ ∗
     ⌜ is_map_val v m ⌝.
-Program Definition own_map := unseal (_:seal (@own_map_def)). Obligation 1. by eexists. Qed.
+Program Definition own_map := unseal (_:seal (@own_map_def)).
 Definition own_map_unseal : own_map = _ := seal_eq _.
 
 Notation "mref ↦$ dq m" := (own_map mref dq m)

--- a/new/golang/theory/slice.v
+++ b/new/golang/theory/slice.v
@@ -26,7 +26,7 @@ Context `{!heapGS Σ}.
 Definition own_slice_def `{!IntoVal V} `{!IntoValTyped V t} (s : slice.t) (dq : dfrac) (vs : list V): iProp Σ :=
   ([∗ list] i ↦ v ∈ vs, (s.(slice.ptr_f) +ₗ[t] i) ↦{dq} v ) ∗
   ⌜length vs = uint.nat s.(slice.len_f) ∧ uint.Z s.(slice.len_f) ≤ uint.Z s.(slice.cap_f)⌝.
-Program Definition own_slice := unseal (_:seal (@own_slice_def)). Obligation 1. by eexists. Qed.
+Program Definition own_slice := unseal (_:seal (@own_slice_def)).
 Definition own_slice_unseal : own_slice = _ := seal_eq _.
 
 Global Arguments own_slice {_ _ _ _} (s dq vs).
@@ -41,7 +41,7 @@ Definition own_slice_cap_def (s : slice.t) : iProp Σ :=
   ⌜ uint.Z s.(slice.len_f) ≤ uint.Z s.(slice.cap_f) ⌝ ∗
   [∗ list] i ∈ (seq (uint.nat s.(slice.len_f)) (uint.nat s.(slice.cap_f) - uint.nat s.(slice.len_f))),
     (s.(slice.ptr_f) +ₗ[t] Z.of_nat i) ↦ (default_val V).
-Program Definition own_slice_cap := unseal (_:seal (@own_slice_cap_def)). Obligation 1. by eexists. Qed.
+Program Definition own_slice_cap := unseal (_:seal (@own_slice_cap_def)).
 Definition own_slice_cap_unseal : own_slice_cap = _ := seal_eq _.
 
 Ltac unseal := rewrite ?own_slice_unseal /own_slice_def

--- a/new/golang/theory/struct.v
+++ b/new/golang/theory/struct.v
@@ -47,7 +47,7 @@ Definition field_set_f t f0 fv: val -> val :=
   .
 
 Definition field_ref_f_def t f0 l: loc := l +ₗ (struct.field_offset t f0).1.
-Program Definition field_ref_f := unseal (_:seal (@field_ref_f_def)). Obligation 1. by eexists. Qed.
+Program Definition field_ref_f := unseal (_:seal (@field_ref_f_def)).
 Definition field_ref_f_unseal : field_ref_f = _ := seal_eq _.
 
 Class Wf (t : go_type) : Set :=

--- a/new/golang/theory/typing.v
+++ b/new/golang/theory/typing.v
@@ -31,7 +31,7 @@ Section goose_lang.
                      end) d
     | _ => LitV LitPoison
     end.
-  Program Definition val_aux := unseal (_:seal (@val_aux_def)). Obligation 1. by eexists. Qed.
+  Program Definition val_aux := unseal (_:seal (@val_aux_def)).
   Definition val_aux_unseal : val_aux = _ := seal_eq _.
 End goose_lang.
 End struct.

--- a/new/proof/asyncfile.v
+++ b/new/proof/asyncfile.v
@@ -142,7 +142,6 @@ Definition own_AsyncFile_internal f N γ P lk : iProp Σ :=
 #[global]
 Program Instance : IsPkgInit asyncfile :=
   ltac2:(build_pkg_init ()).
-Final Obligation. apply _. Qed.
 
 Definition is_AsyncFile (N:namespace) (f:loc) γ P : iProp Σ :=
   ∃ (mu : loc),

--- a/new/proof/context.v
+++ b/new/proof/context.v
@@ -31,7 +31,6 @@ Context `{!goGlobalsGS Σ}.
 #[global]
 Program Instance : IsPkgInit context :=
   ltac2:(build_pkg_init ()).
-Final Obligation. Proof. apply _. Qed.
 
 Import Context_state.
 Definition is_Context (c : interface.t) (s : Context_state.t) : iProp Σ :=

--- a/new/proof/grove_ffi.v
+++ b/new/proof/grove_ffi.v
@@ -80,7 +80,6 @@ Section grove.
   #[global]
   Program Instance pkg_is_initialized : IsPkgInit grove_ffi :=
     ltac2:(build_pkg_init ()).
-  Final Obligation. apply _. Qed.
 
   Definition is_Listener (l : loc) (host : u64) : iProp Σ :=
     is_pkg_init grove_ffi ∗

--- a/new/proof/kv.v
+++ b/new/proof/kv.v
@@ -13,7 +13,6 @@ Implicit Types (E:coPset).
 #[global]
 Program Instance : IsPkgInit kv :=
   ltac2:(build_pkg_init ()).
-Final Obligation. apply _. Qed.
 
 (* Specification of Kv interface. *)
 Definition is_Kv_Put kvptsto E (v : interface.t) : iProp Σ :=

--- a/new/proof/lock.v
+++ b/new/proof/lock.v
@@ -49,7 +49,6 @@ Global Instance is_lock_pers N γ key R : Persistent (is_lock N γ key R) := _.
 #[global]
 Program Instance : IsPkgInit lockservice :=
   ltac2:(build_pkg_init ()).
-Final Obligation. apply _. Qed.
 
 Lemma wp_MakeLockClerk kv kvptsto E :
   {{{

--- a/new/proof/primitive.v
+++ b/new/proof/primitive.v
@@ -9,7 +9,6 @@ Context `{!goGlobalsGS Σ}.
 #[global]
 Program Instance is_pkg_init_inst : IsPkgInit (PROP:=iProp Σ) primitive :=
   ltac2:(build_pkg_init ()).
-Final Obligation. Proof. apply _. Qed.
 
 Lemma wp_Assume (cond : bool) :
   {{{ is_pkg_init primitive }}}

--- a/new/proof/proof_prelude.v
+++ b/new/proof/proof_prelude.v
@@ -1,6 +1,7 @@
 From iris.algebra Require Export auth gmap frac agree excl vector.
 From Perennial.algebra Require Export big_op.
-From Perennial.Helpers Require Export Tactics List ListLen BigOp Transitions ModArith iris ipm.
+From Perennial.Helpers Require Export
+  Tactics ProgramAuto List ListLen BigOp Transitions ModArith iris ipm.
 From Perennial.base_logic Require Export ghost_var.
 From Perennial.program_logic Require Export ncinv.
 From New.golang Require Export theory.

--- a/new/proof/std.v
+++ b/new/proof/std.v
@@ -41,7 +41,6 @@ Context `{!std.GlobalAddrs}.
 #[global]
 Program Instance : IsPkgInit std :=
   ltac2:(build_pkg_init ()).
-Final Obligation. apply _. Qed.
 
 Lemma wp_Assert (cond : bool) :
   {{{ is_pkg_init std ∗ ⌜cond = true⌝ }}}

--- a/new/proof/sync.v
+++ b/new/proof/sync.v
@@ -32,12 +32,10 @@ Context `{!goGlobalsGS Σ}.
 #[global]
 Program Instance race_pkg_is_init : IsPkgInit race :=
   ltac2:(build_pkg_init ()).
-Final Obligation. Proof. apply _. Qed.
 
 #[global]
 Program Instance pkg_is_init : IsPkgInit sync :=
   ltac2:(build_pkg_init ()).
-Final Obligation. apply _. Qed.
 
 (** This means [m] is a valid mutex with invariant [R]. *)
 Definition is_Mutex (m: loc) (R : iProp Σ) : iProp Σ :=

--- a/new/proof/sync/atomic.v
+++ b/new/proof/sync/atomic.v
@@ -11,7 +11,6 @@ Context `{!atomic.GlobalAddrs}.
 #[global]
 Program Instance is_pkg_init_inst : IsPkgInit atomic :=
   ltac2:(build_pkg_init ()).
-Final Obligation. apply _. Qed.
 
 Lemma wp_LoadUint64 (addr : loc) dq :
   ∀ Φ,

--- a/src/Helpers/ProgramAuto.v
+++ b/src/Helpers/ProgramAuto.v
@@ -1,0 +1,23 @@
+From Coq.Program Require Import Tactics.
+From stdpp Require Import base.
+
+(* this Ltac is here to support rebinding, if needed *)
+Ltac obligation_tac :=
+  try
+    match goal with
+    | |- seal _ => eexists; reflexivity
+    | _ => solve [ apply _ ]
+    end.
+
+#[global,export]
+Obligation Tactic := obligation_tac.
+
+#[global]
+Unset Transparent Obligations.
+
+Module test.
+  Definition foo_def := 3.
+  Program Definition foo := unseal (_:seal (@foo_def)).
+  (* should not create any obligations *)
+  Definition foo_unseal : foo = _ := seal_eq _.
+End test.


### PR DESCRIPTION
Specifically two very common and simple classes of obligations: the obligation from the sealing pattern from stdpp, and typeclass instances that come up from creating IsPkgInit programmatically in Ltac2.