### PR TITLE
Specs for RWMutex

### DIFF
--- a/new/golang/theory/auto.v
+++ b/new/golang/theory/auto.v
@@ -36,7 +36,9 @@ Ltac destruct_pkg_init H :=
         end
     end.
 
-Tactic Notation "wp_start" "as" constr(pat) :=
+(* This doesn't unfold the function being called; convenient for proving specs
+   that wrap another spec. *)
+Tactic Notation "wp_start_folded" "as" constr(pat) :=
   (* Sometimes a Hoare triple is used in the logic, which is an iProp with a
   persistently modality in front, unlike the top-level Hoare triple notation
   which does not require the modality.
@@ -51,7 +53,10 @@ Tactic Notation "wp_start" "as" constr(pat) :=
   try clear x;
   iIntros (Φ) "Hpre HΦ";
   destruct_pkg_init "Hpre";
-  iDestruct "Hpre" as pat;
+  iDestruct "Hpre" as pat.
+
+Tactic Notation "wp_start" "as" constr(pat) :=
+  wp_start_folded as pat;
   (* only do this if it produces a single goal *)
   try (first [ wp_func_call | wp_method_call ]; wp_call; [idtac]).
 

--- a/new/proof/asyncfile.v
+++ b/new/proof/asyncfile.v
@@ -210,8 +210,9 @@ Proof.
   wp_apply wp_with_defer as "%defer defer".
   simpl subst.
   wp_auto.
-  iDestruct (Mutex_is_Locker with "[$]") as "#Hlk".
-  wp_apply (wp_Mutex__Lock with "[$]") as "[Hlocked Hown]".
+  iDestruct (Mutex_is_Locker with "[] [$]") as "#Hlk".
+  { iPkgInit. }
+  wp_apply (wp_Mutex__Lock with "[$HmuInv]") as "[Hlocked Hown]".
   wp_for "Hown".
   destruct bool_decide eqn:?.
   { (* case: wait *)
@@ -312,11 +313,7 @@ Proof.
     {
       replace (x) with (word.add idx 1).
       { iFrame "#". }
-      {
-        assert (uint.Z (word.add idx 1) = uint.Z x) by word.
-        apply int_Z_inj in H1; first done.
-        apply _. (* FIXME: why is this typeclass left? *)
-      }
+      { word. }
     }
     { done. }
   }
@@ -332,11 +329,7 @@ Proof.
   {
     replace (x) with (word.add idx 1).
     { iFrame "#". }
-    {
-      assert (uint.Z (word.add idx 1) = uint.Z x) by word.
-      apply int_Z_inj in H1; first done.
-      apply _. (* FIXME: why is this typeclass left? *)
-    }
+    { word. }
   }
   { done. }
 Qed.
@@ -361,7 +354,7 @@ Proof.
   iNamed "His2".
   wp_apply wp_with_defer as "%defer Hdefer".
   simpl subst. wp_auto.
-  wp_apply (wp_Mutex__Lock with "[$]") as "[Hlocked Hown]".
+  wp_apply (wp_Mutex__Lock with "[$HmuInv]") as "[Hlocked Hown]".
   iNamed "Hown".
   wp_auto.
   wp_apply wp_SumAssumeNoOverflow as "%Hno_overflow".
@@ -478,7 +471,8 @@ Proof.
     wp_apply (wp_Cond__Wait with "[-HΦ HH s]").
     {
       iFrame "HindexCond_is".
-      iDestruct (Mutex_is_Locker with "[]") as "$".
+      iDestruct (Mutex_is_Locker with "[] []") as "$".
+      { iPkgInit. }
       { iFrame "#". }
       iFrame "∗#%". done.
     }
@@ -525,7 +519,7 @@ Proof.
   iModIntro.
   iIntros "Hfile".
   wp_auto.
-  wp_apply (wp_Mutex__Lock with "[$]") as "[Hlocked Hown]".
+  wp_apply (wp_Mutex__Lock with "[$HmuInv]") as "[Hlocked Hown]".
   iClear "Hfilename Hdata HindexCond_is HdurableIndexCond_is".
   iNamed "Hown".
   wp_auto.
@@ -647,8 +641,7 @@ Proof.
   iNamed "H".
   iAssert (|={⊤}=> is_AsyncFile N l γ P)%I with "[-HpreIdx HpreData HdurIdx Hfile HΦ Hvol_data Hnotclosed data s]" as ">#His".
   {
-    iMod (init_Mutex with "[] [$] [-]") as "$"; last by iFrame "#".
-    { iPkgInit. }
+    iMod (init_Mutex with "[$] [-]") as "$"; last by iFrame "#".
     iNext. by iFrame "∗#".
   }
 

--- a/new/proof/go_etcd_io/etcd/client/v3/leasing.v
+++ b/new/proof/go_etcd_io/etcd/client/v3/leasing.v
@@ -133,7 +133,7 @@ Proof.
   iEval (simpl) in "Hl".
   iRename "Hcl" into "#Hcl_in".
   iNamed "Hl".
-  iMod (start_WaitGroup (nroot .@ "wg") with "[$]") as (γwg) "(#Hwg_is & Hwg_ctr & Hwg_wait)".
+  iMod (init_WaitGroup (nroot .@ "wg") with "[$]") as (γwg) "(#Hwg_is & Hwg_ctr & Hwg_wait)".
   wp_apply (wp_WaitGroup__Add with "[]").
   { iFrame "#". }
   iApply fupd_mask_intro; [solve_ndisj | iIntros "Hmask"].

--- a/new/proof/std.v
+++ b/new/proof/std.v
@@ -8,36 +8,6 @@ Context `{hG: heapGS Σ, !ffi_semantics _ _}.
 Context `{!goGlobalsGS Σ}.
 Context `{!std.GlobalAddrs}.
 
-(** NOTE:
-  The discipline followed by other proofs so far has been to define
-  [is_initialized] to require [is_defined] of the current package, but the
-  [is_initialized] of all the imported packages (as opposed to [primitive.is_defined],
-  it would be [primitive.is_initialized]).
-
-  A package's [is_initialized] predicate is meant to include not only the
-  systematic [is_defined] predicate, but also custom logical facts written by
-  the proof developer (e.g. some packages initialize global variables to hold a
-  read-only error value that gets used by functions in the package).
-
-  [is_initialized] is intended to cover the entire precondition relating to
-  all package initialization (e.g. the [sync.is_defined ∗
-  atomic.is_initialized] in [wp_JoinHandle__finish] below should be part of
-  [is_initialized]).
-
-  Another pattern in the other proofs is to include [is_initialized] in the
-  predicate associated to every object in this package. E.g. [is_JoinHandle]
-  could have [is_initialized] in it, so [wp_JoinHandle__finish] doesn't even need
-  to mention [is_initialized]. Explicit [is_initialized] would only be needed
-  for specs that don't have a package object in the precondition. This might not
-  be that great, since it increases the "entropy" of specs (sometimes you write
-  [is_initialized], and sometimes you don't).
-
-  We should eventually make all the proofs follow the same discipline for
-  initialization-related predicates, whether it's more like this proof or the
-  other proofs. It would be even nicer if the framework could enforce the
-  discipline somehow (e.g. maybe the imported packages' [is_initialized] gets
-  automatically included here).
- *)
 #[global]
 Program Instance : IsPkgInit std :=
   ltac2:(build_pkg_init ()).
@@ -107,11 +77,7 @@ Proof.
   iMod (init_Mutex (∃ (done_b: bool),
          "done_b" ∷ jh_l ↦s[std.JoinHandle :: "done"] done_b ∗
          "HP" ∷ if done_b then P else True)
-         with "[] [$] [Hdone]") as "Hlock".
-  { iPkgInit. }
-  { iNext.
-    iFrame.
-  }
+         with "[$] [$]") as "Hlock".
   wp_auto.
   iApply "HΦ".
   rewrite /is_JoinHandle.
@@ -126,7 +92,7 @@ Proof.
   wp_start as "[Hhandle P]".
   iNamed "Hhandle".
   wp_auto.
-  wp_apply (wp_Mutex__Lock with "Hlock") as "[locked Hinv]".
+  wp_apply (wp_Mutex__Lock with "[$Hlock]") as "[locked Hinv]".
   iNamed "Hinv".
   wp_auto.
   wp_apply (wp_Cond__Signal with "[$Hcond]").
@@ -165,7 +131,7 @@ Lemma wp_JoinHandle__Join l P :
 Proof.
   wp_start as "Hjh". iNamed "Hjh".
   wp_auto.
-  wp_apply (wp_Mutex__Lock with "Hlock").
+  wp_apply (wp_Mutex__Lock with "[$Hlock]").
   iIntros "[Hlocked Hlinv]". iNamed "Hlinv".
   wp_auto.
 
@@ -181,7 +147,7 @@ Proof.
     iApply "HΦ". done.
   - wp_apply (wp_Cond__Wait with "[$Hcond locked done HP]") as "H".
     { iSplit.
-      - iApply (Mutex_is_Locker with "Hlock").
+      - iApply (Mutex_is_Locker with "[] Hlock"). iPkgInit.
       - iFrame. }
     iDestruct "H" as "[Hlocked Hlinv]". iNamed "Hlinv".
     wp_for_post.

--- a/new/proof/sync.v
+++ b/new/proof/sync.v
@@ -1,2 +1,2 @@
 From New.proof.sync_proof Require Export
-  base cond mutex rwmutex waitgroup.
+  base cond mutex rwmutex_guard waitgroup.

--- a/new/proof/sync_proof/rwmutex.v
+++ b/new/proof/sync_proof/rwmutex.v
@@ -345,6 +345,7 @@ Definition own_RWMutex γ (state : rwmutex) : iProp Σ :=
   ghost_var γ.(prot_gn).(state_gn) (1/2) state.
 #[global] Opaque own_RWMutex.
 #[local] Transparent own_RWMutex.
+Global Instance own_RWMutex_timeless γ state : Timeless (own_RWMutex γ state) :=  _.
 
 Definition own_RLock_token γ : iProp Σ :=
   own_toks γ.(prot_gn).(rlock_overflow_gn) 1.
@@ -378,7 +379,7 @@ Definition is_RWMutex (rw : loc) γ N : iProp Σ :=
     ).
 #[global] Opaque is_RWMutex.
 #[local] Transparent is_RWMutex.
-Instance is_RWMutex_pers rw γ N : Persistent (is_RWMutex rw γ N) := _.
+Global Instance is_RWMutex_pers rw γ N : Persistent (is_RWMutex rw γ N) := _.
 
 Import Ltac2.
 Set Default Proof Mode "Classic".
@@ -413,7 +414,7 @@ Ltac rwAtomicEnd := iMod "Hmask" as "_".
 Lemma wp_RWMutex__RLock γ rw N :
   ∀ Φ,
   is_pkg_init sync ∗ is_RWMutex rw γ N ∗ own_RLock_token γ -∗
-  (|={⊤∖↑N,∅}=> ∃ state, own_RWMutex γ state ∗
+  ▷(|={⊤∖↑N,∅}=> ∃ state, own_RWMutex γ state ∗
      (∀ num_readers, ⌜ state = RLocked num_readers ⌝ → own_RWMutex γ (RLocked (S num_readers)) ={∅,⊤∖↑N}=∗ Φ #())) -∗
   WP rw @ sync @ "RWMutex'ptr" @ "RLock" #() {{ Φ }}.
 Proof.
@@ -435,7 +436,7 @@ Qed.
 Lemma wp_RWMutex__TryRLock γ rw N :
   ∀ Φ,
   is_pkg_init sync ∗ is_RWMutex rw γ N ∗ own_RLock_token γ -∗
-  ((|={⊤∖↑N,∅}=> ∃ state, own_RWMutex γ state ∗
+  ▷((|={⊤∖↑N,∅}=> ∃ state, own_RWMutex γ state ∗
       (∀ num_readers, ⌜ state = RLocked num_readers ⌝ →
                       own_RWMutex γ (RLocked (S num_readers)) ={∅,⊤∖↑N}=∗ Φ #true)) ∧
    Φ #false)
@@ -464,7 +465,7 @@ Qed.
 Lemma wp_RWMutex__RUnlock γ rw N :
   ∀ Φ,
   is_pkg_init sync ∗ is_RWMutex rw γ N -∗
-  (|={⊤∖↑N,∅}=> ∃ num_readers,
+  ▷(|={⊤∖↑N,∅}=> ∃ num_readers,
      own_RWMutex γ (RLocked (S num_readers)) ∗
      (own_RWMutex γ (RLocked num_readers) ∗ own_RLock_token γ ={∅,⊤∖↑N}=∗
       Φ #())) -∗
@@ -498,7 +499,7 @@ Qed.
 Lemma wp_RWMutex__Lock γ rw N :
   ∀ Φ,
   is_pkg_init sync ∗ is_RWMutex rw γ N -∗
-  (|={⊤∖↑N,∅}=> ∃ state, own_RWMutex γ state ∗
+  ▷(|={⊤∖↑N,∅}=> ∃ state, own_RWMutex γ state ∗
      (⌜ state = RLocked 0 ⌝ → own_RWMutex γ Locked ={∅,⊤∖↑N}=∗ Φ #())) -∗
   WP rw @ sync @ "RWMutex'ptr" @ "Lock" #() {{ Φ }}.
 Proof.
@@ -533,7 +534,7 @@ Qed.
 Lemma wp_RWMutex__TryLock γ rw N :
   ∀ Φ,
   is_pkg_init sync ∗ is_RWMutex rw γ N -∗
-  ((|={⊤∖↑N,∅}=> ∃ state, own_RWMutex γ state ∗
+  ▷((|={⊤∖↑N,∅}=> ∃ state, own_RWMutex γ state ∗
     (⌜ state = RLocked 0 ⌝ → own_RWMutex γ Locked ={∅,⊤∖↑N}=∗ Φ #true)) ∧
      Φ #false) -∗
   WP rw @ sync @ "RWMutex'ptr" @ "TryLock" #() {{ Φ }}.
@@ -564,7 +565,7 @@ Local Hint Unfold sync.rwmutexMaxReaders actualMaxReaders : word.
 Lemma wp_RWMutex__Unlock γ rw N :
   ∀ Φ,
   is_pkg_init sync ∗ is_RWMutex rw γ N -∗
-  (|={⊤∖↑N,∅}=> own_RWMutex γ Locked ∗
+  ▷(|={⊤∖↑N,∅}=> own_RWMutex γ Locked ∗
     (own_RWMutex γ (RLocked 0) ={∅,⊤∖↑N}=∗ Φ #())
   ) -∗
   WP rw @ sync @ "RWMutex'ptr" @ "Unlock" #() {{ Φ }}.
@@ -614,7 +615,6 @@ Proof.
   iNamed "H".
 
   (* alloc protocol resources *)
-  Print RWMutex_protocol_names.
   iMod (own_tok_auth_alloc) as (γread_wait_gn) "Hread_wait".
 
   iMod (own_tok_auth_alloc) as (γrlock_overflow_gn) "Hrlock".

--- a/new/proof/sync_proof/rwmutex.v
+++ b/new/proof/sync_proof/rwmutex.v
@@ -150,15 +150,15 @@ Lemma step_RUnlock_readerCount_Add γ writer_sem reader_sem reader_count reader_
 Proof.
   iIntros "Hinv". iNamed "Hinv".
   replace (Z.to_nat (sint.Z pos_reader_count))%nat with (1 + Z.to_nat (sint.Z (word.sub pos_reader_count (W32 1))))%nat by word.
-  iDestruct (own_toks_plus with "Hrlocks") as "[Hr Hrlocks]".
+  iDestruct (own_toks_add with "Hrlocks") as "[Hr Hrlocks]".
   destruct wl; iNamed "Hinv"; try done.
   - destruct decide. { exfalso. word. } iFrame. iFrame. iPureIntro. word.
   - destruct decide.
-    * iMod (own_tok_auth_plus 1 with "Houtstanding") as "[Houtstanding $]".
+    * iMod (own_tok_auth_add 1 with "Houtstanding") as "[Houtstanding $]".
       iFrame. iFrame. iPureIntro. word.
     * exfalso. word.
   - destruct decide.
-    * iMod (own_tok_auth_plus 1 with "Houtstanding") as "[Houtstanding $]".
+    * iMod (own_tok_auth_add 1 with "Houtstanding") as "[Houtstanding $]".
       iFrame. iFrame. iPureIntro. word.
     * exfalso. word.
 Qed.
@@ -618,7 +618,7 @@ Proof.
   iMod (own_tok_auth_alloc) as (γread_wait_gn) "Hread_wait".
 
   iMod (own_tok_auth_alloc) as (γrlock_overflow_gn) "Hrlock".
-  iMod (own_tok_auth_plus (Z.to_nat actualMaxReaders) with "Hrlock") as "[Hrlock Htoks]".
+  iMod (own_tok_auth_add (Z.to_nat actualMaxReaders) with "Hrlock") as "[Hrlock Htoks]".
   iMod (ghost_var_alloc (NotLocked (W32 0))) as (γwlock_gn) "[Hwl Hwl_inv]".
 
   iMod (ghost_var_alloc (RLocked 0)) as (γstate_gn) "[Hstate Hstate_inv]".
@@ -647,7 +647,7 @@ Proof.
   iModIntro. generalize (Z.to_nat (actualMaxReaders)).
   intros n. iClear "#". iInduction n as [|].
   { done. }
-  iDestruct (own_toks_plus _ _ 1 with "Htoks") as "[? ?]". iFrame.
+  iDestruct (own_toks_add _ 1 with "Htoks") as "[? ?]". iFrame.
   by iApply "IHn".
 Qed.
 

--- a/new/proof/sync_proof/rwmutex_guard.v
+++ b/new/proof/sync_proof/rwmutex_guard.v
@@ -1,0 +1,72 @@
+From New.proof.sync_proof Require Import base.
+From New.proof.sync_proof Require rwmutex.
+Import Qextra.
+
+Section proof.
+
+Context `{hG:heapGS Σ, !ffi_semantics _ _}.
+Context `{!goGlobalsGS Σ}.
+Context `{!syncG Σ}.
+
+Definition rfrac_def : Qp := / pos_to_Qp (Z.to_pos rwmutex.actualMaxReaders + 1).
+Program Definition rfrac := sealed @rfrac_def.
+Definition rfrac_unseal : rfrac = _ := seal_eq _.
+
+Definition own_RWMutex (rw : loc) (P : Qp → iProp Σ) : iProp Σ :=
+  ∃ γ γmax,
+  "Hown" ∷ rwmutex.own_RLock_token γ ∗
+  "Hmax" ∷ own_toks γmax 1 ∗
+  "#His" ∷ rwmutex.is_RWMutex rw γ (nroot.@"rw") ∗
+  "#HPfrac" ∷ □(∀ q1 q2, P (q1 + q2)%Qp ∗-∗ P q1 ∗ P q2) ∗
+  "#Hinv" ∷ inv (nroot.@"inv")
+    (∃ st, rwmutex.own_RWMutex γ st ∗
+           match st with
+           | Locked => True
+           | RLocked n =>
+               own_tok_auth γmax (Z.to_nat rwmutex.actualMaxReaders) ∗
+               own_toks γmax n ∗
+               P ((pos_to_Qp $ Z.to_pos $ (rwmutex.actualMaxReaders + 1 - Z.of_nat n)%Z) * rfrac)%Qp
+           end
+    ).
+
+Definition own_RWMutex_RLocked (rw : loc) (P : Qp → iProp Σ) : iProp Σ :=
+  True
+.
+
+(* XXX: For iDestructExists. *)
+Instance : Inhabited rwmutex := {| inhabitant := Locked |}.
+
+Lemma wp_RWMutex__RLock rw P :
+  {{{ is_pkg_init sync ∗ own_RWMutex rw P }}}
+    rw @ sync @ "RWMutex'ptr" @ "RLock" #()
+  {{{ RET #(); ▷ P rfrac }}}.
+Proof.
+  wp_start_folded as "Hpre". iNamed "Hpre".
+  wp_apply (rwmutex.wp_RWMutex__RLock with "[$]").
+  iInv "Hinv" as "Hi" "Hclose".
+  iDestruct "Hi" as (?) "[>Hown HP]".
+  iFrame. iApply fupd_mask_intro. { solve_ndisj. }
+  iIntros "Hmask". iIntros (?) "% H". subst.
+  iDestruct "HP" as "(>Hauth & >Htoks & HP)".
+  iCombine "Htoks Hmax" as "Htoks".
+  iCombine "Hauth Htoks" gives %Hle.
+  replace
+    (pos_to_Qp _ * rfrac)%Qp
+    with
+    (rfrac + pos_to_Qp (Z.to_pos $ (rwmutex.actualMaxReaders + 1 - Z.of_nat (num_readers + 1))%Z) * rfrac)%Qp.
+  2:{
+    replace (rfrac) with (1 * rfrac)%Qp at 1.
+    2:{ rewrite left_id //. }
+    rewrite -Qp.mul_add_distr_r.
+    f_equal. rewrite pos_to_Qp_add. f_equal.
+    word.
+  }
+  iDestruct ("HPfrac" with "HP") as "[HP' HP]".
+  iSpecialize ("HΦ" with "HP'"). iFrame.
+  iMod "Hmask" as "_".
+  iMod ("Hclose" with "[-]").
+  { iFrame. replace (num_readers + 1)%nat with (S num_readers) by word. iFrame. } (* FIXME: word simplifier *)
+  done.
+Qed.
+
+End proof.

--- a/new/proof/sync_proof/rwmutex_guard.v
+++ b/new/proof/sync_proof/rwmutex_guard.v
@@ -1,37 +1,63 @@
 From New.proof.sync_proof Require Import base.
 From New.proof.sync_proof Require rwmutex.
-Import Qextra.
 
+(** A specification for RWMutex which guards a fractional resource [P q].
+    [RLock] returns [P rfrac] while [Lock] returns [P 1]. *)
 Section proof.
 
 Context `{hG:heapGS Σ, !ffi_semantics _ _}.
 Context `{!goGlobalsGS Σ}.
 Context `{!syncG Σ}.
 
-Definition rfrac_def : Qp := / pos_to_Qp (Z.to_pos rwmutex.actualMaxReaders + 1).
+Definition rfrac_def : Qp := / pos_to_Qp (Z.to_pos (rwmutex.actualMaxReaders + 1)).
 Program Definition rfrac := sealed @rfrac_def.
 Definition rfrac_unseal : rfrac = _ := seal_eq _.
 
-Definition own_RWMutex (rw : loc) (P : Qp → iProp Σ) : iProp Σ :=
-  ∃ γ γmax,
-  "Hown" ∷ rwmutex.own_RLock_token γ ∗
-  "Hmax" ∷ own_toks γmax 1 ∗
-  "#His" ∷ rwmutex.is_RWMutex rw γ (nroot.@"rw") ∗
-  "#HPfrac" ∷ □(∀ q1 q2, P (q1 + q2)%Qp ∗-∗ P q1 ∗ P q2) ∗
-  "#Hinv" ∷ inv (nroot.@"inv")
+Local Definition is_inv P γ γmax γrlocked γlocked : iProp Σ :=
+  inv (nroot.@"inv")
     (∃ st, rwmutex.own_RWMutex γ st ∗
            match st with
-           | Locked => True
+           | Locked => own_tok_auth γrlocked 0
            | RLocked n =>
-               own_tok_auth γmax (Z.to_nat rwmutex.actualMaxReaders) ∗
+               own_tok_auth γrlocked n ∗
                own_toks γmax n ∗
+               ghost_var γlocked 1 () ∗
                P ((pos_to_Qp $ Z.to_pos $ (rwmutex.actualMaxReaders + 1 - Z.of_nat n)%Z) * rfrac)%Qp
            end
     ).
 
+Definition own_RWMutex (rw : loc) (P : Qp → iProp Σ) : iProp Σ :=
+  ∃ γ γmax γrlocked γlocked,
+  "Hown" ∷ rwmutex.own_RLock_token γ ∗
+  "Hmax" ∷ own_toks γmax 1 ∗
+  "#His" ∷ rwmutex.is_RWMutex rw γ (nroot.@"rw") ∗
+  "#HPfrac" ∷ □(∀ q1 q2, P (q1 + q2)%Qp ∗-∗ P q1 ∗ P q2) ∗
+  "#Hauth" ∷ own_tok_auth_dfrac γmax DfracDiscarded (Z.to_nat rwmutex.actualMaxReaders) ∗
+  "#Hinv" ∷ is_inv P γ γmax γrlocked γlocked.
+#[global] Opaque own_RWMutex.
+#[local] Transparent own_RWMutex.
+
 Definition own_RWMutex_RLocked (rw : loc) (P : Qp → iProp Σ) : iProp Σ :=
-  True
-.
+  ∃ γ γmax γrlocked γlocked,
+  "Hrlocked" ∷ own_toks γrlocked 1 ∗
+  "#His" ∷ rwmutex.is_RWMutex rw γ (nroot.@"rw") ∗
+  "#HPfrac" ∷ □(∀ q1 q2, P (q1 + q2)%Qp ∗-∗ P q1 ∗ P q2) ∗
+  "#Hauth" ∷ own_tok_auth_dfrac γmax DfracDiscarded (Z.to_nat rwmutex.actualMaxReaders) ∗
+  "#Hinv" ∷ is_inv P γ γmax γrlocked γlocked.
+#[global] Opaque own_RWMutex_RLocked.
+#[local] Transparent own_RWMutex_RLocked.
+
+Definition own_RWMutex_Locked (rw : loc) (P : Qp → iProp Σ) : iProp Σ :=
+  ∃ γ γmax γrlocked γlocked,
+  "Hlocked" ∷ ghost_var γlocked 1 () ∗
+  "Hown_rlock" ∷ rwmutex.own_RLock_token γ ∗
+  "Hmax" ∷ own_toks γmax 1 ∗
+  "#His" ∷ rwmutex.is_RWMutex rw γ (nroot.@"rw") ∗
+  "#HPfrac" ∷ □(∀ q1 q2, P (q1 + q2)%Qp ∗-∗ P q1 ∗ P q2) ∗
+  "#Hauth" ∷ own_tok_auth_dfrac γmax DfracDiscarded (Z.to_nat rwmutex.actualMaxReaders) ∗
+  "#Hinv" ∷ is_inv P γ γmax γrlocked γlocked.
+#[global] Opaque own_RWMutex_Locked.
+#[local] Transparent own_RWMutex_Locked.
 
 (* XXX: For iDestructExists. *)
 Instance : Inhabited rwmutex := {| inhabitant := Locked |}.
@@ -39,7 +65,7 @@ Instance : Inhabited rwmutex := {| inhabitant := Locked |}.
 Lemma wp_RWMutex__RLock rw P :
   {{{ is_pkg_init sync ∗ own_RWMutex rw P }}}
     rw @ sync @ "RWMutex'ptr" @ "RLock" #()
-  {{{ RET #(); ▷ P rfrac }}}.
+  {{{ RET #(); own_RWMutex_RLocked rw P ∗ ▷ P rfrac }}}.
 Proof.
   wp_start_folded as "Hpre". iNamed "Hpre".
   wp_apply (rwmutex.wp_RWMutex__RLock with "[$]").
@@ -47,12 +73,10 @@ Proof.
   iDestruct "Hi" as (?) "[>Hown HP]".
   iFrame. iApply fupd_mask_intro. { solve_ndisj. }
   iIntros "Hmask". iIntros (?) "% H". subst.
-  iDestruct "HP" as "(>Hauth & >Htoks & HP)".
+  iDestruct "HP" as "(>Hrtok & >Htoks & ? & HP)".
   iCombine "Htoks Hmax" as "Htoks".
   iCombine "Hauth Htoks" gives %Hle.
-  replace
-    (pos_to_Qp _ * rfrac)%Qp
-    with
+  replace (pos_to_Qp _ * rfrac)%Qp with
     (rfrac + pos_to_Qp (Z.to_pos $ (rwmutex.actualMaxReaders + 1 - Z.of_nat (num_readers + 1))%Z) * rfrac)%Qp.
   2:{
     replace (rfrac) with (1 * rfrac)%Qp at 1.
@@ -61,12 +85,86 @@ Proof.
     f_equal. rewrite pos_to_Qp_add. f_equal.
     word.
   }
+  iMod (own_tok_auth_add 1 with "Hrtok") as "[Hrtok Ht]".
   iDestruct ("HPfrac" with "HP") as "[HP' HP]".
-  iSpecialize ("HΦ" with "HP'"). iFrame.
+  iSpecialize ("HΦ" with "[$]"). iFrame.
   iMod "Hmask" as "_".
   iMod ("Hclose" with "[-]").
   { iFrame. replace (num_readers + 1)%nat with (S num_readers) by word. iFrame. } (* FIXME: word simplifier *)
   done.
+Qed.
+
+Lemma wp_RWMutex__RUnlock rw P :
+  {{{ is_pkg_init sync ∗ own_RWMutex_RLocked rw P ∗ ▷ P rfrac }}}
+    rw @ sync @ "RWMutex'ptr" @ "RUnlock" #()
+  {{{ RET #(); own_RWMutex rw P }}}.
+Proof.
+  wp_start_folded as "[Ho HP_in]". iNamed "Ho".
+  wp_apply (rwmutex.wp_RWMutex__RUnlock with "[$]").
+  iInv "Hinv" as "Hi" "Hclose".
+  iDestruct "Hi" as (?) "[>Hown HP]".
+  destruct st.
+  2:{ iDestruct "HP" as ">HP". iExFalso.
+    iCombine "HP Hrlocked" gives %Hbad. lia. }
+  iDestruct "HP" as "(>Hrauth & >Htoks & Hl & HP)".
+  iApply fupd_mask_intro. { solve_ndisj. }
+  iIntros "Hmask".
+  iCombine "Hrauth Hrlocked" gives %Hle.
+  iCombine "Hauth Htoks" gives %Hmaxle.
+  iExists (num_readers - 1)%nat.
+  replace (S (num_readers - 1)) with num_readers by lia.
+  iFrame. iIntros "[Hrlock Hown]".
+  iMod (own_tok_auth_sub with "Hrauth Hrlocked") as "Hrauth".
+  iDestruct (own_toks_add_1 (num_readers - 1)%nat 1 with "[Htoks]") as "[Htok Htoks]".
+  { iExactEq "Htoks". f_equal. lia. }
+  iSpecialize ("HΦ" with "[$]"). iFrame.
+  iMod "Hmask" as "_". iMod ("Hclose" with "[-]"); last done.
+  iFrame. iFrame. iNext.
+  iDestruct ("HPfrac" with "[$HP $HP_in]") as "HP".
+  iExactEq "HP". f_equal.
+  replace (_ + 1 - (_ - 1)%nat) with (rwmutex.actualMaxReaders + 1 - num_readers + 1) by lia.
+  rewrite Z2Pos.inj_add; try word.
+  rewrite -pos_to_Qp_add. rewrite Qp.mul_add_distr_r.
+  f_equal. rewrite left_id //.
+Qed.
+
+Lemma wp_RWMutex__Lock rw P :
+  {{{ is_pkg_init sync ∗ own_RWMutex rw P }}}
+    rw @ sync @ "RWMutex'ptr" @ "Lock" #()
+  {{{ RET #(); own_RWMutex_Locked rw P ∗ ▷ P 1%Qp }}}.
+Proof.
+  wp_start_folded as "Ho". iNamed "Ho".
+  wp_apply (rwmutex.wp_RWMutex__Lock with "[$]").
+  iInv "Hinv" as "Hi" "Hclose".
+  iDestruct "Hi" as (?) "[>Hstate HP]".
+  iFrame. iApply fupd_mask_intro. { solve_ndisj. } iIntros "Hmask".
+  iIntros "% Hst". subst.
+  rewrite rfrac_unseal. rewrite /rfrac_def Qp.mul_inv_r.
+  iDestruct "HP" as "(? & ? & >Hl & HP)".
+  iDestruct ("HΦ" with "[$]") as "$".
+  iMod "Hmask" as "_".
+  iMod ("Hclose" with "[$]"); last done.
+Qed.
+
+Lemma wp_RWMutex__Unlock rw P :
+  {{{ is_pkg_init sync ∗ own_RWMutex_Locked rw P ∗ ▷ P 1%Qp }}}
+    rw @ sync @ "RWMutex'ptr" @ "Unlock" #()
+  {{{ RET #(); own_RWMutex rw P }}}.
+Proof.
+  wp_start_folded as "[Ho HP_in]". iNamed "Ho".
+  wp_apply (rwmutex.wp_RWMutex__Unlock with "[$]").
+  iInv "Hinv" as "Hi" "Hclose".
+  iDestruct "Hi" as (?) "[>Hstate HP]".
+  destruct st.
+  { iDestruct "HP" as "(_ & _ & >Hbad & _)". iCombine "Hlocked Hbad" gives %Hbad.
+    exfalso. naive_solver. }
+  iFrame. iApply fupd_mask_intro. { solve_ndisj. } iIntros "Hmask".
+  iIntros "Hst". iDestruct ("HΦ" with "[$]") as "$".
+  iMod own_toks_0 as "?".
+  iMod "Hmask" as "_".
+  iMod ("Hclose" with "[-]"); last done.
+  iFrame.
+  rewrite rfrac_unseal. rewrite /rfrac_def Qp.mul_inv_r. iFrame.
 Qed.
 
 End proof.

--- a/new/proof/sync_proof/sema.v
+++ b/new/proof/sync_proof/sema.v
@@ -17,7 +17,7 @@ Definition own_sema γ (v : w32) : iProp Σ := ghost_var γ (1/2) v.
 #[local] Transparent own_sema.
 Global Instance own_sema_timeless  γ v : Timeless (own_sema γ v) := _.
 
-Lemma start_sema {E} N sema v :
+Lemma init_sema {E} N sema v :
   sema ↦ v ={E}=∗ ∃ γ, is_sema sema γ N ∗ own_sema γ v.
 Proof.
   iIntros "Hs".

--- a/new/proof/sync_proof/waitgroup.v
+++ b/new/proof/sync_proof/waitgroup.v
@@ -107,7 +107,7 @@ Proof.
   iInv "Hinv" as ">Hi". iNamed "Hi".
   iCombine "Hwaiters_bounded H" gives %[_ ->].
   iCombine "Hwaiters_bounded H" as "H". rewrite dfrac_op_own Qp.half_half.
-  iMod (own_tok_auth_plus 1 with "H") as "[H Htok]".
+  iMod (own_tok_auth_add 1 with "H") as "[H Htok]".
   iModIntro. rewrite <- (Z2Nat.inj_add _ 1) by word. rewrite -H.
   iDestruct "H" as "[H1 H2]". iSplitR "Htok H2"; by iFrame.
 Qed.
@@ -337,7 +337,7 @@ Proof.
   iCombine "Hzeroauth_wg Hsema_zerotoks_wg" gives %Hs.
   replace (sema) with (W32 0) by word.
   clear Huf Hs unfinished_waiters sema.
-  iMod (own_tok_auth_plus (uint.nat waiters) with "[$Hzeroauth_wg]") as "[Hzeroauth_wg Hzerotoks_wg]".
+  iMod (own_tok_auth_add (uint.nat waiters) with "[$Hzeroauth_wg]") as "[Hzeroauth_wg Hzerotoks_wg]".
   iEval (rewrite enc_0) in "Hptsto".
   iDestruct "Hptsto" as "[Hptsto1_wg Hptsto2_wg]".
   destruct Hwake as [Hwake1 Hwake2].
@@ -381,7 +381,7 @@ Proof.
   iIntros "Hsema_wg".
   iMod "Hmask" as "_".
   replace (uint.nat wrem)%nat with (1+(uint.nat (word.sub wrem (W32 1))))%nat by word.
-  iDestruct (own_toks_plus with "Hzerotoks") as "[Hzerotok Hzerotoks]".
+  iDestruct (own_toks_add with "Hzerotoks") as "[Hzerotok Hzerotoks]".
   iCombine "Hsema_zerotoks_wg Hzerotok" as "Hsema_zerotok_wg".
   iCombine "Hzeroauth_wg Hsema_zerotok_wg" gives %Hbound.
   iCombineNamed "*_wg" as "Hi".
@@ -471,7 +471,7 @@ Proof.
 
   iCombine "HR_in Hwait_toks_wg" as "Hwait_toks'_wg".
   iCombine "Hwaiters_bounded_wg Hwait_toks'_wg" gives %HwaitersLe.
-  iDestruct (own_toks_plus with "Hwait_toks'_wg") as "[HR_in Hwait_toks_wg]".
+  iDestruct (own_toks_add with "Hwait_toks'_wg") as "[HR_in Hwait_toks_wg]".
   iCombineNamed "*_wg" as "Hi".
   iMod ("Hclose" with "[Hi]").
   { iNamed "Hi". by iFrame. }
@@ -526,7 +526,7 @@ Proof.
     destruct (uint.nat sema) eqn:Hsema.
     { exfalso. lia. }
     replace (S n) with (1 + n)%nat by done.
-    iDestruct (own_toks_plus with "Hsema_zerotoks_wg") as "[Hzerotok Hsema_zerotoks_wg]".
+    iDestruct (own_toks_add with "Hsema_zerotoks_wg") as "[Hzerotok Hsema_zerotoks_wg]".
     iMod "Hmask" as "_".
     iCombineNamed "*_wg" as "Hi".
     iMod ("Hclose" with "[Hi]") as "_".
@@ -555,7 +555,7 @@ Proof.
     destruct unfinished_waiters; first by (exfalso; lia).
     iMod (own_tok_auth_delete_S with "Hzeroauth_wg Hzerotok") as "Hzeroauth_wg".
     replace (S _) with (1 + unfinished_waiters)%nat by done.
-    iDestruct (own_toks_plus with "Hunfinished_wait_toks_wg") as "[HR Hunfinished_wait_toks_wg]".
+    iDestruct (own_toks_add with "Hunfinished_wait_toks_wg") as "[HR Hunfinished_wait_toks_wg]".
     iMod (fupd_mask_subseteq _) as "Hmask"; last iMod "HΦ" as (?) "[Hwg HΦ]".
     { solve_ndisj. }
     iCombine "Hwg Hctr_wg" gives %[_ ->].

--- a/new/proof/sync_proof/waitgroup.v
+++ b/new/proof/sync_proof/waitgroup.v
@@ -125,7 +125,7 @@ Definition own_WaitGroup γ (counter : w32) : iProp Σ :=
 #[local] Transparent own_WaitGroup.
 #[global] Instance own_WaitGroup_timeless γ counter : Timeless (own_WaitGroup γ counter) := _.
 
-Lemma start_WaitGroup N wg_ptr :
+Lemma init_WaitGroup N wg_ptr :
   wg_ptr ↦ (default_val sync.WaitGroup.t) ={⊤}=∗
   ∃ γ,
   is_WaitGroup wg_ptr γ N ∗ own_WaitGroup γ (W32 0) ∗ own_WaitGroup_waiters γ (W32 0).
@@ -135,7 +135,7 @@ Proof.
   iNamed "H". simpl.
 
   iMod (ghost_var_alloc (W32 0)) as "[%counter_gn [Hctr1 Hctr2]]".
-  iMod (start_sema with "[$Hsema]") as "[%sema_gn [Hs1 Hs2]]".
+  iMod (init_sema with "[$Hsema]") as "[%sema_gn [Hs1 Hs2]]".
   iMod (own_tok_auth_alloc) as "[%waiter_gn [Hwaiters Hw2]]".
   iMod (own_tok_auth_alloc) as "[%zerostate_gn Hzerostate]".
 

--- a/new/proof/tok_set.v
+++ b/new/proof/tok_set.v
@@ -2,6 +2,7 @@ From iris.algebra Require Import numbers auth.
 From iris.base_logic.lib Require Export own.
 From iris.bi.lib Require Import fractional.
 From iris.proofmode Require Import proofmode.
+From Perennial.goose_lang Require Import ipersist.
 From Perennial Require Import base.
 
 Class tok_setG Σ := {
@@ -61,6 +62,14 @@ Proof.
   intuition.
 Qed.
 
+Global Instance own_tok_auth_dfrac_update_to_persistent γ dq n :
+  UpdateIntoPersistently (own_tok_auth_dfrac γ dq n) (own_tok_auth_dfrac γ DfracDiscarded n).
+Proof.
+  unseal. unfold UpdateIntoPersistently.
+  iIntros "H". iMod (own_update with "H") as "H".
+  { apply auth_update_auth_persist. }
+  iDestruct "H" as "#H". done.
+Qed.
 
 Lemma own_tok_auth_alloc :
   ⊢ |==> ∃ γ, own_tok_auth γ O.

--- a/new/proof/tok_set.v
+++ b/new/proof/tok_set.v
@@ -29,35 +29,6 @@ Definition own_toks_unseal : own_toks = _ := seal_eq _.
 
 Local Ltac unseal := rewrite ?own_tok_auth_dfrac_unseal /own_tok_auth_dfrac_def ?own_toks_unseal /own_toks_def.
 
-Lemma own_tok_auth_alloc :
-  ⊢ |==> ∃ γ, own_tok_auth γ O.
-Proof. unseal. iApply own_alloc. rewrite auth_auth_valid //. Qed.
-
-Lemma own_tok_auth_plus m γ n :
-  own_tok_auth γ n ==∗ own_tok_auth γ (n + m) ∗ own_toks γ m.
-Proof. unseal. rewrite -own_op. iApply own_update. by apply auth_update_alloc, nat_local_update.
-Qed.
-
-Lemma own_tok_auth_delete m γ n :
-  own_tok_auth γ (n + m) -∗ own_toks γ m ==∗ own_tok_auth γ n.
-Proof. unseal. iApply own_update_2. by apply auth_update_dealloc, nat_local_update. Qed.
-
-Lemma own_tok_auth_S γ n :
-  own_tok_auth γ n ==∗ own_tok_auth γ (S n) ∗ own_toks γ 1.
-Proof. replace (S n) with (n + 1)%nat by lia. iApply (own_tok_auth_plus 1). Qed.
-
-Lemma own_tok_auth_delete_S γ n :
-  own_tok_auth γ (S n) -∗ own_toks γ 1 ==∗ own_tok_auth γ n.
-Proof. replace (S n) with (n + 1)%nat by lia. iApply (own_tok_auth_delete 1). Qed.
-
-Lemma own_toks_0 γ :
-  ⊢ |==> own_toks γ 0.
-Proof. unseal. iApply own_unit. Qed.
-
-Lemma own_toks_plus m γ n :
-  own_toks γ (n + m) ⊣⊢ own_toks γ n ∗ own_toks γ m.
-Proof. unseal. rewrite -own_op //. Qed.
-
 Global Instance own_toks_combine_as γ n m :
   CombineSepAs (own_toks γ n) (own_toks γ m) (own_toks γ (n + m)).
 Proof. rewrite /CombineSepAs. unseal. rewrite -own_op auth_frag_op //. Qed.
@@ -90,7 +61,55 @@ Proof.
   intuition.
 Qed.
 
+
+Lemma own_tok_auth_alloc :
+  ⊢ |==> ∃ γ, own_tok_auth γ O.
+Proof. unseal. iApply own_alloc. rewrite auth_auth_valid //. Qed.
+
+Lemma own_tok_auth_add m γ n :
+  own_tok_auth γ n ==∗ own_tok_auth γ (n + m) ∗ own_toks γ m.
+Proof. unseal. rewrite -own_op. iApply own_update. by apply auth_update_alloc, nat_local_update.
+Qed.
+
+Lemma own_tok_auth_sub m γ n :
+  own_tok_auth γ n -∗ own_toks γ m ==∗ own_tok_auth γ (n - m).
+Proof.
+  iIntros "H1 H2". iCombine "H1 H2" gives %H. unseal.
+  iApply (own_update_2 with "H1 H2"). apply auth_update_dealloc, nat_local_update.
+  rewrite right_id. lia.
+Qed.
+
+Lemma own_tok_auth_S γ n :
+  own_tok_auth γ n ==∗ own_tok_auth γ (S n) ∗ own_toks γ 1.
+Proof. replace (S n) with (n + 1)%nat by lia. iApply (own_tok_auth_add 1). Qed.
+
+Lemma own_tok_auth_delete_S γ n :
+  own_tok_auth γ (S n) -∗ own_toks γ 1 ==∗ own_tok_auth γ n.
+Proof.
+  iIntros. iMod (own_tok_auth_sub with "[$] [$]") as "?".
+  replace (S n - 1)%nat with n by lia. done.
+Qed.
+
+Lemma own_toks_0 γ :
+  ⊢ |==> own_toks γ 0.
+Proof. unseal. iApply own_unit. Qed.
+
+Lemma own_toks_add m n γ :
+  own_toks γ (n + m) ⊣⊢ own_toks γ n ∗ own_toks γ m.
+Proof. unseal. rewrite -own_op //. Qed.
+
+Lemma own_toks_add_1 m n γ :
+  own_toks γ (n + m) ⊢ own_toks γ n ∗ own_toks γ m.
+Proof. unseal. rewrite -own_op //. Qed.
+
+Lemma own_toks_add_2 m n γ :
+  own_toks γ n ∗ own_toks γ m ⊢ own_toks γ (n + m).
+Proof. unseal. rewrite -own_op //. Qed.
+
 Global Instance own_toks_Timeless γ n : Timeless (own_toks γ n).
+Proof. unseal. apply _. Qed.
+
+Global Instance own_tok_auth_dfrac_Persistent γ n : Persistent (own_tok_auth_dfrac γ DfracDiscarded n).
 Proof. unseal. apply _. Qed.
 
 Global Instance own_tok_auth_dfrac_Timeless γ dq n : Timeless (own_tok_auth_dfrac γ dq n).

--- a/src/Helpers/Qextra.v
+++ b/src/Helpers/Qextra.v
@@ -4,35 +4,6 @@ Require Import Psatz.
 Require Import QArith.
 Local Open Scope Q_scope.
 
-(*
-Definition Qp_of_Zp (z : Z) (Hpos : (0 < z)%Z) : Qp.
-Proof.
-  refine (mk_Qp (Qc_of_Z z) _).
-  rewrite -Z2Qc_inj_0.
-  rewrite -Z2Qc_inj_lt.
-  auto.
-Qed.
-*)
-
-Definition Qp_of_Z (z : Z) : Qp.
-Proof.
-  refine (mk_Qp (Qc_of_Z (1 `max` z)) _).
-  abstract (rewrite -Z2Qc_inj_0 -Z2Qc_inj_lt; lia).
-Defined.
-
-Lemma Qp_of_Z_add (z1 z2 : Z) :
-  (0 < z1)%Z →
-  (0 < z2)%Z →
-  Qp_of_Z (z1 + z2)%Z =
-  Qp.add (Qp_of_Z z1) (Qp_of_Z z2).
-Proof.
-  intros Hpos1 Hpos2.
-  rewrite /Qp_of_Z //=.
-  apply Qp.to_Qc_inj_iff => //=.
-  rewrite -Z2Qc_inj_add.
-  f_equal. lia.
-Qed.
-
 Fixpoint Qppower (q: Qp) (n: nat) :=
   match n with
   | O => 1%Qp

--- a/src/goose_lang/lib/rwlock/rwlock_derived.v
+++ b/src/goose_lang/lib/rwlock/rwlock_derived.v
@@ -3,7 +3,6 @@ From iris.proofmode Require Import tactics.
 From iris.algebra Require Import excl.
 From Perennial.base_logic.lib Require Import invariants.
 From Perennial.program_logic Require Export weakestpre.
-From Perennial.Helpers Require Import Qextra.
 
 From Perennial.goose_lang Require Export lang typing.
 From Perennial.goose_lang Require Import proofmode wpc_proofmode notation crash_borrow.
@@ -11,8 +10,6 @@ From Perennial.goose_lang Require Import persistent_readonly.
 From Perennial.goose_lang.lib Require Import typed_mem.
 From Perennial.goose_lang.lib Require Export rwlock.impl.
 From Perennial.goose_lang.lib Require Export rwlock.rwlock_noncrash.
-Require Import Field.
-Add Field Qcfield : Qcanon.Qcft.
 Set Default Proof Using "Type".
 
 Section goose_lang.
@@ -23,9 +20,6 @@ Context {ext_tys: ext_types ext}.
 Section proof.
   Context `{!heapGS Σ} (N : namespace).
   Context `{!stagedG Σ}.
-
-  Definition rfrac: Qp :=
-    (Qp.inv (Qp_of_Z (2^64)))%Qp.
 
   Definition is_crash_rwlock lk R Rc :=
     is_rwlock N lk (λ q, crash_borrow (R q) (Rc q)).

--- a/src/goose_lang/lib/rwlock/rwlock_noncrash.v
+++ b/src/goose_lang/lib/rwlock/rwlock_noncrash.v
@@ -24,74 +24,49 @@ Section proof.
   Context `{!stagedG Σ}.
 
   Definition rfrac: Qp :=
-    (Qp.inv (Qp_of_Z (2^64)))%Qp.
+    (/(pos_to_Qp (Z.to_pos (2^64))))%Qp.
 
   Definition num_readers (n : u64) := 0 `max` uint.Z (word.sub n 1).
   Definition remaining_readers (n : u64) : Z :=
     (2^64 - num_readers n).
   Definition remaining_frac (n: u64) :=
-    ((Qp_of_Z (remaining_readers n)) * rfrac)%Qp.
+    ((pos_to_Qp (Z.to_pos (remaining_readers n))) * rfrac)%Qp.
 
   Hint Unfold num_readers remaining_readers : word.
 
-  Local Tactic Notation "word" :=
-      unfold remaining_readers, num_readers in *; word.
   Lemma remaining_frac_read_acquire n :
     1 ≤ uint.Z n →
     uint.Z n < uint.Z (word.add n 1) →
     remaining_frac n = Qp.add (remaining_frac (word.add n 1)) rfrac.
   Proof.
     intros Hle1 Hle2.
-    intros.
-    rewrite -Qp.to_Qc_inj_iff/Qp_of_Z//=.
-    assert (Heq1: Qc_of_Z (1 `max` remaining_readers n) = Qc_of_Z (remaining_readers n)).
-    { f_equal.
-      word.
-    }
-    assert (Heq2: Qc_of_Z (1 `max` remaining_readers (word.add n 1)) =
-                  Qc_of_Z (remaining_readers (word.add n 1))).
-    { f_equal. word. }
-    rewrite ?Heq1 ?Heq2.
-    assert (Heq3: (remaining_readers (word.add n 1)) = remaining_readers n - 1).
-    { rewrite /remaining_readers/num_readers.
-      word. }
-    rewrite Heq3 //=.
-    rewrite Z2Qc_inj_sub.
-    field_simplify => //=.
-    f_equal. rewrite Z2Qc_inj_1. field.
+    intros. rewrite /remaining_frac /remaining_readers /num_readers.
+    replace (uint.Z (word.sub n (W64 1))) with (uint.Z n - 1) by word.
+    replace (uint.Z (word.sub _ _)) with (uint.Z n) by word.
+    rewrite -> !Z.max_r by lia.
+    replace (2^64 - (uint.Z n - 1)) with ((2^64 - uint.Z n) + 1) by word.
+    rewrite -> Z2Pos.inj_add by word. rewrite -pos_to_Qp_add.
+    rewrite Qp.mul_add_distr_r.
+    f_equal. rewrite left_id //.
   Qed.
 
   Lemma remaining_frac_read_release n :
     1 < uint.Z n →
     Qp.add (remaining_frac n) rfrac = remaining_frac (word.sub n 1).
   Proof.
-    intros Hlt.
-    rewrite -Qp.to_Qc_inj_iff/Qp_of_Z//=.
-    assert (Heq1: Qc_of_Z (1 `max` remaining_readers n) = Qc_of_Z (remaining_readers n)).
-    { f_equal. rewrite /remaining_readers.
-      rewrite Z.max_r //. rewrite /num_readers.
-      word.
-    }
-    assert (Heq2: Qc_of_Z (1 `max` remaining_readers (word.sub n 1)) =
-                  Qc_of_Z (remaining_readers (word.sub n 1))).
-    { f_equal. word. }
-    rewrite ?Heq1 ?Heq2.
-    assert (Heq3: (remaining_readers (word.sub n 1)) = remaining_readers n + 1).
-    { word. }
-    rewrite Heq3 //=.
-    rewrite Z2Qc_inj_add.
-    field_simplify => //=.
+    intros Hlt. rewrite /remaining_frac /remaining_readers /num_readers.
+    replace (2^64 - 0 `max` (uint.Z (word.sub n (W64 1)))) with (2^64 - (uint.nat n - 1)) by word.
+    replace (2^64 - 0 `max` _) with (2^64 - (uint.nat n - 1) + 1) by word.
+    rewrite -> !Z2Pos.inj_add by word. rewrite -pos_to_Qp_add.
+    rewrite Qp.mul_add_distr_r. f_equal.
+    rewrite left_id //.
   Qed.
 
   Lemma remaining_free :
     remaining_frac 1 = 1%Qp.
   Proof.
-    rewrite -Qp.to_Qc_inj_iff/Qp_of_Z//=.
-    assert (Heq1: Qc_of_Z (1 `max` remaining_readers 1) = Qc_of_Z (remaining_readers 1)).
-    { f_equal. }
-    rewrite Heq1 //=.
-    field_simplify => //=.
-    rewrite Z2Qc_inj_1. auto.
+    rewrite /remaining_frac /remaining_readers /num_readers.
+    rewrite Qp.mul_inv_r //.
   Qed.
 
   Definition rwlock_inv (l : loc) (R: Qp → iProp Σ) : iProp Σ :=


### PR DESCRIPTION
This adds specs for `RWMutex` that guard a fractional resource. This is similar to the old `rwlock.v` specs, except it limits the number of simultaneous `RLock`s and requires a token to call `RUnlock` to ensure the user does not call `RUnlock` on an already-unlocked `RWMutex`.

This also tries to more consistently put `is_pkg_init pkgname` as the first clause in the precondition of specs, which may require changes to external proofs relying on `sync.Mutex` (@tchajed ).