### PR TITLE
Add a DFractional typeclass

### DIFF
--- a/new/golang/theory/mem.v
+++ b/new/golang/theory/mem.v
@@ -37,13 +37,20 @@ Section goose_lang.
   Global Instance typed_pointsto_persistent l v : Persistent (l ↦□ v).
   Proof. unseal. apply _. Qed.
 
+  Global Instance typed_pointsto_dfractional l v : DFractional (λ dq, l ↦{dq} v)%I.
+  Proof. unseal. apply _. Qed.
+  Global Instance typed_pointsto_as_dfractional l v dq : AsDFractional
+                                                     (l ↦{dq} v)
+                                                     (λ dq, l ↦{dq} v)%I dq.
+  Proof. auto. Qed.
+
   Global Instance typed_pointsto_fractional l v : Fractional (λ q, l ↦{#q} v)%I.
   Proof. unseal. apply _. Qed.
 
   Global Instance typed_pointsto_as_fractional l v q : AsFractional
                                                      (l ↦{#q} v)
                                                      (λ q, l ↦{#q} v)%I q.
-  Proof. constructor; auto. apply _. Qed.
+  Proof. auto. Qed.
 
   Lemma alist_val_inj a b :
     alist_val a = alist_val b →
@@ -173,23 +180,13 @@ Section goose_lang.
   Lemma typed_pointsto_persist l dq v :
     l ↦{dq} v ==∗ l ↦□ v.
   Proof.
-    unseal. iIntros "?".
-    iApply big_sepL_bupd.
-    iApply (big_sepL_impl with "[$]").
-    iModIntro. iIntros.
-    iApply (heap_pointsto_persist with "[$]").
+    iIntros "H". iPersist "H". done.
   Qed.
 
   #[global]
   Instance typed_pointsto_update_persist l dq v :
     UpdateIntoPersistently (l ↦{dq} v) (l ↦□ v).
-  Proof.
-    rewrite /UpdateIntoPersistently.
-    iIntros "H".
-    iMod (typed_pointsto_persist with "H") as "#H".
-    iFrame "H".
-    done.
-  Qed.
+  Proof. apply _. Qed.
 
   Lemma typed_pointsto_not_null l dq v :
     go_type_size t > 0 →

--- a/new/golang/theory/slice.v
+++ b/new/golang/theory/slice.v
@@ -1,5 +1,6 @@
 From Perennial.Helpers Require Import List ListLen Fractional NamedProps.
 From iris.algebra Require Import dfrac.
+From Perennial.iris_lib Require Import dfractional.
 From Perennial.goose_lang Require Import ipersist.
 From New.golang.defn Require Export slice.
 From New.golang.theory Require Export list mem exception loop typing primitive auto.
@@ -65,6 +66,15 @@ Qed.
 Lemma replicate_0 A (x:A) : replicate 0 x = [].
 Proof. reflexivity. Qed.
 
+#[global]
+Instance own_slice_dfractional s vs :
+  DFractional (λ dq, s ↦*{dq} vs).
+Proof. unseal; apply _. Qed.
+#[global]
+Instance own_slice_as_dfractional s dq vs :
+  AsDFractional (s ↦*{dq} vs) (λ dq, s ↦*{dq} vs) dq.
+Proof. auto. Qed.
+
 Instance own_slice_fractional s vs :
   fractional.Fractional (λ q, s ↦*{#q} vs).
 Proof. unseal; apply _. Qed.
@@ -114,24 +124,13 @@ Proof. unseal; apply _. Qed.
 Lemma own_slice_persist s dq vs:
   s ↦*{dq} vs ==∗ s ↦*□ vs.
 Proof.
-  unseal.
-  iIntros "[Hs %Hl]".
-  iSplitL; last done.
-  iApply big_sepL_bupd.
-  iApply (big_sepL_impl with "Hs").
-  iModIntro. iIntros "* % ?".
-  iApply (typed_pointsto_persist with "[$]").
+  iIntros "H". iPersist "H". done.
 Qed.
 
 #[global]
 Instance own_slice_update_to_persistent s dq vs :
   UpdateIntoPersistently (s ↦*{dq} vs) (s ↦*□ vs).
-Proof.
-  red.
-  iIntros "H".
-  iMod (own_slice_persist with "H") as "#H".
-  iModIntro. iFrame "H".
-Qed.
+Proof. apply _. Qed.
 
 Global Instance own_slice_timeless s dq vs : Timeless (s ↦*{dq} vs).
 Proof. unseal; apply _. Qed.

--- a/src/algebra/na_heap.v
+++ b/src/algebra/na_heap.v
@@ -5,6 +5,7 @@ From iris.algebra Require Export dfrac.
 From iris.algebra Require Import csum excl auth cmra_big_op numbers lib.gmap_view.
 From iris.bi Require Import fractional.
 From Perennial.base_logic Require Export lib.own.
+From Perennial.iris_lib Require Export dfractional.
 From iris.proofmode Require Export tactics.
 From Perennial.algebra Require Export blocks.
 Set Default Proof Using "Type".
@@ -241,19 +242,38 @@ Section na_heap.
     AsFractional (na_heap_pointsto_st WSt l (DfracOwn q) v) (λ q, na_heap_pointsto_st WSt l (DfracOwn q) v)%I q.
   Proof. split; first done. apply _. Qed.
 
-  Global Instance na_heap_pointsto_fractional l v: Fractional (λ q, l ↦{#q} v)%I.
+  Lemma na_heap_pointsto_persist l dq v:
+    l ↦{dq} v ==∗ l ↦□ v.
   Proof.
-    intros p q.
-    rewrite na_heap_pointsto_eq -own_op -gmap_view_frag_add -pair_op.
-    rewrite agree_idemp.
-    rewrite // Cinr_op.
+    rewrite na_heap_pointsto_eq.
+    iApply own_update.
+    apply gmap_view_frag_persist.
   Qed.
-  Global Instance na_heap_pointsto_as_fractional l q v:
-    AsFractional (l ↦{#q} v) (λ q, l ↦{#q} v)%I q.
-  Proof. split; first done. apply _. Qed.
 
   Global Instance na_heap_pointsto_persistent l v : Persistent (l ↦□ v).
   Proof. rewrite na_heap_pointsto_eq. apply _. Qed.
+
+  Global Instance na_heap_pointsto_dfractional l v : DFractional (λ dq, na_heap_pointsto l dq v).
+  Proof.
+    constructor; intros.
+    - rewrite na_heap_pointsto_eq -own_op -gmap_view_frag_op -pair_op.
+      rewrite agree_idemp.
+      rewrite // Cinr_op.
+    - apply _.
+    - iIntros "H". iMod (na_heap_pointsto_persist with "H") as "$". done.
+  Qed.
+
+  Global Instance na_heap_pointsto_as_dfractional l dq v :
+    AsDFractional (na_heap_pointsto l dq v) (λ dq, na_heap_pointsto l dq v) dq.
+  Proof. auto. Qed.
+
+  Global Instance na_heap_pointsto_fractional l v: Fractional (λ q, l ↦{#q} v)%I.
+  Proof.
+    apply (fractional_of_dfractional (λ dq, na_heap_pointsto l dq v)).
+  Qed.
+  Global Instance na_heap_pointsto_as_fractional l q v:
+    AsFractional (l ↦{#q} v) (λ q, l ↦{#q} v)%I q.
+  Proof. auto. Qed.
 
   Global Instance na_heap_pointsto_combine_sep_gives l dq1 dq2 v1 v2 :
     CombineSepGives (l ↦{dq1} v1)%I (l ↦{dq2} v2)%I ⌜ ✓(dq1 ⋅ dq2) ∧ v1 = v2 ⌝%I.
@@ -262,14 +282,6 @@ Section na_heap.
          iDestruct (own_valid_2 with "H1 H2") as %Hvalid.
          iModIntro. iPureIntro. apply gmap_view_frag_op_valid in Hvalid as [? [? ?]].
          split; first done. simpl in *. pose proof (to_agree_op_inv_L _ _ H3). done.
-  Qed.
-
-  Lemma na_heap_pointsto_persist l dq v:
-    l ↦{dq} v ==∗ l ↦□ v.
-  Proof.
-    rewrite na_heap_pointsto_eq.
-    iApply own_update.
-    apply gmap_view_frag_persist.
   Qed.
 
   Lemma na_heap_pointsto_st_agree l st1 st2 q1 q2 v1 v2 :

--- a/src/goose_lang/lib/typed_mem/typed_mem.v
+++ b/src/goose_lang/lib/typed_mem/typed_mem.v
@@ -2,6 +2,7 @@ From iris.proofmode Require Import coq_tactics reduction.
 From iris.proofmode Require Import tactics.
 From iris.proofmode Require Import environments.
 From Perennial.program_logic Require Import weakestpre.
+From Perennial.iris_lib Require Import dfractional.
 From Perennial.goose_lang Require Import proofmode.
 From Perennial.goose_lang Require Export typing.
 From Perennial.goose_lang.lib Require Import persistent_readonly.
@@ -48,11 +49,16 @@ Section goose_lang.
   Global Instance struct_pointsto_timeless l t q v: Timeless (l ↦[t]{q} v).
   Proof. unseal. apply _. Qed.
 
+  Global Instance struct_pointsto_dfractional l t v: DFractional (λ dq, l ↦[t]{dq} v)%I.
+  Proof. unseal. apply _. Qed.
+  Global Instance struct_pointsto_as_dfractional l t dq v: AsDFractional (l ↦[t]{dq} v) (λ dq, l ↦[t]{dq} v)%I dq.
+  Proof. auto. Qed.
+
   Global Instance struct_pointsto_fractional l t v: fractional.Fractional (λ q, l ↦[t]{#q} v)%I.
   Proof. unseal. apply _. Qed.
 
   Global Instance struct_pointsto_as_fractional l t q v: fractional.AsFractional (l ↦[t]{#q} v) (λ q, l ↦[t]{#q} v)%I q.
-  Proof. split; [ auto | apply _ ]. Qed.
+  Proof. auto. Qed.
 
   Theorem struct_pointsto_singleton l q t v v0 :
     flatten_struct v = [v0] ->
@@ -145,13 +151,7 @@ Section goose_lang.
   Lemma struct_pointsto_persist l dq t v:
     l ↦[t]{dq} v ==∗ l ↦[t]□ v.
   Proof.
-    rewrite struct_pointsto_eq /struct_pointsto_def.
-    iIntros "[Ha %Ht]".
-    iDestruct (big_sepL_mono with "Ha") as "Ha".
-    2: iMod (big_sepL_bupd with "Ha") as "Ha".
-    { iIntros (???) "H".
-      iMod (heap_pointsto_persist with "H") as "H". iModIntro. iExact "H". }
-    iModIntro. iFrame "Ha". done.
+    iIntros "H". iPersist "H". done.
   Qed.
 
   Lemma byte_pointsto_untype l q (x: u8) :

--- a/src/iris_lib/dfractional.v
+++ b/src/iris_lib/dfractional.v
@@ -33,7 +33,6 @@ Section dfractional.
   Implicit Types q : Qp.
   Implicit Types dq : dfrac.
 
-  (* TODO: not sure if this can be an instance *)
   Lemma fractional_of_dfractional Φ : DFractional Φ → Fractional (λ q, Φ (DfracOwn q)).
   Proof.
     intros ?.
@@ -42,8 +41,11 @@ Section dfractional.
     rewrite -dfrac_op_own dfractional //.
   Qed.
 
-  (* TODO: not sure if this can be an instance *)
-  Lemma as_fractional_of_as_dfractional P Φ q :
+  (* TODO: not sure if this is a good instance to have. It doesn't allow proving
+  Fractional directly, and it's hard to do that with typeclass search due to
+  higher-order unification struggling to go from a predicate over Qp to one
+  over dfrac. *)
+  Global Instance as_fractional_of_as_dfractional P Φ q :
     AsDFractional P Φ (DfracOwn q) → AsFractional P (λ q, Φ (DfracOwn q)) q.
   Proof.
     intros [Heq ?].

--- a/src/iris_lib/dfractional.v
+++ b/src/iris_lib/dfractional.v
@@ -1,0 +1,153 @@
+From iris.bi Require Export bi.
+From iris.proofmode Require Import classes classes_make proofmode.
+From iris.bi.lib Require Import fractional.
+From iris.algebra Require Import dfrac.
+From iris.prelude Require Import options.
+
+(** This library is a (partial) copy of the Iris fractional library, adapted to
+dfrac. We do extend the interface to include dfrac-specific laws. *)
+
+Class DFractional {PROP : bi} `{BUpd PROP} (Φ : dfrac → PROP) :=
+  { dfractional dp dq : Φ (dp ⋅ dq) ⊣⊢ Φ dp ∗ Φ dq;
+    dfractional_persistent : Persistent (Φ DfracDiscarded);
+    dfractional_persist dq : Φ dq ⊢ |==> Φ DfracDiscarded; }.
+Global Arguments dfractional {_ _ _ _} _ _.
+Global Arguments dfractional_persistent {_ _} _ {_}.
+Global Arguments dfractional_persist {_ _ _ _} _.
+
+(** The [AsDFractional] typeclass is analogous to [AsFractional]: it is only
+there to assist higher-order unification for APIs that want to take a [P] that
+has to be turned into [Φ dq]. See the documentation for [AsFractional] for more
+details. *)
+Class AsDFractional {PROP : bi} (H: BUpd PROP) (P : PROP) (Φ : dfrac → PROP) (dq : dfrac) := {
+  as_dfractional : P ⊣⊢ Φ dq;
+  as_dfractional_dfractional : DFractional Φ
+}.
+Global Arguments AsDFractional {_ _} _%_I _%_I _%_Qp.
+Global Hint Mode AsDFractional - - ! - - : typeclass_instances.
+
+Section dfractional.
+  Context {PROP : bi} {H: BiBUpd PROP}.
+  Implicit Types P Q : PROP.
+  Implicit Types Φ : dfrac → PROP.
+  Implicit Types q : Qp.
+  Implicit Types dq : dfrac.
+
+  (* TODO: not sure if this can be an instance *)
+  Lemma fractional_of_dfractional Φ : DFractional Φ → Fractional (λ q, Φ (DfracOwn q)).
+  Proof.
+    intros ?.
+    rewrite /Fractional.
+    intros.
+    rewrite -dfrac_op_own dfractional //.
+  Qed.
+
+  (* TODO: not sure if this can be an instance *)
+  Lemma as_fractional_of_as_dfractional P Φ q :
+    AsDFractional P Φ (DfracOwn q) → AsFractional P (λ q, Φ (DfracOwn q)) q.
+  Proof.
+    intros [Heq ?].
+    constructor; [ done | ].
+    apply fractional_of_dfractional; auto.
+  Qed.
+
+  (* this instance isn't generally useful since DFractional doesn't unify with Φ
+  dq *)
+  Local Existing Instance dfractional_persistent.
+
+  Global Instance DFractional_proper :
+    Proper (pointwise_relation _ (≡) ==> iff) (@DFractional PROP _).
+  Proof.
+    intros Φ1 Φ2 Hequiv.
+    split; intros [? ? ?].
+    - constructor; setoid_rewrite <- Hequiv; auto.
+    - constructor; setoid_rewrite -> Hequiv; auto.
+  Qed.
+
+  Global Instance persistent_dfractional (P : PROP) :
+    Persistent P → TCOr (Affine P) (Absorbing P) → DFractional (λ _, P).
+  Proof.
+    intros ??. constructor; [ | by auto | by auto ].
+    intros dq1 dq2. apply: bi.persistent_sep_dup.
+  Qed.
+
+  Global Instance dfractional_sep Φ Ψ :
+    DFractional Φ → DFractional Ψ → DFractional (λ dq, Φ dq ∗ Ψ dq)%I.
+  Proof.
+    intros ??.
+    constructor.
+    - intros dq1 dq2. rewrite !dfractional -!assoc. f_equiv.
+      rewrite !assoc. f_equiv. by rewrite comm.
+    - apply _.
+    - intros dq.
+      rewrite (dfractional_persist dq).
+      rewrite (dfractional_persist dq).
+      iIntros "[>H1 >H2]".
+      iFrame. done.
+  Qed.
+
+  Global Instance dfractional_big_sepL {A} (l : list A) Ψ :
+    (∀ k x, DFractional (Ψ k x)) →
+    DFractional (PROP:=PROP) (λ dq, [∗ list] k↦x ∈ l, Ψ k x dq)%I.
+  Proof.
+    intros ?.
+    constructor.
+    - intros dq1 dq2. rewrite -big_sepL_sep. by setoid_rewrite dfractional.
+    - apply _.
+    - intros q. rewrite -big_sepL_bupd.
+      iIntros "H".
+      iApply (big_sepL_impl with "H").
+      iIntros "!>" (???).
+      iApply dfractional_persist.
+  Qed.
+
+  Global Instance dfractional_big_sepL2 {A B} (l1 : list A) (l2 : list B) Ψ :
+    (∀ k x1 x2, DFractional (Ψ k x1 x2)) →
+    DFractional (PROP:=PROP) (λ dq, [∗ list] k↦x1; x2 ∈ l1; l2, Ψ k x1 x2 dq)%I.
+  Proof.
+    intros ?.
+    constructor.
+    - intros dq1 dq2. rewrite -big_sepL2_sep. by setoid_rewrite dfractional.
+    - apply _.
+    - intros q.
+      rewrite !big_sepL2_alt.
+      iIntros "[$ H]".
+      rewrite -big_sepL_bupd.
+      iApply (big_sepL_impl with "H").
+      iIntros "!>" (???).
+      iApply dfractional_persist.
+  Qed.
+
+  Lemma dfractional_update_to_dfrac `{BiBUpd PROP} Φ dq `{BiAffine PROP} :
+    DFractional Φ →
+    ✓dq →
+    Φ (DfracOwn 1) ⊢ |==> Φ dq.
+  Proof.
+    intros ? Hvalid.
+    destruct dq.
+    - apply -> dfrac_valid_own in Hvalid.
+      apply Qp.le_lteq in Hvalid as [? | ?].
+      + destruct (Qp.lt_sum q 1) as [[q' ->] _]; auto.
+        change (DfracOwn (q + q')) with (DfracOwn q ⋅ DfracOwn q').
+        rewrite dfractional.
+        iIntros "[$ _]"; auto.
+      + subst; auto.
+    - rewrite dfractional_persist //.
+    - rewrite /valid /cmra_valid /= in Hvalid.
+      destruct (Qp.lt_sum q 1) as [[q' ->] _]; auto.
+      change (DfracBoth q) with (DfracOwn q ⋅ DfracDiscarded).
+      change (DfracOwn (q + q')) with (DfracOwn q ⋅ DfracOwn q').
+      rewrite !dfractional.
+      iIntros "[$ H2]".
+      iMod (dfractional_persist with "H2") as "$".
+      done.
+  Qed.
+
+End dfractional.
+
+Global Arguments fractional_of_dfractional {_ _} Φ {_} p q.
+
+Ltac solve_as_frac :=
+  solve [ constructor; [ done | apply _ ] ].
+Hint Extern 1 (AsDFractional _ _ _) => solve_as_frac : core.
+Hint Extern 1 (AsFractional _ _ _) => solve_as_frac : core.


### PR DESCRIPTION
This is just a start. I didn't add instances for every use of Fractional, just the most basic ones. This does automatically give UpdateIntoPersistently for these definitions, which is nice and one of the original motivations here.

We could also try to fully replace Fractional with DFractional, but this would require a little more experimentation and integration with the IPM - deriving Fractional from DFractional automatically seems tricky due to higher-order unification issues.