### PR TITLE
Fix old and broken toml files for Goose update

### DIFF
--- a/new/code/bytes.v.toml
+++ b/new/code/bytes.v.toml
@@ -1,3 +1,9 @@
+translate = [
+  "!*",
+]
+imports = [
+  "!*",
+]
 axiomatize = [
   "Buffer",
 ]

--- a/new/code/context.v.toml
+++ b/new/code/context.v.toml
@@ -2,3 +2,6 @@ translate = [
   "Context",
   "CancelFunc",
 ]
+imports = [
+  "!*"
+]

--- a/new/code/crypto/rand.v.toml
+++ b/new/code/crypto/rand.v.toml
@@ -1,3 +1,6 @@
-Imports = []
-ToTranslate = []
-ToAxiomatize = []
+translate = [
+  "!*",
+]
+imports = [
+  "!*",
+]

--- a/new/code/errors.v.toml
+++ b/new/code/errors.v.toml
@@ -1,3 +1,6 @@
-Imports = []
-ToTranslate = []
-ToAxiomatize = []
+translate = [
+  "!*",
+]
+imports = [
+  "!*",
+]

--- a/new/code/fmt.v.toml
+++ b/new/code/fmt.v.toml
@@ -1,3 +1,9 @@
+translate = [
+  "!*",
+]
+imports = [
+  "!*",
+]
 trusted = [
   "Print",
   "Printf"

--- a/new/code/github_com/goose_lang/primitive.v.toml
+++ b/new/code/github_com/goose_lang/primitive.v.toml
@@ -1,3 +1,9 @@
+translate = [
+  "!*",
+]
+imports = [
+  "!*",
+]
 trusted = [
   "UInt64Put",
   "Assume",

--- a/new/code/github_com/goose_lang/primitive/disk.v.toml
+++ b/new/code/github_com/goose_lang/primitive/disk.v.toml
@@ -1,3 +1,9 @@
+translate = [
+  "!*",
+]
+imports = [
+  "!*",
+]
 trusted = [
   "Disk",
   "BlockSize",

--- a/new/code/github_com/mit_pdos/gokv/trusted_proph.v.toml
+++ b/new/code/github_com/mit_pdos/gokv/trusted_proph.v.toml
@@ -6,3 +6,7 @@ trusted = [
   "ResolveBytes",
   "NewProph",
 ]
+
+imports = [
+  "!*",
+]

--- a/new/code/github_com/stretchr/testify/assert.v.toml
+++ b/new/code/github_com/stretchr/testify/assert.v.toml
@@ -1,3 +1,6 @@
-Imports = []
-ToTranslate = []
-ToAxiomatize = []
+translate = [
+  "!*",
+]
+imports = [
+  "!*",
+]

--- a/new/code/go_etcd_io/etcd/api/v3/etcdserverpb.v.toml
+++ b/new/code/go_etcd_io/etcd/api/v3/etcdserverpb.v.toml
@@ -39,3 +39,7 @@ translate = [
   "Compare_Lease",
 
 ]
+
+imports = [
+  "!*",
+]

--- a/new/code/go_etcd_io/etcd/api/v3/mvccpb.v.toml
+++ b/new/code/go_etcd_io/etcd/api/v3/mvccpb.v.toml
@@ -5,3 +5,7 @@ translate = [
   "DELETE",
   "Event",
 ]
+
+imports = [
+  "!*",
+]

--- a/new/code/go_etcd_io/raft/v3/quorum/slices.v.toml
+++ b/new/code/go_etcd_io/raft/v3/quorum/slices.v.toml
@@ -1,3 +1,7 @@
 translate = [
   "Tup",
 ]
+
+imports = [
+  "!*",
+]

--- a/new/code/go_etcd_io/raft/v3/raftpb.v.toml
+++ b/new/code/go_etcd_io/raft/v3/raftpb.v.toml
@@ -53,3 +53,7 @@ axiomatize = [
   # FIXME: translate this by allowing for recursion over sliceT
   "Message",
 ]
+
+imports = [
+  "!*",
+]

--- a/new/code/go_uber_org/zap.v.toml
+++ b/new/code/go_uber_org/zap.v.toml
@@ -1,3 +1,6 @@
 imports = [
   "go.uber.org/zap/zapcore",
 ]
+translate = [
+  "!*",
+]

--- a/new/code/go_uber_org/zap/zapcore.v.toml
+++ b/new/code/go_uber_org/zap/zapcore.v.toml
@@ -2,3 +2,6 @@ translate = [
   "Field",
   "FieldType",
 ]
+imports = [
+  "!*",
+]

--- a/new/code/google_golang_org/grpc.v.toml
+++ b/new/code/google_golang_org/grpc.v.toml
@@ -1,3 +1,6 @@
-Imports = []
-ToTranslate = []
-ToAxiomatize = []
+translate = [
+  "!*",
+]
+imports = [
+  "!*",
+]

--- a/new/code/google_golang_org/grpc/codes.v.toml
+++ b/new/code/google_golang_org/grpc/codes.v.toml
@@ -12,3 +12,6 @@ translate = [
   "Unauthenticated",
   "Unavailable",
 ]
+imports = [
+  "!*"
+]

--- a/new/code/google_golang_org/grpc/status.v.toml
+++ b/new/code/google_golang_org/grpc/status.v.toml
@@ -1,0 +1,6 @@
+translate = [
+  "!*",
+]
+imports = [
+  "!*",
+]

--- a/new/code/internal/race.v.toml
+++ b/new/code/internal/race.v.toml
@@ -1,3 +1,6 @@
 translate = [
   "Enabled",
 ]
+imports = [
+  "!*",
+]

--- a/new/code/io.v.toml
+++ b/new/code/io.v.toml
@@ -2,3 +2,6 @@ translate = [
   "Reader",
   "Writer",
 ]
+imports = [
+  "!*"
+]

--- a/new/code/log.v.toml
+++ b/new/code/log.v.toml
@@ -8,3 +8,7 @@ trusted = [
   "Printf",
   "Println",
 ]
+
+imports = [
+  "!*"
+]

--- a/new/code/math.v.toml
+++ b/new/code/math.v.toml
@@ -2,3 +2,7 @@ translate = [
   "MaxUint64",
   "MaxInt64",
 ]
+
+imports = [
+  "!*"
+]

--- a/new/code/math/big.v.toml
+++ b/new/code/math/big.v.toml
@@ -1,3 +1,6 @@
-Imports = []
-ToTranslate = []
-ToAxiomatize = []
+translate = [
+  "!*",
+]
+imports = [
+  "!*",
+]

--- a/new/code/math/rand.v.toml
+++ b/new/code/math/rand.v.toml
@@ -1,3 +1,6 @@
-Imports = []
-ToTranslate = []
-ToAxiomatize = []
+translate = [
+  "!*",
+]
+imports = [
+  "!*",
+]

--- a/new/code/os.v.toml
+++ b/new/code/os.v.toml
@@ -1,3 +1,6 @@
-Imports = []
-ToTranslate = []
-ToAxiomatize = []
+translate = [
+  "!*",
+]
+imports = [
+  "!*",
+]

--- a/new/code/slices.v.toml
+++ b/new/code/slices.v.toml
@@ -1,3 +1,6 @@
-Imports = []
-ToTranslate = []
-ToAxiomatize = []
+translate = [
+  "!*",
+]
+imports = [
+  "!*",
+]

--- a/new/code/sort.v.toml
+++ b/new/code/sort.v.toml
@@ -1,3 +1,6 @@
-Imports = []
-ToTranslate = []
-ToAxiomatize = []
+translate = [
+  "!*",
+]
+imports = [
+  "!*",
+]

--- a/new/code/strconv.v.toml
+++ b/new/code/strconv.v.toml
@@ -1,3 +1,6 @@
-Imports = []
-ToTranslate = []
-ToAxiomatize = []
+translate = [
+  "!*",
+]
+imports = [
+  "!*",
+]

--- a/new/code/strings.v.toml
+++ b/new/code/strings.v.toml
@@ -1,2 +1,5 @@
 translate = ["Builder"]
 axiomatize = ["Builder"]
+imports = [
+  "!*"
+]

--- a/new/code/sync.v
+++ b/new/code/sync.v
@@ -267,6 +267,15 @@ Definition RWMutex__Unlock : val :=
     then do:  ((func_call #race.race #"Enable"%go) #())
     else do:  #())).
 
+(* RLocker returns a [Locker] interface that implements
+   the [Locker.Lock] and [Locker.Unlock] methods by calling rw.RLock and rw.RUnlock.
+
+   go: rwmutex.go:240:20 *)
+Definition RWMutex__RLocker : val :=
+  rec: "RWMutex__RLocker" "rw" <> :=
+    exception_do (let: "rw" := (mem.alloc "rw") in
+    return: (interface.make #sync.sync #"rlocker'ptr" (![#ptrT] "rw"))).
+
 Definition WaitGroup : go_type := structT [
   "noCopy" :: noCopy;
   "state" :: atomic.Uint64;
@@ -415,7 +424,7 @@ Definition vars' : list (go_string * go_type) := [].
 
 Definition functions' : list (go_string * val) := [("NewCond"%go, NewCond); ("runtime_Semacquire"%go, runtime_Semacquire); ("runtime_SemacquireWaitGroup"%go, runtime_SemacquireWaitGroup); ("runtime_SemacquireRWMutexR"%go, runtime_SemacquireRWMutexR); ("runtime_SemacquireRWMutex"%go, runtime_SemacquireRWMutex); ("runtime_Semrelease"%go, runtime_Semrelease)].
 
-Definition msets' : list (go_string * (list (go_string * val))) := [("Cond"%go, []); ("Cond'ptr"%go, [("Broadcast"%go, Cond__Broadcast); ("Signal"%go, Cond__Signal); ("Wait"%go, Cond__Wait)]); ("noCopy"%go, []); ("noCopy'ptr"%go, []); ("Mutex"%go, []); ("Mutex'ptr"%go, [("Lock"%go, Mutex__Lock); ("TryLock"%go, Mutex__TryLock); ("Unlock"%go, Mutex__Unlock)]); ("RWMutex"%go, []); ("RWMutex'ptr"%go, [("Lock"%go, RWMutex__Lock); ("RLock"%go, RWMutex__RLock); ("RUnlock"%go, RWMutex__RUnlock); ("TryLock"%go, RWMutex__TryLock); ("TryRLock"%go, RWMutex__TryRLock); ("Unlock"%go, RWMutex__Unlock); ("rUnlockSlow"%go, RWMutex__rUnlockSlow)]); ("WaitGroup"%go, []); ("WaitGroup'ptr"%go, [("Add"%go, WaitGroup__Add); ("Done"%go, WaitGroup__Done); ("Wait"%go, WaitGroup__Wait)])].
+Definition msets' : list (go_string * (list (go_string * val))) := [("Cond"%go, []); ("Cond'ptr"%go, [("Broadcast"%go, Cond__Broadcast); ("Signal"%go, Cond__Signal); ("Wait"%go, Cond__Wait)]); ("noCopy"%go, []); ("noCopy'ptr"%go, []); ("Mutex"%go, []); ("Mutex'ptr"%go, [("Lock"%go, Mutex__Lock); ("TryLock"%go, Mutex__TryLock); ("Unlock"%go, Mutex__Unlock)]); ("RWMutex"%go, []); ("RWMutex'ptr"%go, [("Lock"%go, RWMutex__Lock); ("RLock"%go, RWMutex__RLock); ("RLocker"%go, RWMutex__RLocker); ("RUnlock"%go, RWMutex__RUnlock); ("TryLock"%go, RWMutex__TryLock); ("TryRLock"%go, RWMutex__TryRLock); ("Unlock"%go, RWMutex__Unlock); ("rUnlockSlow"%go, RWMutex__rUnlockSlow)]); ("WaitGroup"%go, []); ("WaitGroup'ptr"%go, [("Add"%go, WaitGroup__Add); ("Done"%go, WaitGroup__Done); ("Wait"%go, WaitGroup__Wait)])].
 
 #[global] Instance info' : PkgInfo sync.sync :=
   {|

--- a/new/code/sync.v.toml
+++ b/new/code/sync.v.toml
@@ -1,4 +1,5 @@
 translate = [
+  "!*",
   "rwmutexMaxReaders",
   "RWMutex",
   "RWMutex.TryLock",

--- a/new/code/sync.v.toml
+++ b/new/code/sync.v.toml
@@ -2,18 +2,10 @@ translate = [
   "!*",
   "rwmutexMaxReaders",
   "RWMutex",
-  "RWMutex.TryLock",
-  "RWMutex.Lock",
-  "RWMutex.Unlock",
-  "RWMutex.RLock",
-  "RWMutex.TryRLock",
-  "RWMutex.RUnlock",
-  "RWMutex.rUnlockSlow",
+  "RWMutex.*",
 
   "WaitGroup",
-  "WaitGroup.Add",
-  "WaitGroup.Done",
-  "WaitGroup.Wait",
+  "WaitGroup.*",
   "noCopy",
 ]
 
@@ -32,14 +24,10 @@ trusted = [
   # E.g. in Mutex.Lock:
   # https://github.com/golang/go/blob/ff27d270c9f95178f9749bc8e1f15957b1c1d5b3/src/internal/sync/mutex.go#L100
   "Mutex",
-  "Mutex.Lock",
-  "Mutex.TryLock",
-  "Mutex.Unlock",
+  "Mutex.*",
 
   "Cond",
-  "Cond.Wait",
-  "Cond.Signal",
-  "Cond.Broadcast",
+  "Cond.*",
   "NewCond",
 
   "runtime_Semacquire",

--- a/new/code/sync/atomic.v.toml
+++ b/new/code/sync/atomic.v.toml
@@ -25,3 +25,7 @@ trusted = [
   "AddInt32",
   "CompareAndSwapInt32",
 ]
+
+imports = [
+  "!*",
+]

--- a/new/code/testing.v.toml
+++ b/new/code/testing.v.toml
@@ -1,3 +1,9 @@
 axiomatize = [
   "T",
 ]
+translate = [
+  "!*",
+]
+imports = [
+  "!*",
+]

--- a/new/code/time.v.toml
+++ b/new/code/time.v.toml
@@ -1,3 +1,6 @@
+imports = [
+  "!*",
+]
 translate = [
   "Time",
   "Second",

--- a/new/generatedproof/sync.v
+++ b/new/generatedproof/sync.v
@@ -246,6 +246,10 @@ Global Instance wp_method_call_RWMutex'ptr_RLock :
   WpMethodCall sync "RWMutex'ptr" "RLock" _ (is_pkg_defined sync) :=
   ltac:(apply wp_method_call'; reflexivity).
 
+Global Instance wp_method_call_RWMutex'ptr_RLocker :
+  WpMethodCall sync "RWMutex'ptr" "RLocker" _ (is_pkg_defined sync) :=
+  ltac:(apply wp_method_call'; reflexivity).
+
 Global Instance wp_method_call_RWMutex'ptr_RUnlock :
   WpMethodCall sync "RWMutex'ptr" "RUnlock" _ (is_pkg_defined sync) :=
   ltac:(apply wp_method_call'; reflexivity).


### PR DESCRIPTION
It's now necessary to explicitly write a negative pattern (`"!*"`) to avoid translating (or importing) everything by default.