### PR TITLE
seal `u64_le`

### DIFF
--- a/src/Helpers/ListLen.v
+++ b/src/Helpers/ListLen.v
@@ -31,7 +31,8 @@ Hint Rewrite u32_le_length : len.
 #[global]
 Hint Rewrite length_seqZ : len.
 
-Ltac len := autorewrite with len; try word; try lia.
+(* users can add their own Hint Unfold's to the len db. *)
+Ltac len := autounfold with len; autorewrite with len; try word; try lia.
 
 Tactic Notation "list_elem" constr(l) constr(i) "as" simple_intropattern(x) :=
   let H := fresh "H" x "_lookup" in

--- a/src/Helpers/Word/LittleEndian.v
+++ b/src/Helpers/Word/LittleEndian.v
@@ -145,7 +145,7 @@ Proof.
     let T := type of t in change T with (HList.tuple byte n) in *.
     rewrite combine_unfold.
     rewrite BitOps.or_to_plus.
-    2: { pose proof (IHn t).
+    { pose proof (IHn t).
       pose proof (word.unsigned_range b).
       split.
       { unfold Z.shiftl; simpl. lia. }
@@ -158,13 +158,17 @@ Proof.
     unfold Z.eqf; intros.
     rewrite Z.land_spec.
     rewrite Z.bits_0.
-    (* TODO: error here. *)
     destruct (decide (n0 < 0)).
-    { rewrite Z.testbit_neg_r; lia. }
+    { rewrite Z.testbit_neg_r; [ | lia ].
+      rewrite andb_false_l; auto.
+    }
     destruct (decide (n0 < 8)).
-    + rewrite Z.shiftl_spec_low; lia.
-    + rewrite (Zmod_small_bits_high 8); lia.
+    + rewrite Z.shiftl_spec_low; [ | lia ].
+      rewrite andb_false_r; auto.
+    + rewrite (Zmod_small_bits_high 8); [ | lia | lia ].
+      rewrite andb_false_l; auto.
 Qed.
+
 
 Lemma le_to_u64_le bs :
   length bs = 8%nat ->
@@ -174,10 +178,10 @@ Proof.
   intros.
   do 8 (destruct bs; [ simpl in H; lia | ]).
   destruct bs; [ clear H | simpl in H; lia ].
-  unfold u64_le_def, le_to_u64.
+  unfold le_to_u64, u64_le_def.
   rewrite word.unsigned_of_Z.
   rewrite wrap_small.
-  2: { rewrite LittleEndian.split_combine.
+  { rewrite LittleEndian.split_combine.
     simpl; auto. }
   cbv [length].
   apply combine_bound.

--- a/src/goose_lang/lib/encoding/encoding.v
+++ b/src/goose_lang/lib/encoding/encoding.v
@@ -120,6 +120,7 @@ Theorem u32_le_to_sru (x: u32) :
                    (cons #(W8 (uint.Z (word.sru x (W32 (3%nat * 8)))))
                          nil))).
 Proof.
+  rewrite u32_le_unseal /u32_le_def.
   rewrite /b2val.
   cbv [u32_le fmap list_fmap LittleEndian.split HList.tuple.to_list List.map].
   rewrite -word_byte_extract; last lia.
@@ -134,6 +135,7 @@ Theorem wp_EncodeUInt32 (l: loc) (x: u32) vs s E :
     EncodeUInt32 #x #l @ s ; E
   {{{ RET #(); l ↦∗[byteT] (b2val <$> u32_le x) }}}.
 Proof.
+  rewrite u32_le_unseal /u32_le_def.
   iIntros (Φ) "(>Hl & %) HΦ".
   unfold EncodeUInt32.
   repeat (destruct vs; simpl in H; [ congruence | ]).
@@ -183,6 +185,7 @@ Definition u64_le_bytes (x: u64) : list val :=
 
 Lemma u64_le_bytes_length x : length (u64_le_bytes x) = w64_bytes.
 Proof.
+  rewrite /u64_le_bytes u64_le_unseal /u64_le_def.
   rewrite length_fmap //.
 Qed.
 
@@ -191,6 +194,7 @@ Theorem wp_EncodeUInt64 (l: loc) (x: u64) vs stk E :
     EncodeUInt64 #x #l @ stk ; E
   {{{ RET #(); l ↦∗[byteT] (b2val <$> u64_le x) }}}.
 Proof.
+  rewrite u64_le_unseal /u64_le_def.
   iIntros (Φ) "(>Hl & %) HΦ".
   unfold EncodeUInt64.
   repeat (destruct vs; simpl in H; [ congruence | ]).
@@ -281,11 +285,12 @@ Proof.
   { iPureIntro.
     rewrite length_take; lia. }
   iIntros "Henc".
-  change (Z.to_nat 8) with 8%nat.
-  iDestruct (array_app with "[$Henc $Hrest]") as "Htogether".
   iApply "HΦ".
-  iFrame.
+  change (Z.to_nat 8) with 8%nat.
   rewrite length_app length_drop u64_le_bytes_length.
+  rewrite /u64_le_bytes u64_le_unseal /u64_le_def.
+  iDestruct (array_app with "[$Henc $Hrest]") as "Htogether".
+  iFrame.
   iPureIntro.
   lia.
 Qed.
@@ -295,6 +300,7 @@ Definition u32_le_bytes (x: u32) : list val :=
 
 Lemma u32_le_bytes_length x : length (u32_le_bytes x) = w32_bytes.
 Proof.
+  rewrite /u32_le_bytes u32_le_unseal /u32_le_def.
   rewrite length_fmap //.
 Qed.
 
@@ -316,11 +322,12 @@ Proof.
   { iPureIntro.
     rewrite length_take; lia. }
   iIntros "Henc".
-  change (Z.to_nat 4) with 4%nat.
-  iDestruct (array_app with "[$Henc $Hrest]") as "Htogether".
   iApply "HΦ".
-  iFrame.
+  change (Z.to_nat 4) with 4%nat.
   rewrite length_app length_drop u32_le_bytes_length.
+  rewrite /u32_le_bytes u32_le_unseal /u32_le_def.
+  iDestruct (array_app with "[$Henc $Hrest]") as "Htogether".
+  iFrame.
   iPureIntro.
   lia.
 Qed.
@@ -522,6 +529,7 @@ Theorem decode_encode (x : w32) :
 Proof.
   apply word.unsigned_inj.
   pose proof (u32_le_to_word x).
+  rewrite u32_le_unseal /u32_le_def in H.
   cbv [le_to_u32 u32_le map LittleEndian.combine LittleEndian.split length Datatypes.HList.tuple.to_list Datatypes.HList.tuple.of_list PrimitivePair.pair._1 PrimitivePair.pair._2] in H.
   rewrite Z.shiftl_0_l in H.
   rewrite Z.lor_0_r in H.
@@ -565,6 +573,7 @@ Theorem decode_encode64 (x : w64) :
 Proof.
   apply word.unsigned_inj.
   pose proof (u64_le_to_word x).
+  rewrite u64_le_unseal /u64_le_def in H.
   cbv [le_to_u64 u64_le map LittleEndian.combine LittleEndian.split length Datatypes.HList.tuple.to_list Datatypes.HList.tuple.of_list PrimitivePair.pair._1 PrimitivePair.pair._2] in H.
   rewrite Z.shiftl_0_l in H.
   rewrite Z.lor_0_r in H.
@@ -597,6 +606,7 @@ Theorem wp_DecodeUInt32 (l: loc) q (x: u32) s E :
     DecodeUInt32 #l @ s ; E
   {{{ RET #x; l ↦∗[byteT]{q} (b2val <$> u32_le x) }}}.
 Proof.
+  rewrite u32_le_unseal /u32_le_def.
   iIntros (Φ) ">Hl HΦ".
   cbv [u32_le fmap list_fmap LittleEndian.split HList.tuple.to_list List.map].
   rewrite ?array_cons ?loc_add_assoc.
@@ -620,6 +630,7 @@ Theorem wp_DecodeUInt64 (l: loc) q (x: u64) s E :
     DecodeUInt64 #l @ s ; E
   {{{ RET #x; l ↦∗[byteT]{q} (b2val <$> u64_le x) }}}.
 Proof.
+  rewrite u64_le_unseal /u64_le_def.
   iIntros (Φ) ">Hl HΦ".
   cbv [u64_le fmap list_fmap LittleEndian.split HList.tuple.to_list List.map].
   rewrite ?array_cons ?loc_add_assoc.
@@ -681,7 +692,8 @@ Proof.
   wp_apply (wp_UInt64Get with "[$Hs]").
   { iPureIntro.
     rewrite Htake8.
-    rewrite take_app_le; len; eauto. }
+    rewrite take_app_length'; [done|].
+    by rewrite u64_le_bytes_length. }
   iIntros "Hs".
   rewrite -Htake8.
   iApply "HΦ".
@@ -694,7 +706,7 @@ Proof.
   apply (f_equal length) in Htake8.
   autorewrite with len in Htake8.
   rewrite Htake8.
-  auto.
+  by rewrite u64_le_bytes_length.
 Qed.
 
 Theorem wp_UInt64Get' stk E s q (x: u64) :

--- a/src/program_proof/bank/bank_proof.v
+++ b/src/program_proof/bank/bank_proof.v
@@ -217,7 +217,8 @@ Proof.
   wp_apply wp_StringToBytes.
   iIntros (?) "Hsl".
   iDestruct (own_slice_to_small with "Hsl") as "Hsl".
-  wp_apply (wp_ReadInt with "[$]").
+  wp_apply (wp_ReadInt [] with "[Hsl]").
+  { by list_simplifier. }
   iIntros. wp_pures. iModIntro. by iApply "HΦ".
 Qed.
 

--- a/src/program_proof/cachekv/proof.v
+++ b/src/program_proof/cachekv/proof.v
@@ -44,8 +44,7 @@ Lemma encode_cacheValue_inj v l v' l' :
 Proof.
   intros H.
   rewrite /encode_cacheValue in H.
-  apply app_inj_1 in H.
-  2:{ done. }
+  apply app_inj_1 in H; [|len].
   destruct H as [H1 H2].
   split.
   { done. }

--- a/src/program_proof/ctrexample/server.v
+++ b/src/program_proof/ctrexample/server.v
@@ -337,9 +337,8 @@ Proof using Type*.
         apply nil_length_inv in HslSize.
         rewrite HslSize in Hbad.
         apply has_encoding_length in Hbad.
-        Transparent u64_le.
-        simpl in Hbad.
-        lia.
+        rewrite encoded_length_singleton u64_le_length in Hbad.
+        simpl in Hbad. lia.
       }
       iFrame.
       done.

--- a/src/program_proof/examples/async_mem_alloc_inode_proof.v
+++ b/src/program_proof/examples/async_mem_alloc_inode_proof.v
@@ -178,7 +178,9 @@ Proof.
   split_and!.
   - rewrite /inode.wf /=.
     cbv; congruence.
-  - reflexivity.
+  - list_simplifier.
+    rewrite /block_encodes /has_encoding /marshal_proof.encode /marshal_proof.encode1.
+    by rewrite ?u64_le_unseal.
   - reflexivity.
 Qed.
 

--- a/src/program_proof/examples/inode_proof.v
+++ b/src/program_proof/examples/inode_proof.v
@@ -160,7 +160,9 @@ Proof.
   split_and!.
   - rewrite /inode.wf /=.
     cbv; congruence.
-  - reflexivity.
+  - list_simplifier.
+    rewrite /block_encodes /has_encoding /marshal_proof.encode /marshal_proof.encode1.
+    by rewrite ?u64_le_unseal.
   - reflexivity.
 Qed.
 

--- a/src/program_proof/map_marshal_proof.v
+++ b/src/program_proof/map_marshal_proof.v
@@ -115,7 +115,7 @@ Local Definition encode_byte_maplist (l:list (u64 * list u8)) : list u8 :=
 
 Local Lemma encode_byte_maplist_cons k data l :
   encode_byte_maplist ((k, data)::l) = (u64_le k) ++ (u64_le (uint.Z (length data))) ++ data ++ encode_byte_maplist l.
-Proof. done. Qed.
+Proof. by list_simplifier. Qed.
 
 Local Definition has_partial_byte_map_encoding (enc:list u8) (fullsize: u64) (m:gmap u64 (list u8)) : Prop :=
   ∃ l,
@@ -161,7 +161,7 @@ Proof.
     split; first by apply NoDup_nil_2.
     rewrite map_zip_with_empty_r.
     split; first by apply list_to_map_nil.
-    do 2 rewrite -size_dom. rewrite -Hkvs_dom size_dom. done. }
+    do 2 rewrite -size_dom. rewrite -Hkvs_dom size_dom. by list_simplifier. }
   { (* core loop *)
      clear Φ s' mptr. iIntros (k v kvs_todo kvs_done Φ) "!# [HI %Hk] HΦ". iNamed "HI". wp_pures.
      wp_load. wp_apply (wp_WriteInt with "Hs"). iIntros (s') "Hs". wp_store. clear s.
@@ -276,7 +276,7 @@ Local Definition encode_u64_maplist (l:list (u64 * u64)) : list u8 :=
 
 Local Lemma encode_u64_maplist_cons k data l :
   encode_u64_maplist ((k, data)::l) = (u64_le k) ++ (u64_le data) ++ encode_u64_maplist l.
-Proof. done. Qed.
+Proof. by list_simplifier. Qed.
 
 Local Definition has_partial_u64_map_encoding (enc:list u8) (fullsize: u64) (m:gmap u64 u64) : Prop :=
   ∃ l,
@@ -321,7 +321,7 @@ Proof.
     exists [].
     split; first by apply NoDup_nil_2.
     split; first by apply list_to_map_nil.
-    done. }
+    by list_simplifier. }
   { (* core loop *)
      clear Φ s' mptr. iIntros (k v mtodo mdone Φ) "!# [HI %Hk] HΦ". iNamed "HI". wp_pures.
      wp_load. wp_apply (wp_WriteInt with "Hs"). iIntros (s') "Hs". wp_store. clear s.
@@ -345,6 +345,7 @@ Proof.
      - rewrite list_to_map_snoc //. rewrite Hls //.
      - rewrite Henc. rewrite -!app_assoc. repeat f_equal.
        rewrite /encode_u64_maplist flat_map_app. f_equal.
+       by list_simplifier.
   }
   iIntros "[Hkvs_map HI]". iNamed "HI".
   wp_load. iApply "HΦ". iFrame.

--- a/src/program_proof/map_string_marshal_proof.v
+++ b/src/program_proof/map_string_marshal_proof.v
@@ -66,7 +66,7 @@ Proof.
     split; first by apply NoDup_nil_2.
     rewrite map_zip_with_empty_r.
     split; first by apply list_to_map_nil.
-    rewrite Hmsize. done. }
+    rewrite Hmsize. by list_simplifier. }
   { (* core loop *)
      clear Φ s' mptr. iIntros (k v m_todo m_done Φ) "!# [HI %Hk] HΦ". iNamed "HI". wp_pures.
      wp_load. wp_apply (wp_WriteInt with "Hs"). iIntros (?) "Hs". wp_store. clear s.

--- a/src/program_proof/marshal_proof.v
+++ b/src/program_proof/marshal_proof.v
@@ -233,7 +233,7 @@ Proof.
   iFrame "Hs". iModIntro.
   rewrite encoded_length_app1 u64_le_length.
   iSplitR; first by iPureIntro; len.
-  iSplitR; first by iPureIntro; len.
+  iSplitR; first by iPureIntro; word.
   iSplitL "Hoff".
   { iExactEq "Hoff".
     rewrite /named.
@@ -243,6 +243,8 @@ Proof.
   - subst off.
     apply has_encoding_app; auto.
     eapply has_encoding_from_app; eauto.
+    rewrite /encode /encode1.
+    by list_simplifier.
 Qed.
 
 Theorem wp_Enc__PutInt32 stk E enc_v sz r (x:u32) remaining :
@@ -288,6 +290,8 @@ Proof.
   - subst off.
     apply has_encoding_app; auto.
     eapply has_encoding_from_app; eauto.
+    rewrite /encode /encode1.
+    by list_simplifier.
 Qed.
 
 Local Lemma wp_bool2byte stk E (x:bool) :
@@ -513,7 +517,9 @@ Proof.
   rewrite encode_cons.
   eapply has_encoding_from_app.
   rewrite -app_assoc.
-  rewrite drop_app_ge //.
+  rewrite ?/encode ?/encode1.
+  rewrite drop_app_ge //; len.
+  by list_simplifier.
 Qed.
 
 Theorem wp_Dec__GetInt32 stk E dec_v (x: u32) r s q data :
@@ -556,7 +562,9 @@ Proof.
   rewrite encode_cons.
   eapply has_encoding_from_app.
   rewrite -app_assoc.
-  rewrite drop_app_ge //.
+  rewrite ?/encode ?/encode1.
+  rewrite drop_app_ge //; len.
+  by list_simplifier.
 Qed.
 
 Theorem wp_Dec__GetBool stk E dec_v (x: bool) r s q data :

--- a/src/program_proof/marshal_proof.v
+++ b/src/program_proof/marshal_proof.v
@@ -231,8 +231,7 @@ Proof.
   rewrite -!fmap_app.
   iSplitR; first eauto.
   iFrame "Hs". iModIntro.
-  rewrite encoded_length_app1.
-  change (length (encode1 (EncUInt64 x))) with 8%nat.
+  rewrite encoded_length_app1 u64_le_length.
   iSplitR; first by iPureIntro; len.
   iSplitR; first by iPureIntro; len.
   iSplitL "Hoff".
@@ -276,7 +275,7 @@ Proof.
   rewrite -!fmap_app.
   iSplitR; first eauto.
   iFrame "Hs". iModIntro.
-  rewrite encoded_length_app1.
+  rewrite encoded_length_app1 u32_le_length.
   change (length (encode1 _)) with 4%nat.
   iSplitR; first by iPureIntro; len.
   iSplitR; first by iPureIntro; len.
@@ -493,7 +492,8 @@ Proof.
   { eapply has_encoding_inv in Henc as [extra [Henc ?]].
     rewrite -fmap_drop -fmap_take.
     rewrite Henc.
-    reflexivity. }
+    rewrite encode_cons -(assoc_L (++)) take_app_length'; [done|].
+    by rewrite u64_le_length. }
   iIntros "Hs2".
   iDestruct (slice.own_slice_small_take_drop_1 with "[$Hs1 $Hs2]") as "Hs"; first by word.
   iApply "HΦ".
@@ -502,7 +502,7 @@ Proof.
   pose proof (has_encoding_length Henc).
   autorewrite with len in H.
   rewrite encoded_length_cons in H.
-  change (length (encode1 _)) with 8%nat in H.
+  rewrite u64_le_length in H.
   iSplitR; first iPureIntro.
   { word. }
   iPureIntro.
@@ -534,7 +534,8 @@ Proof.
   { eapply has_encoding_inv in Henc as [extra [Henc ?]].
     rewrite -fmap_drop -fmap_take.
     rewrite Henc.
-    reflexivity. }
+    rewrite encode_cons -(assoc_L (++)) take_app_length'; [done|].
+    by rewrite u32_le_length. }
   iIntros "Hs2".
   iDestruct (slice.own_slice_small_take_drop_1 with "[$Hs1 $Hs2]") as "Hs"; first by word.
   iApply "HΦ".
@@ -543,6 +544,7 @@ Proof.
   pose proof (has_encoding_length Henc).
   autorewrite with len in H.
   rewrite encoded_length_cons in H.
+  rewrite u32_le_length in H.
   change (length (encode1 _)) with 4%nat in H.
   iSplitR; first iPureIntro.
   { word. }

--- a/src/program_proof/marshal_stateless_proof.v
+++ b/src/program_proof/marshal_stateless_proof.v
@@ -6,17 +6,26 @@ From Perennial.goose_lang.lib Require Import encoding.
 From Perennial.program_proof Require Import proof_prelude std_proof.
 From Perennial.goose_lang.lib Require Import slice.typed_slice.
 
+(* Requires that l = x ++ tail, but is associated with some automation so the tail
+   can be determined to be empty when `l = x`. *)
+Class MarshalEqTail (l x tail: list w8) : Prop := marshal_eq : l = x ++ tail.
+Global Instance marshal_eq_diag x : MarshalEqTail x x [].
+Proof. rewrite /MarshalEq app_nil_r //. Qed.
+Global Hint Extern 0 (MarshalEqTail _ _ _) => (reflexivity) : typeclass_instances.
+(* This says that the [tail] is an output whereas [l] and [x] are inputs. *)
+Global Hint Mode MarshalEqTail ! ! - : typeclass_instances.
+
 Section goose_lang.
 Context `{hG: heapGS Σ, !ffi_semantics _ _, !ext_types _}.
 
 Implicit Types (v:val).
 
-Theorem wp_ReadInt tail s q x :
-  {{{ own_slice_small s byteT q (u64_le x ++ tail) }}}
+Theorem wp_ReadInt s q l x tail {H:MarshalEqTail l (u64_le x) tail} :
+  {{{ own_slice_small s byteT q l }}}
     ReadInt (slice_val s)
   {{{ s', RET (#x, slice_val s'); own_slice_small s' byteT q tail }}}.
 Proof.
-  iIntros (Φ) "Hs HΦ". wp_rec.
+  iIntros (Φ) "Hs HΦ". wp_rec. rewrite H.
   wp_apply (wp_UInt64Get_unchanged with "Hs").
   { rewrite /list.untype fmap_app take_app_length' //. len. }
   iIntros "Hs".

--- a/src/program_proof/marshal_stateless_proof.v
+++ b/src/program_proof/marshal_stateless_proof.v
@@ -11,7 +11,7 @@ Context `{hG: heapGS Σ, !ffi_semantics _ _, !ext_types _}.
 
 Implicit Types (v:val).
 
-Theorem wp_ReadInt s q x tail :
+Theorem wp_ReadInt tail s q x :
   {{{ own_slice_small s byteT q (u64_le x ++ tail) }}}
     ReadInt (slice_val s)
   {{{ s', RET (#x, slice_val s'); own_slice_small s' byteT q tail }}}.
@@ -26,7 +26,7 @@ Proof.
   rewrite drop_app_length'; [done|len].
 Qed.
 
-Theorem wp_ReadInt32 s q (x: u32) tail :
+Theorem wp_ReadInt32 tail s q (x: u32) :
   {{{ own_slice_small s byteT q (u32_le x ++ tail) }}}
     ReadInt32 (slice_val s)
   {{{ s', RET (#x, slice_val s'); own_slice_small s' byteT q tail }}}.

--- a/src/program_proof/marshal_stateless_proof.v
+++ b/src/program_proof/marshal_stateless_proof.v
@@ -18,11 +18,12 @@ Theorem wp_ReadInt s q x tail :
 Proof.
   iIntros (Φ) "Hs HΦ". wp_rec.
   wp_apply (wp_UInt64Get_unchanged with "Hs").
-  { rewrite /list.untype fmap_app take_app_length' //. }
+  { rewrite /list.untype fmap_app take_app_length' //. len. }
   iIntros "Hs".
   wp_apply (wp_SliceSkip_small with "Hs").
   { len. }
-  iIntros (s') "Hs'". wp_pures. iApply "HΦ". done.
+  iIntros (s') "Hs'". wp_pures. iApply "HΦ".
+  rewrite drop_app_length'; [done|len].
 Qed.
 
 Theorem wp_ReadInt32 s q (x: u32) tail :
@@ -32,11 +33,12 @@ Theorem wp_ReadInt32 s q (x: u32) tail :
 Proof.
   iIntros (Φ) "Hs HΦ". wp_rec.
   wp_apply (wp_UInt32Get_unchanged with "Hs").
-  { rewrite /list.untype fmap_app take_app_length' //. }
+  { rewrite /list.untype fmap_app take_app_length' //. len. }
   iIntros "Hs".
   wp_apply (wp_SliceSkip_small with "Hs").
   { len. }
-  iIntros (s') "Hs'". wp_pures. iApply "HΦ". done.
+  iIntros (s') "Hs'". wp_pures. iApply "HΦ".
+  rewrite drop_app_length'; [done|len].
 Qed.
 
 Theorem wp_ReadBytes s q (len: u64) (head tail : list u8) :
@@ -305,7 +307,8 @@ Proof.
   rewrite /own_slice. iExactEq "Hsl". repeat f_equal.
   rewrite /list.untype fmap_app. f_equal.
   { rewrite take_app_length' //. len. }
-  rewrite drop_ge //. len.
+  rewrite drop_ge; [|len].
+  by list_simplifier.
 Qed.
 
 Theorem wp_WriteInt32 s x (vs : list u8) :
@@ -333,7 +336,8 @@ Proof.
   rewrite /own_slice. iExactEq "Hsl". repeat f_equal.
   rewrite /list.untype fmap_app. f_equal.
   { rewrite take_app_length' //. len. }
-  rewrite drop_ge //. len.
+  rewrite drop_ge; [|len].
+  by list_simplifier.
 Qed.
 
 Theorem wp_WriteBytes s (vs : list u8) data_sl q (data : list u8) :

--- a/src/program_proof/tulip/cmd.v
+++ b/src/program_proof/tulip/cmd.v
@@ -917,7 +917,9 @@ Section encode.
     not (encode_lsn_icommand lsn icmd []).
   Proof.
     intros Henc.
-    by destruct Henc as (cmddata & Happ & _).
+    destruct Henc as (cmddata & Happ & _).
+    apply (f_equal length) in Happ.
+    revert Happ. len.
   Qed.
 
 End encode.

--- a/src/program_proof/tulip/encode.v
+++ b/src/program_proof/tulip/encode.v
@@ -23,7 +23,7 @@ Proof.
   rewrite /encode_u64s_xlen.
   intros Hlen.
   apply (serialize_length_inv u64_le).
-  { intros x. by destruct (nil_or_length_pos (u64_le x)). }
+  { intros x. len. }
   done.
 Qed.
 
@@ -39,6 +39,7 @@ Qed.
 
 Definition encode_string (x : byte_string) : list u8 :=
   u64_le (U64 (length x)) ++ x.
+Hint Unfold encode_string : len.
 
 Definition encode_strings_xlen (xs : list byte_string) : list u8 :=
   serialize encode_string xs.
@@ -61,7 +62,7 @@ Proof.
   rewrite /encode_strings_xlen.
   intros Hlen.
   apply (serialize_length_inv encode_string).
-  { intros x. by destruct (nil_or_length_pos (encode_string x)). }
+  { intros x. destruct (nil_or_length_pos (encode_string x)); len. }
   done.
 Qed.
 
@@ -83,6 +84,7 @@ Definition encode_dbval (x : dbval) : list u8 :=
 
 Definition encode_dbmod (x : dbmod) : list u8 :=
   encode_string x.1 ++ encode_dbval x.2.
+Hint Unfold encode_dbmod : len.
 
 Definition encode_dbmods_xlen (xs : list dbmod) : list u8 :=
   serialize encode_dbmod xs.
@@ -105,7 +107,7 @@ Proof.
   rewrite /encode_dbmods_xlen.
   intros Hlen.
   apply (serialize_length_inv encode_dbmod).
-  { intros x. by destruct (nil_or_length_pos (encode_dbmod x)). }
+  { intros x. destruct (nil_or_length_pos (encode_dbmod x)); len. }
   done.
 Qed.
 

--- a/src/program_proof/tulip/paxos/program/decode_request.v
+++ b/src/program_proof/tulip/paxos/program/decode_request.v
@@ -41,7 +41,8 @@ Section decode_request.
     (*@ }                                                                       @*)
     wp_apply (wp_ReadInt with "Hbs").
     iIntros (p1) "Hbs".
-    wp_apply (wp_ReadInt with "Hbs").
+    wp_apply (wp_ReadInt [] with "[Hbs]").
+    { by list_simplifier. }
     iIntros (p2) "Hbs".
     wp_pures.
     by iApply "HΦ".

--- a/src/program_proof/tulip/paxos/program/decode_response.v
+++ b/src/program_proof/tulip/paxos/program/decode_response.v
@@ -84,7 +84,8 @@ Section decode_response.
     iIntros (p1) "Hbs".
     wp_apply (wp_ReadInt with "Hbs").
     iIntros (p2) "Hbs".
-    wp_apply (wp_ReadInt with "Hbs").
+    wp_apply (wp_ReadInt [] with "[Hbs]").
+    { by list_simplifier. }
     iIntros (p3) "Hbs".
     wp_pures.
     by iApply "HΦ".

--- a/src/program_proof/tulip/paxos/program/resume.v
+++ b/src/program_proof/tulip/paxos/program/resume.v
@@ -309,6 +309,7 @@ Section resume.
         (*@                                                                         @*)
         wp_apply (wp_ReadInt with "Hdata").
         iIntros (q') "Hdata".
+        iEval list_simplifier in "Hdata".
         wp_apply (wp_ReadInt with "Hdata").
         iIntros (bs1) "Hdata".
         wp_apply (wp_ReadInt with "Hdata").
@@ -371,6 +372,7 @@ Section resume.
         (*@                                                                         @*)
         wp_apply (wp_ReadInt with "Hdata").
         iIntros (q') "Hdata".
+        iEval list_simplifier in "Hdata".
         wp_apply (wp_ReadInt with "Hdata").
         iIntros (bs1) "Hdata".
         wp_apply (wp_DecodeStrings with "Hdata").

--- a/src/program_proof/tulip/paxos/recovery.v
+++ b/src/program_proof/tulip/paxos/recovery.v
@@ -140,6 +140,9 @@ Definition encode_paxos_accept (lsn : u64) (ents : ledger) : list u8 :=
 Definition encode_paxos_expand (lsn : u64) : list u8 :=
   u64_le (U64 5) ++ u64_le lsn.
 
+Hint Unfold encode_paxos_extend encode_paxos_append encode_paxos_prepare
+  encode_paxos_advance encode_paxos_accept encode_paxos_expand : len.
+
 Definition encode_paxos_cmd c :=
   match c with
   | CmdPaxosExtend ents => encode_paxos_extend ents
@@ -161,7 +164,9 @@ Proof.
   destruct cmds as [| c tl]; first done.
   exfalso.
   rewrite /encode_paxos_cmds /= serialize_cons in Henc.
-  by destruct c.
+  apply (f_equal length) in Henc.
+  revert Henc.
+  destruct c; simpl in *; len.
 Qed.
 
 Lemma encode_paxos_cmds_snoc cmds cmd :

--- a/src/program_proof/tulip/program/gcoord/decode.v
+++ b/src/program_proof/tulip/program/gcoord/decode.v
@@ -108,7 +108,8 @@ Section decode.
     iIntros (p1) "Hbs".
     wp_apply (wp_ReadInt with "Hbs").
     iIntros (p2) "Hbs".
-    wp_apply (wp_ReadInt with "Hbs").
+    wp_apply (wp_ReadInt [] with "[Hbs]").
+    { by list_simplifier. }
     iIntros (p3) "Hbs".
     wp_pures.
     by iApply "HΦ".
@@ -138,7 +139,8 @@ Section decode.
     iIntros (p1) "Hbs".
     wp_apply (wp_ReadInt with "Hbs").
     iIntros (p2) "Hbs".
-    wp_apply (wp_ReadInt with "Hbs").
+    wp_apply (wp_ReadInt [] with "[Hbs]").
+    { by list_simplifier. }
     iIntros (p3) "Hbs".
     wp_pures.
     by iApply "HΦ".
@@ -172,7 +174,8 @@ Section decode.
     iIntros (p2) "Hbs".
     wp_apply (wp_ReadInt with "Hbs").
     iIntros (p3) "Hbs".
-    wp_apply (wp_ReadInt with "Hbs").
+    wp_apply (wp_ReadInt [] with "[Hbs]").
+    { by list_simplifier. }
     iIntros (p4) "Hbs".
     wp_pures.
     by iApply "HΦ".
@@ -206,7 +209,8 @@ Section decode.
     iIntros (p2) "Hbs".
     wp_apply (wp_ReadInt with "Hbs").
     iIntros (p3) "Hbs".
-    wp_apply (wp_ReadInt with "Hbs").
+    wp_apply (wp_ReadInt [] with "[Hbs]").
+    { by list_simplifier. }
     iIntros (p4) "Hbs".
     wp_pures.
     by iApply "HΦ".
@@ -232,7 +236,8 @@ Section decode.
     (*@ }                                                                       @*)
     wp_apply (wp_ReadInt with "Hbs").
     iIntros (p1) "Hbs".
-    wp_apply (wp_ReadInt with "Hbs").
+    wp_apply (wp_ReadInt [] with "[Hbs]").
+    { by list_simplifier. }
     iIntros (p2) "Hbs".
     wp_pures.
     by iApply "HΦ".
@@ -309,7 +314,8 @@ Section decode.
       iIntros (bs6P) "Hbs".
       wp_apply (wp_ReadInt with "Hbs").
       iIntros (bs7P) "Hbs".
-      wp_apply (wp_ReadInt with "Hbs").
+      wp_apply (wp_ReadInt [] with "[Hbs]").
+      { by list_simplifier. }
       iIntros (bs8P) "Hbs".
       wp_pures.
       destruct b; wp_pures.
@@ -338,7 +344,8 @@ Section decode.
     (*@ }                                                                       @*)
     wp_apply (wp_ReadInt with "Hbs").
     iIntros (p1) "Hbs".
-    wp_apply (wp_ReadInt with "Hbs").
+    wp_apply (wp_ReadInt [] with "[Hbs]").
+    { by list_simplifier. }
     iIntros (p2) "Hbs".
     wp_pures.
     by iApply "HΦ".
@@ -364,7 +371,8 @@ Section decode.
     (*@ }                                                                       @*)
     wp_apply (wp_ReadInt with "Hbs").
     iIntros (p1) "Hbs".
-    wp_apply (wp_ReadInt with "Hbs").
+    wp_apply (wp_ReadInt [] with "[Hbs]").
+    { by list_simplifier. }
     iIntros (p2) "Hbs".
     wp_pures.
     by iApply "HΦ".

--- a/src/program_proof/tulip/program/gcoord/encode.v
+++ b/src/program_proof/tulip/program/gcoord/encode.v
@@ -79,6 +79,7 @@ Section encode.
     iFrame.
     iPureIntro.
     rewrite /= /encode_fast_prepare_req /encode_fast_prepare_req_xkind.
+    list_simplifier.
     by eauto 10.
   Qed.
 
@@ -124,6 +125,7 @@ Section encode.
     iFrame.
     iPureIntro.
     rewrite /= /encode_validate_req /encode_validate_req_xkind.
+    list_simplifier.
     by eauto 10.
   Qed.
 
@@ -256,7 +258,9 @@ Section encode.
     wp_pures.
     rewrite uint_nat_W64_0 replicate_0 app_nil_l -app_assoc.
     iApply "HΦ".
-    by iFrame.
+    iFrame.
+    rewrite /encode_txnreq /encode_inquire_req /encode_inquire_req_xkind /encode_ts_rank.
+    by list_simplifier.
   Qed.
 
   Theorem wp_EncodeTxnRefreshRequest (ts : u64) (rank : u64) :

--- a/src/program_proof/tulip/program/replica/decode.v
+++ b/src/program_proof/tulip/program/replica/decode.v
@@ -168,7 +168,8 @@ Section decode.
     (*@ }                                                                       @*)
     wp_apply (wp_ReadInt with "Hbs").
     iIntros (bs1P) "Hbs".
-    wp_apply (wp_ReadInt with "Hbs").
+    wp_apply (wp_ReadInt [] with "[Hbs]").
+    { by list_simplifier. }
     iIntros (bs2P) "Hbs".
     wp_pures.
     by iApply "HΦ".
@@ -194,7 +195,8 @@ Section decode.
     (*@ }                                                                       @*)
     wp_apply (wp_ReadInt with "Hbs").
     iIntros (bs1P) "Hbs".
-    wp_apply (wp_ReadInt with "Hbs").
+    wp_apply (wp_ReadInt [] with "[Hbs]").
+    { by list_simplifier. }
     iIntros (bs2P) "Hbs".
     wp_pures.
     by iApply "HΦ".
@@ -220,7 +222,8 @@ Section decode.
     (*@ }                                                                       @*)
     wp_apply (wp_ReadInt with "Hbs").
     iIntros (bs1P) "Hbs".
-    wp_apply (wp_ReadInt with "Hbs").
+    wp_apply (wp_ReadInt [] with "[Hbs]").
+    { by list_simplifier. }
     iIntros (bs2P) "Hbs".
     wp_pures.
     by iApply "HΦ".
@@ -235,13 +238,17 @@ Section decode.
     iIntros (bs Φ) "Hbs HΦ".
     wp_rec.
 
-    wp_apply (wp_ReadInt with "Hbs").
+    wp_apply (wp_ReadInt with "[Hbs]").
+    { subst bs. rewrite /encode_inquire_req_xkind /encode_ts_rank.
+      by list_simplifier. }
     iIntros (bs1P) "Hbs".
     wp_apply (wp_ReadInt with "Hbs").
     iIntros (bs2P) "Hbs".
     wp_apply (wp_ReadInt with "Hbs").
     iIntros (bs3P) "Hbs".
-    wp_apply (wp_ReadInt with "Hbs").
+    wp_pures.
+    wp_apply (wp_ReadInt [] with "[Hbs]").
+    { by list_simplifier. }
     iIntros (bs4P) "Hbs".
     wp_pures.
     by iApply "HΦ".
@@ -267,7 +274,8 @@ Section decode.
     (*@ }                                                                       @*)
     wp_apply (wp_ReadInt with "Hbs").
     iIntros (bs1P) "Hbs".
-    wp_apply (wp_ReadInt with "Hbs").
+    wp_apply (wp_ReadInt [] with "[Hbs]").
+    { by list_simplifier. }
     iIntros (bs2P) "Hbs".
     wp_pures.
     by iApply "HΦ".
@@ -320,7 +328,9 @@ Section decode.
     (*@         Timestamp     : ts,                                             @*)
     (*@     }                                                                   @*)
     (*@ }                                                                       @*)
-    wp_apply (wp_ReadInt with "Hbs").
+    wp_apply (wp_ReadInt [] with "[Hbs]").
+    { subst bs. rewrite /encode_abort_req_xkind.
+      by list_simplifier. }
     iIntros (bs1P) "Hbs".
     wp_pures.
     by iApply "HΦ".

--- a/src/program_proof/tulip/program/replica/encode.v
+++ b/src/program_proof/tulip/program/replica/encode.v
@@ -45,7 +45,9 @@ Section encode.
     wp_pures.
     rewrite uint_nat_W64_0 replicate_0 app_nil_l -!app_assoc.
     iApply "HΦ".
-    by iFrame.
+    iFrame.
+    rewrite /encode_txnresp /encode_read_resp /encode_read_resp_xkind /encode_string /encode_dbpver.
+    by list_simplifier.
   Qed.
 
   Theorem wp_EncodeTxnFastPrepareResponse (ts : u64) (rid : u64) (res : rpres) :
@@ -289,15 +291,17 @@ Section encode.
       iApply "HΦ".
       iFrame.
       iPureIntro.
-      rewrite /= /encode_inquire_resp /encode_inquire_resp_xkind.
-      by eauto.
+      rewrite /= /encode_inquire_resp /encode_inquire_resp_xkind /encode_ppsl.
+      repeat (esplit; try done).
+      by list_simplifier.
     }
     rewrite uint_nat_W64_0 replicate_0 app_nil_l -!app_assoc.
     iApply "HΦ".
     iFrame.
     iPureIntro.
-    rewrite /= /encode_inquire_resp /encode_inquire_resp_xkind.
-    by eauto.
+    rewrite /= /encode_inquire_resp /encode_inquire_resp_xkind /encode_ppsl.
+    esplit; try done.
+    by list_simplifier.
   Qed.
 
   Theorem wp_EncodeTxnCommitResponse (ts : u64) (res : rpres) :

--- a/src/program_proof/tulip/program/replica/replica_resume.v
+++ b/src/program_proof/tulip/program/replica/replica_resume.v
@@ -624,7 +624,8 @@ Section program.
         iIntros (bs2P) "Hdata".
         wp_apply (wp_ReadInt with "Hdata").
         iIntros (bs3P) "Hdata".
-        wp_apply (wp_ReadInt with "Hdata").
+        wp_apply (wp_ReadInt with "[Hdata]").
+        { by list_simplifier. }
         iIntros (bs4P) "Hdata".
         wp_apply (wp_ReadBool with "Hdata").
         iIntros (dec bs5P) "[%Hdec Hdata]".

--- a/src/program_proof/tulip/program/txnlog/txnlog.v
+++ b/src/program_proof/tulip/program/txnlog/txnlog.v
@@ -172,7 +172,8 @@ Section program.
       wp_apply (wp_ReadInt with "Hbs").
       iIntros (p1) "Hbs".
       wp_pures.
-      wp_apply (wp_ReadInt with "Hbs").
+      wp_apply (wp_ReadInt [] with "[Hbs]").
+      { by list_simplifier. }
       iIntros (p2) "Hbs".
       wp_pures.
       iSpecialize ("HΦ" $! (CmdAbort tid) _ Slice.nil).

--- a/src/program_proof/tulip/program/util/encode_ints.v
+++ b/src/program_proof/tulip/program/util/encode_ints.v
@@ -37,7 +37,10 @@ Section program.
                  let l := encode_u64s_xlen (take (uint.nat i) ns) in
                 "HdataP" ∷ dataP ↦[slice.T byteT] px ∗
                 "Hdata"  ∷ own_slice px byteT (DfracOwn 1) (bs ++ u64_le nW ++ l))%I.
-    wp_apply (wp_forSlice P with "[] [$Hns $Hp $HdataP]"); last first; first 1 last.
+    wp_apply (wp_forSlice P with "[] [$Hns Hp $HdataP]"); last first; first 1 last.
+    { replace (uint.nat (W64 0)) with (0%nat) by word.
+      rewrite /encode_u64s_xlen /serialize.serialize.
+      by list_simplifier. }
     { clear Φ.
       iIntros (i s Φ) "!> [HP %Hloop] HΦ".
       destruct Hloop as [Hi Hs].
@@ -49,7 +52,8 @@ Section program.
       iApply "HΦ".
       iFrame.
       rewrite uint_nat_word_add_S; last word.
-      by rewrite (take_S_r _ _ _ Hs) encode_u64s_xlen_snoc -app_assoc.
+      rewrite (take_S_r _ _ _ Hs) encode_u64s_xlen_snoc.
+      by list_simplifier.
     }
     iIntros "[HP Hns]".
     iNamed "HP".

--- a/src/program_proof/tulip/program/util/encode_kvmap.v
+++ b/src/program_proof/tulip/program/util/encode_kvmap.v
@@ -40,7 +40,9 @@ Section program.
                 "Hdata"  ∷ own_slice px byteT (DfracOwn 1) (bs ++ u64_le (W64 (size m)) ++ l) ∗
                 "%Hml"   ∷ ⌜ml ≡ₚ map_to_list mx⌝)%I.
     wp_apply (wp_MapIter_fold _ _ _ P with "Hm [-HΦ]").
-    { iExists _, []. rewrite map_to_list_empty. by iFrame. }
+    { iExists _, []. rewrite map_to_list_empty.
+      rewrite /encode_dbmods_xlen /serialize.serialize.
+      list_simplifier. by iFrame. }
     { clear Φ.
       iIntros (mx k v Φ) "!> [HP %Hk] HΦ".
       destruct Hk as [Hmxk Hmk].

--- a/src/program_proof/tulip/program/util/encode_kvmap_from_slice.v
+++ b/src/program_proof/tulip/program/util/encode_kvmap_from_slice.v
@@ -37,7 +37,10 @@ Section program.
                  let l := encode_dbmods_xlen (take (uint.nat i) xs) in
                 "HdataP" ∷ dataP ↦[slice.T byteT] px ∗
                 "Hdata"  ∷ own_slice px byteT (DfracOwn 1) (bs ++ u64_le nW ++ l))%I.
-    wp_apply (wp_forSlice P with "[] [$Hm $Hp $HdataP]"); last first; first 1 last.
+    wp_apply (wp_forSlice P with "[] [$Hm Hp $HdataP]"); last first; first 1 last.
+    { replace (uint.nat (W64 0)) with (0%nat) by word.
+      rewrite /encode_dbmods_xlen /serialize.serialize.
+      by list_simplifier. }
     { clear Φ.
       iIntros (i x Φ) "!> [HP %Hloop] HΦ".
       destruct Hloop as [Hi Hx].
@@ -49,7 +52,8 @@ Section program.
       iApply "HΦ".
       iFrame.
       rewrite uint_nat_word_add_S; last word.
-      by rewrite (take_S_r _ _ _ Hx) encode_dbmods_xlen_snoc -app_assoc.
+      rewrite (take_S_r _ _ _ Hx) encode_dbmods_xlen_snoc -app_assoc.
+      by list_simplifier.
     }
     iIntros "[HP Hm]".
     iNamed "HP".

--- a/src/program_proof/tulip/program/util/encode_strings.v
+++ b/src/program_proof/tulip/program/util/encode_strings.v
@@ -38,7 +38,10 @@ Section program.
                  let l := encode_strings_xlen (take (uint.nat i) strs) in
                 "HdataP" ∷ dataP ↦[slice.T byteT] px ∗
                 "Hdata"  ∷ own_slice px byteT (DfracOwn 1) (bs ++ u64_le nW ++ l))%I.
-    wp_apply (wp_forSlice P with "[] [$Hstrs $Hp $HdataP]"); last first; first 1 last.
+    wp_apply (wp_forSlice P with "[] [$Hstrs Hp $HdataP]"); last first; first 1 last.
+    { replace (uint.nat (W64 0)) with (0%nat) by word.
+      rewrite /encode_strings_xlen /serialize.serialize.
+      by list_simplifier. }
     { clear Φ.
       iIntros (i s Φ) "!> [HP %Hloop] HΦ".
       destruct Hloop as [Hi Hs].
@@ -50,7 +53,8 @@ Section program.
       iApply "HΦ".
       iFrame.
       rewrite uint_nat_word_add_S; last word.
-      by rewrite (take_S_r _ _ _ Hs) encode_strings_xlen_snoc -app_assoc.
+      rewrite (take_S_r _ _ _ Hs) encode_strings_xlen_snoc.
+      by list_simplifier.
     }
     iIntros "[HP Hstrs]".
     iNamed "HP".

--- a/src/program_proof/tutorial/kvservice/full_proof.v
+++ b/src/program_proof/tutorial/kvservice/full_proof.v
@@ -90,7 +90,8 @@ Lemma wp_DecodeUint64 sl x q :
 Proof.
   iIntros (Φ) "Hsl HΦ".
   wp_rec.
-  wp_apply (wp_ReadInt with "Hsl").
+  wp_apply (wp_ReadInt [] with "[Hsl]").
+  { by list_simplifier. }
   iIntros (?) "Hsl".
   wp_pures.
   by iApply "HΦ".

--- a/src/program_proof/tutorial/kvservice/proof.v
+++ b/src/program_proof/tutorial/kvservice/proof.v
@@ -90,7 +90,8 @@ Lemma wp_DecodeUint64 sl x q :
 Proof.
   iIntros (Φ) "Hsl HΦ".
   wp_rec.
-  wp_apply (wp_ReadInt with "Hsl").
+  wp_apply (wp_ReadInt [] with "[Hsl]").
+  { by list_simplifier. }
   iIntros (?) "Hsl".
   wp_pures.
   by iApply "HΦ".

--- a/src/program_proof/vrsm/apps/exactlyonce/proof.v
+++ b/src/program_proof/vrsm/apps/exactlyonce/proof.v
@@ -1800,11 +1800,12 @@ Proof.
   iIntros (?) "Hrep_sl _ Hpbck".
   iNamed 1.
   wp_pures.
-  wp_apply (wp_ReadInt with "[Hrep_sl]").
+  wp_apply (wp_ReadInt [] with "[Hrep_sl]").
   {
     simpl.
     unfold compute_reply.
-    iFrame.
+    rewrite /apply_op_and_get_reply /=.
+    by list_simplifier.
   }
   iIntros (?) "_".
   wp_pures.

--- a/src/program_proof/vrsm/apps/vkv/kv_vsm_proof.v
+++ b/src/program_proof/vrsm/apps/vkv/kv_vsm_proof.v
@@ -132,7 +132,7 @@ Proof.
   wp_store. clear sl.
   wp_load.
   iApply "HΦ". iModIntro. iFrame.
-  done.
+  by list_simplifier.
 Qed.
 
 Lemma wp_decodePutArgs enc_sl enc q (key val:byte_string) :

--- a/src/program_proof/vrsm/configservice/config_marshal_proof.v
+++ b/src/program_proof/vrsm/configservice/config_marshal_proof.v
@@ -84,7 +84,8 @@ Proof.
        the first (i+1) entries *)
     rewrite -app_assoc.
     f_equal.
-    replace (u64_le srv) with (concat (u64_le <$> [srv])) by done.
+    replace (u64_le srv) with (concat (u64_le <$> [srv])).
+    2: { by list_simplifier. }
     rewrite -concat_app.
     rewrite -fmap_app.
     replace (uint.nat (word.add i 1)) with (uint.nat i + 1)%nat by word.
@@ -115,6 +116,8 @@ Proof.
   {
     unfold P.
     iExists _; iFrame.
+    replace (uint.nat (W64 0)) with (0%nat) by word.
+    by list_simplifier.
   }
   iIntros "[HP Hconf_sl]".
   iNamed "HP".
@@ -230,7 +233,8 @@ Proof.
       rewrite Forall_fmap.
       apply Forall_true.
       intros.
-      done.
+      simpl.
+      len.
     }
     word.
   }

--- a/src/program_proof/vrsm/paxos/marshal_proof.v
+++ b/src/program_proof/vrsm/paxos/marshal_proof.v
@@ -58,7 +58,10 @@ Proof.
   iIntros (?) "Hsl". wp_store. wp_loadField.
   wp_load. wp_apply (wp_WriteBytes with "[$Hsl $Hstate_sl]").
   iIntros (?) "[Hsl _]". wp_store.
-  wp_load. iApply "HΦ". iFrame. iPureIntro. done.
+  wp_load. iApply "HΦ". iFrame. iPureIntro.
+  replace (uint.nat (W64 0)) with (0%nat) by word.
+  list_simplifier.
+  by rewrite /has_encoding.
 Qed.
 
 Lemma wp_Decode enc enc_sl (args:C) :
@@ -150,7 +153,8 @@ Proof.
   wp_rec. wp_apply wp_allocStruct; first by val_ty.
   iIntros (?) "Hs". wp_pures.
   iNamedStruct "Hs". rewrite Henc.
-  wp_apply (wp_ReadInt with "[$]").
+  wp_apply (wp_ReadInt [] with "[Hsl]").
+  { list_simplifier. iFrame "Hsl". }
   iIntros (?) "?". wp_pures. wp_storeField.
   iApply "HΦ". iModIntro. repeat iExists _; iFrame "∗#".
 Qed.

--- a/src/program_proof/vrsm/paxos/marshal_proof.v
+++ b/src/program_proof/vrsm/paxos/marshal_proof.v
@@ -59,9 +59,7 @@ Proof.
   wp_load. wp_apply (wp_WriteBytes with "[$Hsl $Hstate_sl]").
   iIntros (?) "[Hsl _]". wp_store.
   wp_load. iApply "HΦ". iFrame. iPureIntro.
-  replace (uint.nat (W64 0)) with (0%nat) by word.
-  list_simplifier.
-  by rewrite /has_encoding.
+  by list_simplifier.
 Qed.
 
 Lemma wp_Decode enc enc_sl (args:C) :
@@ -295,7 +293,8 @@ Proof.
   wp_rec. wp_apply wp_allocStruct; first by val_ty.
   iIntros (?) "Hs". wp_pures.
   iNamedStruct "Hs". rewrite Henc.
-  wp_apply (wp_ReadInt with "[$]").
+  wp_apply (wp_ReadInt [] with "[Hsl]").
+  { by list_simplifier. }
   iIntros (?) "?". wp_pures. wp_storeField. wp_pures.
   iApply "HΦ". iModIntro. repeat iExists _; iFrame "∗#".
 Qed.
@@ -363,7 +362,8 @@ Proof.
   iIntros (?) "Hsl". wp_store. wp_loadField.
   wp_load. wp_apply (wp_WriteBytes with "[$Hsl $Hstate_sl]").
   iIntros (?) "[Hsl _]". wp_store.
-  wp_load. iApply "HΦ". iFrame. iPureIntro. done.
+  wp_load. iApply "HΦ". iFrame. iPureIntro.
+  by list_simplifier.
 Qed.
 
 Lemma wp_Decode enc enc_sl (args:C) :
@@ -421,14 +421,16 @@ Definition encode (st:t) : list u8 :=
 Instance encode_inj : Inj (=) (=) encode.
 Proof.
   intros ???. destruct x, y.
-  apply app_inj_1 in H as [? H]; last done.
-  apply app_inj_1 in H as [? H]; last done.
-  apply app_inj_1 in H as [? H]; last done.
-  apply app_inj_1 in H as [? H]; last done.
+  apply app_inj_1 in H as [? H]; [|len].
+  apply app_inj_1 in H as [? H]; [|len].
+  apply app_inj_1 in H as [? H]; [|len].
+  apply app_inj_1 in H as [? H]; [|len].
   simpl in *.
   apply (f_equal le_to_u64) in H0, H1, H2.
   repeat rewrite u64_le_to_word in H0, H1, H2.
-  subst. f_equal. destruct isLeader0, isLeader1; done.
+  subst. f_equal.
+  apply (inj u64_le) in H3.
+  destruct isLeader0, isLeader1; done.
 Qed.
 
 Context `{!heapGS Σ}.
@@ -476,6 +478,7 @@ Proof.
   wp_loadField. wp_load. wp_apply (wp_WriteBytes with "[$Hsl $Hstate_sl2]").
   iIntros (?) "[Hsl _]". wp_store. wp_load.
   iApply "HΦ".
+  list_simplifier.
   by iFrame.
 Qed.
 

--- a/src/program_proof/vrsm/paxos/marshal_proof.v
+++ b/src/program_proof/vrsm/paxos/marshal_proof.v
@@ -154,7 +154,7 @@ Proof.
   iIntros (?) "Hs". wp_pures.
   iNamedStruct "Hs". rewrite Henc.
   wp_apply (wp_ReadInt [] with "[Hsl]").
-  { list_simplifier. iFrame "Hsl". }
+  { by list_simplifier. }
   iIntros (?) "?". wp_pures. wp_storeField.
   iApply "HΦ". iModIntro. repeat iExists _; iFrame "∗#".
 Qed.

--- a/src/program_proof/vrsm/paxos/marshal_proof.v
+++ b/src/program_proof/vrsm/paxos/marshal_proof.v
@@ -151,7 +151,8 @@ Proof.
   wp_rec. wp_apply wp_allocStruct; first by val_ty.
   iIntros (?) "Hs". wp_pures.
   iNamedStruct "Hs". rewrite Henc.
-  wp_apply (wp_ReadInt with "[$]").
+  wp_apply (wp_ReadInt [] with "[Hsl]").
+  { by list_simplifier. }
   iIntros (?) "?". wp_pures. wp_storeField.
   iApply "HΦ". iModIntro. repeat iExists _; iFrame "∗#".
 Qed.
@@ -292,7 +293,8 @@ Proof.
   wp_rec. wp_apply wp_allocStruct; first by val_ty.
   iIntros (?) "Hs". wp_pures.
   iNamedStruct "Hs". rewrite Henc.
-  wp_apply (wp_ReadInt with "[$]").
+  wp_apply (wp_ReadInt [] with "[Hsl]").
+  { by list_simplifier. }
   iIntros (?) "?". wp_pures. wp_storeField. wp_pures.
   iApply "HΦ". iModIntro. repeat iExists _; iFrame "∗#".
 Qed.

--- a/src/program_proof/vrsm/paxos/marshal_proof.v
+++ b/src/program_proof/vrsm/paxos/marshal_proof.v
@@ -151,8 +151,7 @@ Proof.
   wp_rec. wp_apply wp_allocStruct; first by val_ty.
   iIntros (?) "Hs". wp_pures.
   iNamedStruct "Hs". rewrite Henc.
-  wp_apply (wp_ReadInt [] with "[Hsl]").
-  { by list_simplifier. }
+  wp_apply (wp_ReadInt with "[$]").
   iIntros (?) "?". wp_pures. wp_storeField.
   iApply "HΦ". iModIntro. repeat iExists _; iFrame "∗#".
 Qed.
@@ -293,8 +292,7 @@ Proof.
   wp_rec. wp_apply wp_allocStruct; first by val_ty.
   iIntros (?) "Hs". wp_pures.
   iNamedStruct "Hs". rewrite Henc.
-  wp_apply (wp_ReadInt [] with "[Hsl]").
-  { by list_simplifier. }
+  wp_apply (wp_ReadInt with "[$]").
   iIntros (?) "?". wp_pures. wp_storeField. wp_pures.
   iApply "HΦ". iModIntro. repeat iExists _; iFrame "∗#".
 Qed.

--- a/src/program_proof/vrsm/paxos/withlock_proof.v
+++ b/src/program_proof/vrsm/paxos/withlock_proof.v
@@ -10,6 +10,8 @@ Context `{!paxosG Σ}.
 Context `{!paxosParams.t Σ}.
 Import paxosParams.
 
+Hint Unfold paxosState.encode : len.
+
 Lemma encodes_paxosState_inj st1 st2 data :
   encodes_paxosState st1 data →
   encodes_paxosState st2 data →
@@ -22,10 +24,12 @@ Proof.
     destruct H2 as [H2 | [? ->]].
     { by eapply inj in H2; last apply _. }
     exfalso.
-    done.
+    apply (f_equal length) in H0.
+    revert H0. len.
   }
   destruct H2 as [H2 | [? ->]].
-  { by exfalso. }
+  { apply (f_equal length) in H2.
+    revert H2. len. }
   done.
 Qed.
 

--- a/src/program_proof/vrsm/replica/applybackup_proof.v
+++ b/src/program_proof/vrsm/replica/applybackup_proof.v
@@ -96,7 +96,8 @@ Proof.
       (* FIXME: separate lemma *)
       wp_rec. wp_pures.
       rewrite Henc_rep.
-      wp_apply (wp_ReadInt with "Hrep_sl").
+      wp_apply (wp_ReadInt [] with "[Hrep_sl]").
+      { by list_simplifier. }
       iIntros (?) "_".
       wp_pures.
       iModIntro.
@@ -107,12 +108,13 @@ Proof.
     }
     { (* Apply was rejected by the server (e.g. stale epoch number) *)
       iIntros (err) "%Herr_nz".
-      iIntros.
+      iIntros "% % ? % ? H".
       wp_pures.
       wp_load.
       wp_rec. wp_pures.
       rewrite H.
-      wp_apply (wp_ReadInt with "[$]").
+      wp_apply (wp_ReadInt [] with "[H]").
+      { by list_simplifier. }
       iIntros.
       wp_pures.
       iModIntro.

--- a/src/program_proof/vrsm/replica/becomeprimary_proof.v
+++ b/src/program_proof/vrsm/replica/becomeprimary_proof.v
@@ -69,12 +69,13 @@ Proof.
     iFrame "#".
     (* BecomePrimary was rejected by the server (e.g. stale epoch number) *)
     iIntros (err) "%Herr_nz".
-    iIntros.
+    iIntros "% ? % ? H".
     wp_pures.
     wp_load.
     wp_rec. wp_pures.
     rewrite H.
-    wp_apply (wp_ReadInt with "[$]").
+    wp_apply (wp_ReadInt [] with "[H]").
+    { by list_simplifier. }
     iIntros.
     wp_pures.
     iModIntro.

--- a/src/program_proof/vrsm/replica/marshal_proof.v
+++ b/src/program_proof/vrsm/replica/marshal_proof.v
@@ -82,7 +82,7 @@ Proof.
   wp_load.
   iApply "HΦ".
   iFrame "Henc_sl".
-  done.
+  by list_simplifier.
 Qed.
 
 Lemma wp_Decode enc enc_sl (args:C) :
@@ -213,7 +213,7 @@ Proof.
   iModIntro.
   iApply "HΦ".
   iFrame "Henc_sl".
-  iSplitL ""; first done.
+  iSplitL ""; first by list_simplifier.
   iExists _; iFrame "∗#".
 Qed.
 
@@ -340,7 +340,8 @@ Proof.
   iIntros (args_ptr) "Hargs".
   wp_pures.
   rewrite Henc.
-  wp_apply (wp_ReadInt with "Henc_sl").
+  wp_apply (wp_ReadInt [] with "[Henc_sl]").
+  { by list_simplifier. }
   iIntros (?) "Henc_sl".
   wp_pures.
   iDestruct (struct_fields_split with "Hargs") as "HH".
@@ -433,7 +434,7 @@ Proof.
   iModIntro.
   iApply "HΦ".
   iFrame.
-  done.
+  by list_simplifier.
 Qed.
 
 Lemma wp_Decode enc enc_sl (reply:C) :
@@ -580,6 +581,7 @@ Proof.
     iExists _, (replicas_so_far ++ [x]).
     iFrame.
     rewrite flat_map_app.
+    list_simplifier.
     iFrame.
     iPureIntro; split.
     {
@@ -608,6 +610,7 @@ Proof.
   }
   {
     iExists _, [].
+    list_simplifier.
     iFrame.
     iPureIntro; split; eauto.
     apply prefix_nil.
@@ -753,7 +756,8 @@ Proof.
 
     replace (next_replica :: replicas_left') with ([next_replica] ++ replicas_left') by done.
     rewrite flat_map_app.
-    wp_apply (wp_ReadInt with "Henc_sl").
+    wp_apply (wp_ReadInt with "[Henc_sl]").
+    { by list_simplifier. }
     iIntros (?) "Henc_sl".
     wp_pures.
     wp_loadField.
@@ -822,7 +826,8 @@ Proof.
   {
     iDestruct (own_slice_small_sz with "Henc_sl") as %Hsz.
     assert (length (args.(replicas)) <= length (flat_map u64_le args.(replicas))).
-    { apply flat_map_len_non_nil. destruct x => //=. }
+    { apply flat_map_len_non_nil. destruct x => //=.
+      intros H. apply (f_equal length) in H. revert H. len. }
     iExists nil, _, _.
     iFrame "∗".
     simpl.

--- a/src/program_proof/vrsm/replica/setstate_proof.v
+++ b/src/program_proof/vrsm/replica/setstate_proof.v
@@ -81,7 +81,8 @@ Proof.
       (* FIXME: separate lemma *)
       wp_rec. wp_pures.
       rewrite Henc_rep.
-      wp_apply (wp_ReadInt with "Hrep_sl").
+      wp_apply (wp_ReadInt [] with "[Hrep_sl]").
+      { by list_simplifier. }
       iIntros (?) "_".
       wp_pures.
       iModIntro.
@@ -91,12 +92,13 @@ Proof.
     }
     { (* SetState was rejected by the server (e.g. stale epoch number) *)
       iIntros (err) "%Herr_nz".
-      iIntros.
+      iIntros "% % ? % ? H".
       wp_pures.
       wp_load.
       wp_rec. wp_pures.
       rewrite H.
-      wp_apply (wp_ReadInt with "[$]").
+      wp_apply (wp_ReadInt [] with "[H]").
+      { by list_simplifier. }
       iIntros.
       wp_pures.
       iModIntro.

--- a/src/program_proof/vrsm/replica/start_proof.v
+++ b/src/program_proof/vrsm/replica/start_proof.v
@@ -262,7 +262,8 @@ Proof.
       wp_pures.
       iDestruct "Hspec" as (?) "[% Hspec]".
       subst. wp_rec. wp_pures.
-      wp_apply (wp_ReadInt with "[$]").
+      wp_apply (wp_ReadInt [] with "[Hreq_sl]").
+      { by list_simplifier. }
       iIntros (?) "_". wp_pures.
       wp_apply (wp_Server__IncreaseCommit with "Hsrv [-Hspec] Hspec").
       iIntros "Hspec".

--- a/src/program_proof/vrsm/storage/proof.v
+++ b/src/program_proof/vrsm/storage/proof.v
@@ -107,7 +107,7 @@ Qed.
 Lemma file_encodes_state_snapshot snap ops epoch :
   (length ops < 2 ^ 64)%Z →
   has_snap_encoding snap ops →
-  file_encodes_state ((u64_le (length snap) ++ snap) ++ u64_le epoch ++ u64_le (length ops))
+  file_encodes_state (u64_le (length snap) ++ snap ++ u64_le epoch ++ u64_le (length ops))
     epoch ops false
 .
 Proof.
@@ -610,6 +610,7 @@ Proof.
       iExists _, _, _; iFrame "HP".
       iPureIntro.
       rewrite -app_assoc.
+      list_simplifier.
       by apply file_encodes_state_snapshot.
     }
   }
@@ -660,8 +661,9 @@ Proof.
     iExists _, _; iFrame "HP #".
     iPureIntro.
     unfold newdata.
-    rewrite -app_assoc.
-    by apply file_encodes_state_snapshot.
+    rewrite -?app_assoc.
+    list_simplifier.
+    by eapply file_encodes_state_snapshot.
   }
   iModIntro.
   iExists _.
@@ -1076,8 +1078,8 @@ Proof.
         { word. }
         rewrite app_nil_l.
         rewrite -app_assoc.
-        unshelve (epose proof (file_encodes_state_snapshot snap [] 0 _ Hsnapenc)  as H; done).
-        simpl. lia.
+        list_simplifier.
+        by eapply file_encodes_state_snapshot.
       }
     }
     iNext.
@@ -1087,8 +1089,8 @@ Proof.
     iMod (fmlist_update with "Hallstates") as "[Hallstates Hallstates_lb]".
     {
       instantiate (1:=((replicate (n+1) ([]:list OpType, false)))).
-      rewrite replicate_S.
-      simpl.
+      replace (n + 1) with (1 + n) by lia.
+      rewrite !replicate_S.
       apply prefix_cons.
       apply prefix_nil.
     }
@@ -1115,8 +1117,8 @@ Proof.
       { word. }
       rewrite app_nil_l.
       rewrite -app_assoc.
-      unshelve (epose proof (file_encodes_state_snapshot snap [] 0 _ Hsnapenc)  as H; done).
-      simpl; lia.
+      list_simplifier.
+      by eapply file_encodes_state_snapshot.
     }
     iSplit.
     {
@@ -1159,8 +1161,8 @@ Proof.
       { word. }
       rewrite app_nil_l.
       rewrite -app_assoc.
-      unshelve (epose proof (file_encodes_state_snapshot snap [] 0 _ Hsnapenc)  as H; done).
-      simpl; lia.
+      list_simplifier.
+      by eapply file_encodes_state_snapshot.
     }
     iSplitL; first done.
     iPureIntro.

--- a/src/program_proof/wal/circ_proof.v
+++ b/src/program_proof/wal/circ_proof.v
@@ -1308,7 +1308,7 @@ Proof.
     iExists _, _; iFrame "Haddrs' Hblocks'".
     iSplit; auto.
     iSplit.
-    { iPureIntro.
+   { iPureIntro.
       simpl in Hbkslen.
       apply circ_low_wf_empty; word. }
     change (uint.Z 0) with 0.
@@ -1317,8 +1317,10 @@ Proof.
     iFrame.
     iPureIntro.
     { split.
-      - reflexivity.
-      - reflexivity. }
+      - rewrite /block_encodes /has_encoding /marshal_proof.encode /marshal_proof.encode1.
+        by rewrite ?u64_le_unseal.
+      - rewrite /block_encodes /has_encoding /marshal_proof.encode /marshal_proof.encode1.
+        by rewrite ?u64_le_unseal. }
     }
   iFrame "Hstart2 HdiskEnd2".
   iSplit; auto.

--- a/src/program_proof/wal/circ_proof_crash.v
+++ b/src/program_proof/wal/circ_proof_crash.v
@@ -118,8 +118,10 @@ Lemma zero_encodings :
 Proof.
   rewrite /block_encodes /has_encoding.
   split.
-  - reflexivity.
-  - reflexivity.
+  - rewrite /block_encodes /has_encoding /marshal_proof.encode /marshal_proof.encode1.
+    by rewrite ?u64_le_unseal.
+  - rewrite /block_encodes /has_encoding /marshal_proof.encode /marshal_proof.encode1.
+    by rewrite ?u64_le_unseal.
 Qed.
 
 Lemma circular_init :


### PR DESCRIPTION
this should most definitely be sealed. most proofs don't need to unfold the byte encoding (the only one that did was `wp_initCircular`). the downside of not sealing it was that low-level automation (e.g., that used in `list_simplifier`) would unfold it even tho it was marked opaque. this blew up the context.

the downstream effect of sealing `u64_le` is that low-level tactics no longer automatically simplify list expressions with `u64_le`. e.g., with `simpl`, `u64_le x ++ []` no longer simplifies to `u64_le x` and `(u64_le x ++ y) ++ z` no longer simplifies to `u64_le x ++ y ++ z`. it previously simplified because the automation would unfold u64_le into a concrete list, and concretely simplify the remaining expression. in place of this, we need to use the more fancy `list_simplifier` automation from stdpp.

we also extend the `len` tactic, which automates proofs about `length u64_le`, with a custom unfold database.