### PR TITLE
Verify some generics examples that now translate

### DIFF
--- a/new/proof/github_com/goose_lang/goose/testdata/examples/unittest/generics.v
+++ b/new/proof/github_com/goose_lang/goose/testdata/examples/unittest/generics.v
@@ -80,4 +80,59 @@ Proof.
   iApply "HΦ"; done.
 Qed.
 
+Lemma wp_useContainer :
+  {{{ is_pkg_init generics }}}
+    generics @ "useContainer" #()
+  {{{ RET #(); True }}}.
+Proof.
+  wp_start as "_"; try wp_auto.
+  rewrite <- (default_val_eq_zero_val (V:=generics.Container.t w64)).
+  wp_auto.
+  (* NOTE: there's no way to reduce the pair here to a #x to use the list wp
+  theorems, and anyway there's no wp for map literals yet *)
+Abort.
+
+Lemma wp_useMultiParam :
+  {{{ is_pkg_init generics }}}
+    generics @ "useMultiParam" #()
+  {{{ RET #(); True }}}.
+Proof.
+  wp_start as "_"; try wp_auto.
+  rewrite <- (default_val_eq_zero_val (V:=generics.MultiParam.t w64 bool)).
+  wp_auto.
+  iApply struct_fields_split in "mp"; iNamed "mp".
+  with_strategy opaque [is_pkg_init] cbn.
+  wp_auto.
+  iApply "HΦ"; done.
+Qed.
+
+Lemma wp_multiParamFunc `{!IntoVal A'} `{!IntoValTyped A' A}
+`{!IntoVal B'} `{!IntoValTyped B' B}
+  (x: A') (y: B') :
+  {{{ is_pkg_init generics }}}
+    generics @ "multiParamFunc" #A #B #x #y
+  {{{ s, RET #s; s ↦* [y] }}}.
+Proof.
+  wp_start as "_"; try wp_auto.
+  unshelve wp_apply wp_slice_literal.
+  { apply _. }
+  iIntros (sl) "H".
+  wp_auto.
+  iApply "HΦ". iFrame.
+Qed.
+
+Lemma wp_useMultiParamFunc :
+  {{{ is_pkg_init generics }}}
+    generics @ "useMultiParamFunc" #()
+  {{{ RET #(); True }}}.
+Proof.
+  wp_start as "_"; try wp_auto.
+  unshelve wp_apply wp_multiParamFunc.
+  { apply _. }
+  { apply _. }
+  iIntros (s) "H".
+  wp_auto.
+  iApply "HΦ"; done.
+Qed.
+
 End wps.

--- a/new/proof/github_com/goose_lang/goose/testdata/examples/unittest/generics.v
+++ b/new/proof/github_com/goose_lang/goose/testdata/examples/unittest/generics.v
@@ -1,0 +1,83 @@
+From New.proof Require Import proof_prelude.
+From New.generatedproof.github_com.goose_lang.goose.testdata.examples
+  Require Import unittest.generics.
+
+Section wps.
+Context `{hG: heapGS Σ, !ffi_semantics _ _}.
+Context `{!goGlobalsGS Σ}.
+
+#[global] Program Instance : IsPkgInit generics := ltac2:(build_pkg_init ()).
+
+Section generic_proofs.
+Context `{!IntoVal T'} `{!IntoValTyped T' T} `{Hbounded: BoundedTypeSize T}.
+
+Lemma wp_BoxGet (b: generics.Box.t T') :
+  {{{ is_pkg_init generics }}}
+    generics @ "BoxGet" #T #b
+  {{{ RET #(generics.Box.Value' b); True }}}.
+Proof using Hbounded.
+  wp_start as "_"; try wp_auto.
+  iApply struct_fields_split in "b"; iNamed "b".
+  wp_auto.
+  iApply "HΦ"; done.
+Qed.
+
+Lemma wp_Box__Get (b: generics.Box.t T') :
+  {{{ is_pkg_init generics }}}
+    b @ generics @ "Box" @ "Get" #T #()
+  {{{ RET #(generics.Box.Value' b); True }}}.
+Proof using Hbounded.
+  wp_start as "_"; try wp_auto.
+  iApply struct_fields_split in "b"; iNamed "b".
+  wp_auto.
+  iApply "HΦ"; done.
+Qed.
+
+Lemma wp_makeGenericBox (value: T') :
+  {{{ is_pkg_init generics }}}
+    generics @ "makeGenericBox" #T #value
+  {{{ RET #(generics.Box.mk value); True }}}.
+Proof.
+  wp_start as "_"; try wp_auto.
+  iApply "HΦ"; done.
+Qed.
+End generic_proofs.
+
+Lemma wp_BoxGet2 (b: generics.Box.t w64) :
+  {{{ is_pkg_init generics }}}
+    generics @ "BoxGet2" #b
+  {{{ RET #(generics.Box.Value' b); True }}}.
+Proof.
+  wp_start as "_"; try wp_auto.
+  iApply struct_fields_split in "b"; iNamed "b".
+  wp_auto.
+  iApply "HΦ"; done.
+Qed.
+
+Lemma wp_makeBox :
+  {{{ is_pkg_init generics }}}
+    generics @ "makeBox" #()
+  {{{ RET #(generics.Box.mk (W64 42)); True }}}.
+Proof.
+  wp_start as "_"; try wp_auto.
+  iApply "HΦ"; done.
+Qed.
+
+Lemma wp_useBoxGet :
+  {{{ is_pkg_init generics }}}
+    generics @ "useBoxGet" #()
+  {{{ RET #(W64 42); True }}}.
+Proof.
+  wp_start as "_"; try wp_auto.
+  (* TODO: how to fix automation that does this? *)
+  rewrite <- (default_val_eq_zero_val (V:=generics.Box.t w64)).
+  wp_auto.
+  (* TODO: why does this get shelved? *)
+  unshelve wp_apply wp_makeGenericBox.
+  { apply _. }
+  unshelve wp_apply wp_Box__Get.
+  { apply _. }
+  iApply "HΦ"; done.
+Qed.
+
+End wps.

--- a/new/proof/github_com/goose_lang/std.v
+++ b/new/proof/github_com/goose_lang/std.v
@@ -1,6 +1,5 @@
 From New.proof Require Import proof_prelude.
-From New.code.github_com.goose_lang Require Import std.
-Require Export New.generatedproof.github_com.goose_lang.std.
+From New.generatedproof.github_com.goose_lang Require Export std.
 From New.proof Require Import github_com.goose_lang.primitive sync.
 
 Section wps.

--- a/new/should_build.v
+++ b/new/should_build.v
@@ -1,6 +1,5 @@
-From New.code.go_etcd_io.raft Require v3.
 From New.generatedproof.github_com.goose_lang.goose.testdata.examples
-  Require unittest unittest.generics semantics.
+  Require unittest semantics.
 (* required just to make sure this demo works *)
 From New.golang.theory Require static_mem.
 From New.proof Require go_etcd_io.etcd.raft.v3.

--- a/new/should_build.v
+++ b/new/should_build.v
@@ -5,6 +5,8 @@ From New.generatedproof.github_com.goose_lang.goose.testdata.examples
 From New.golang.theory Require static_mem.
 From New.proof Require go_etcd_io.etcd.raft.v3.
 From New.proof.github_com.mit_pdos.gokv Require partialapp asyncfile lockservice globals_test.
+From New.proof.github_com.goose_lang.goose.testdata.examples
+  Require unittest.generics.
 
 From New.proof Require go_etcd_io.etcd.client.v3.leasing.
 From New.proof Require Import chan context.


### PR DESCRIPTION
Adds translations from https://github.com/goose-lang/goose/pull/93 and verifies some simple specs for the new generics unit tests. This helped find a few bugs in missing support and incorrect arguments, which are hard to spot by inspection.

There are some oddities in these proofs (e.g. unexpectedly shelved instances) that aren't great but they don't seem specifically related to generics and we can debug them separately.