### PR TITLE
Change default value produced by `do:`

### DIFF
--- a/new/golang/defn/exception.v
+++ b/new/golang/defn/exception.v
@@ -15,8 +15,11 @@ Program Definition return_val := sealed @return_val_def.
 Definition return_val_unseal : return_val = _ := seal_eq _.
 
 (* "Exception" monad *)
+(* executing to the end without a return produces a #() to match Go's void
+return semantics (named return values are translated as return statements using
+do_return as defined below). *)
 Local Definition do_execute_def : val :=
-  λ: "v", (#"execute", Var "v")
+  λ: "_v", (#"execute", #())
 .
 
 Program Definition do_execute := sealed @do_execute_def.

--- a/new/golang/theory/exception.v
+++ b/new/golang/theory/exception.v
@@ -15,7 +15,7 @@ Proof.
   wp_call_lc "?". by iApply "Hwp".
 Qed.
 
-Global Instance pure_do_execute_val (v : val) : PureWp True (do: v) (execute_val v).
+Global Instance pure_do_execute_val (v : val) : PureWp True (do: v) (execute_val #()).
 Proof.
   rewrite do_execute_unseal execute_val_unseal.
   intros ?????. iIntros "Hwp".


### PR DESCRIPTION
As discussed in https://github.com/goose-lang/goose/pull/103, to ensure that void functions return a unit value, we can just change the default behavior of `do:` to produce a unit value, and rely on a `return:` statement if anything else should be returned. In Go reaching the end of a function without a return should produce unit for a void function, while in the case of named return values the translation already emits a `return:` as a continuation.