### PR TITLE
Add proof for primitive.AssumeNoStringOverflow

### DIFF
--- a/new/code/github_com/goose_lang/primitive.v
+++ b/new/code/github_com/goose_lang/primitive.v
@@ -12,7 +12,7 @@ Context `{ffi_syntax}.
 
 Definition vars' : list (go_string * go_type) := [].
 
-Definition functions' : list (go_string * val) := [("UInt64Put"%go, UInt64Put); ("RandomUint64"%go, RandomUint64); ("Assume"%go, Assume)].
+Definition functions' : list (go_string * val) := [("UInt64Put"%go, UInt64Put); ("RandomUint64"%go, RandomUint64); ("Assume"%go, Assume); ("AssumeNoStringOverflow"%go, AssumeNoStringOverflow)].
 
 Definition msets' : list (go_string * (list (go_string * val))) := [].
 

--- a/new/code/github_com/goose_lang/primitive.v.toml
+++ b/new/code/github_com/goose_lang/primitive.v.toml
@@ -8,5 +8,6 @@ trusted = [
   "UInt64Put",
   "Assume",
   "RandomUint64",
+  "AssumeNoStringOverflow",
   # FIXME: add remaining functions
 ]

--- a/new/generatedproof/github_com/goose_lang/primitive.v
+++ b/new/generatedproof/github_com/goose_lang/primitive.v
@@ -42,5 +42,9 @@ Global Instance wp_func_call_Assume :
   WpFuncCall primitive "Assume" _ (is_pkg_defined primitive) :=
   ltac:(apply wp_func_call'; reflexivity).
 
+Global Instance wp_func_call_AssumeNoStringOverflow :
+  WpFuncCall primitive "AssumeNoStringOverflow" _ (is_pkg_defined primitive) :=
+  ltac:(apply wp_func_call'; reflexivity).
+
 End names.
 End primitive.

--- a/new/proof/github_com/goose_lang/primitive.v
+++ b/new/proof/github_com/goose_lang/primitive.v
@@ -36,4 +36,19 @@ Proof.
   done.
 Qed.
 
+Lemma wp_AssumeNoStringOverflow (s: byte_string) :
+  {{{ is_pkg_init primitive }}}
+    primitive@"AssumeNoStringOverflow" #s
+  {{{ RET #(); ⌜Z.of_nat (length s) < 2^64⌝ }}}.
+Proof.
+  wp_start as "_".
+  wp_call.
+  wp_if_destruct.
+  - iApply "HΦ". done.
+  - iLöb as "IH".
+    wp_pures.
+    iApply "IH".
+    iApply "HΦ".
+Qed.
+
 End wps.

--- a/new/trusted_code/github_com/goose_lang/primitive.v
+++ b/new/trusted_code/github_com/goose_lang/primitive.v
@@ -78,4 +78,7 @@ this in GooseLang, so we just loop. *)
 
   Definition Linearize : val := λ: <>, #().
 
+  Definition AssumeNoStringOverflow : val :=
+    λ: "s", Assume (IsNoStringOverflow "s").
+
 End code.


### PR DESCRIPTION
This PR also adds a model, which uses IsNoStringOverflow. See https://github.com/goose-lang/primitive/pull/2 for the code (which does nothing).