### PR TITLE
Try to fix another universe problem related to RPCs and ecomp

### DIFF
--- a/src/program_proof/grove_shared/erpc_proof.v
+++ b/src/program_proof/grove_shared/erpc_proof.v
@@ -10,6 +10,8 @@ Notation erpcΣ := (erpc_lib.erpcΣ (list u8)).
 
 Definition erpcN := nroot .@ "erpc".
 
+Set Universe Polymorphism.
+
 (** Spec for an eRPC handler.
 This is isomorphic to RpcSpec, but to avoid confusion we use distinct types. *)
 Record eRPCSpec {Σ} :=

--- a/src/program_proof/memkv/connman_proof.v
+++ b/src/program_proof/memkv/connman_proof.v
@@ -8,6 +8,7 @@ From Perennial.goose_lang.lib Require Import slice.typed_slice.
 
 Section connman_proof.
 
+Set Universe Polymorphism.
 Context `{!urpcregG Σ}.
 Context `{hG: !heapGS Σ}.
 Definition connmanN := nroot .@ "connman".


### PR DESCRIPTION
Try to fix universe problem by making `erpc` and `connman` universe polymorphic (thereby avoiding some templated universes that resulted in inconsistent universe constraints).

Can't make `ecomp` universe polymorphic so easily: doing so makes some `ecomp` terms in `etcd/client/v3.v` no longer typecheck, possibly because typeclass inference related to `MBind` isn't working the same.