### PR TITLE
Add back wp_auto to wp_apply

### DIFF
--- a/new/golang/theory/auto.v
+++ b/new/golang/theory/auto.v
@@ -100,6 +100,10 @@ Ltac2 Type wp_param := [
 
 Ltac2 Type exn ::= [ WpParamExn(wp_param) ].
 
+(* FIXME: setting this variable affects all imports; there doesn't seem to be a
+way to set it locally *)
+Ltac2 mutable wp_apply_auto_default : bool := true.
+
 Tactic Notation "--no-auto" :=
   ltac2:(Control.zero (WpParamExn (RunAuto false))).
 Tactic Notation "--auto" :=
@@ -178,7 +182,7 @@ Ltac2 wp_apply (lem: Ltac1.t) (do_auto: bool) (lc: int) (as_clause: Ltac1.t opti
 
 Tactic Notation "wp_apply" open_constr(lem) tactic1_list(ps) :=
   let f := ltac2:(lem ps_raw |-
-    let r_auto := Ref.ref true in
+    let r_auto := Ref.ref wp_apply_auto_default in
     let r_lc := Ref.ref 0 in
     let r_as: (Ltac1.t option) Ref.ref := Ref.ref None in
     let ps : Ltac1.t list := Option.get (Ltac1.to_list ps_raw) in

--- a/new/golang/theory/slice.v
+++ b/new/golang/theory/slice.v
@@ -328,9 +328,7 @@ Proof.
 
   wp_if_destruct.
   {
-    wp_apply (wp_ArbitraryInt).
-    iIntros (?).
-    wp_pures.
+    wp_apply (wp_ArbitraryInt) as "%".
     rewrite slice_val_fold.
     iApply "HΦ".
     rewrite own_slice_unseal.
@@ -1095,9 +1093,9 @@ Proof.
       list_elem vs' i as y.
       wp_apply (wp_load_slice_elem with "[$Hs2]") as "Hs2".
       { eauto. }
-      wp_auto. wp_apply (wp_store_slice_elem with "[$Hs1]") as "Hs1".
+      wp_apply (wp_store_slice_elem with "[$Hs1]") as "Hs1".
       { len. }
-      wp_auto. wp_for_post.
+      wp_for_post.
       iFrame.
       replace (uint.nat (word.add i (W64 1))) with
         (S (uint.nat i)) by word.
@@ -1184,7 +1182,7 @@ Proof.
   iDestruct (own_slice_len with "Hs2") as %Hs2.
   iDestruct (own_slice_wf with "Hs") as %Hwf1.
   iDestruct (own_slice_wf with "Hs2") as %Hwf2.
-  wp_apply wp_sum_assume_no_overflow as "%Hoverflow". wp_auto.
+  wp_apply wp_sum_assume_no_overflow as "%Hoverflow".
   wp_if_destruct; try wp_auto.
   - wp_pure.
     { word. }
@@ -1220,8 +1218,8 @@ Proof.
     }
     iApply (own_slice_cap_slice_f_change_first with "Hs_new_cap").
     move: l; word.
-  - wp_apply (wp_ArbitraryInt) as "%x". wp_auto.
-    wp_apply wp_sum_assume_no_overflow as "%Hoverflow2". wp_auto.
+  - wp_apply (wp_ArbitraryInt) as "%x".
+    wp_apply wp_sum_assume_no_overflow as "%Hoverflow2".
     wp_apply wp_slice_make3.
     { move: Hoverflow2; word. }
     iIntros (sl) "(Hnew & Hnew_cap & %Hcap)".

--- a/new/proof/github_com/goose_lang/goose/testdata/examples/unittest.v
+++ b/new/proof/github_com/goose_lang/goose/testdata/examples/unittest.v
@@ -31,7 +31,7 @@ Lemma wp_VoidButEndsWithReturn :
 Proof.
   wp_start.
   wp_apply wp_BasicNamedReturn.
-  wp_auto. by iApply "HΦ".
+  by iApply "HΦ".
 Qed.
 
 Lemma wp_VoidImplicitReturnInBranch (b: bool) :
@@ -43,7 +43,7 @@ Proof.
   destruct b; wp_auto.
   - by iApply "HΦ".
   - wp_apply wp_BasicNamedReturn.
-    wp_auto. by iApply "HΦ".
+    by iApply "HΦ".
 Qed.
 
 Lemma wp_typeAssertInt (x: interface.t) (v: w64) :
@@ -54,7 +54,7 @@ Proof.
   wp_start as "->". wp_auto.
   wp_apply wp_interface_type_assert.
   { done. }
-  wp_auto. by iApply "HΦ".
+  by iApply "HΦ".
 Qed.
 
 Lemma wp_wrapUnwrapInt :
@@ -65,7 +65,7 @@ Proof.
   wp_start as "_".
   wp_apply wp_typeAssertInt.
   { done. }
-  wp_auto. by iApply "HΦ".
+  by iApply "HΦ".
 Qed.
 
 Lemma wp_checkedTypeAssert (x: interface.t) :

--- a/new/proof/github_com/goose_lang/goose/testdata/examples/unittest/generics.v
+++ b/new/proof/github_com/goose_lang/goose/testdata/examples/unittest/generics.v
@@ -75,10 +75,10 @@ Proof.
   (* TODO: why does this get shelved? *)
   About IntoValTyped.
   Global Hint Mode IntoValTyped ! - - - : typeclass_instances.
-  unshelve wp_apply wp_makeGenericBox. { apply _. }
+  unshelve wp_apply wp_makeGenericBox --no-auto. { apply _. }
   (* TODO: it's a [wp_load] inside the auto causing the typeclass goal. *)
   unshelve wp_auto. { apply _. }
-  unshelve wp_apply wp_Box__Get. { apply _. }
+  unshelve wp_apply wp_Box__Get --no-auto. { apply _. }
   wp_auto. iApply "HΦ"; done.
 Qed.
 

--- a/new/proof/github_com/goose_lang/std.v
+++ b/new/proof/github_com/goose_lang/std.v
@@ -46,9 +46,9 @@ Proof.
     wp_if_destruct; try wp_auto.
     - list_elem xs1 i as x1_i.
       wp_apply (wp_load_slice_elem with "[$Hs1]") as "Hs1"; first by eauto.
-      wp_auto. wp_pure; first by word.
+      wp_pure; first by word.
       list_elem xs2 i as x2_i.
-      wp_apply (wp_load_slice_elem with "[$Hs2]") as "Hs2"; first by eauto. wp_auto.
+      wp_apply (wp_load_slice_elem with "[$Hs2]") as "Hs2"; first by eauto.
       destruct (bool_decide_reflect (x1_i = x2_i)); subst; wp_auto.
       + wp_for_post.
         iFrame.
@@ -79,7 +79,7 @@ Lemma wp_SumNoOverflow (x y : u64) :
   {{{ RET #(bool_decide (uint.Z (word.add x y) = (uint.Z x + uint.Z y)%Z)); True }}}.
 Proof.
   wp_start as "_"; wp_auto.
-  wp_apply wp_SumNoOverflow. wp_auto.
+  wp_apply wp_SumNoOverflow.
   iApply "HΦ"; done.
 Qed.
 
@@ -113,7 +113,7 @@ Proof.
   wp_auto.
   wp_alloc mu as "?".
   wp_auto.
-  wp_apply (wp_NewCond with "[#]") as "%cond #His_cond". wp_auto.
+  wp_apply (wp_NewCond with "[#]") as "%cond #His_cond".
   wp_alloc jh_l as "jh".
   iApply struct_fields_split in "jh". simpl. iNamed "jh".
   iPersist "Hmu Hcond".
@@ -138,10 +138,10 @@ Proof.
   wp_apply (wp_Mutex__Lock with "[$Hlock]") as "[locked Hinv]".
   iNamed "Hinv".
   wp_auto.
-  wp_apply (wp_Cond__Signal with "[$Hcond]"). wp_auto.
+  wp_apply (wp_Cond__Signal with "[$Hcond]").
   wp_apply (wp_Mutex__Unlock with "[$Hlock $locked done_b P]").
   { iFrame "done_b P". }
-  wp_auto. iApply "HΦ".
+  iApply "HΦ".
   done.
 Qed.
 
@@ -154,14 +154,13 @@ Proof.
   wp_start as "Hwp".
   wp_auto.
   wp_apply (wp_newJoinHandle P) as "%l #Hhandle".
-  wp_auto. iPersist "f h".
-  wp_apply (wp_fork with "[Hwp]"); wp_auto.
-  - (* NOTE: it's important not to do a pure reduction here since it would
-    produce a substitution into the lambda *)
+  iPersist "f h".
+  wp_apply (wp_fork with "[Hwp]").
+  - wp_auto.
     wp_apply "Hwp".
     iIntros "HP".
     wp_auto.
-    wp_apply (wp_JoinHandle__finish with "[$Hhandle $HP]"). wp_auto.
+    wp_apply (wp_JoinHandle__finish with "[$Hhandle $HP]").
     done.
   - iApply "HΦ".
     iFrame "#".
@@ -174,9 +173,7 @@ Lemma wp_JoinHandle__Join l P :
 Proof.
   wp_start as "Hjh". iNamed "Hjh".
   wp_auto.
-  wp_apply (wp_Mutex__Lock with "[$Hlock]").
-  iIntros "[Hlocked Hlinv]". iNamed "Hlinv".
-  wp_auto.
+  wp_apply (wp_Mutex__Lock with "[$Hlock]") as "[Hlocked @]".
 
   iAssert (∃ (done_b: bool),
            "locked" ∷ own_Mutex mu_l ∗
@@ -187,13 +184,13 @@ Proof.
   destruct done_b0; wp_auto.
   - wp_for_post.
     wp_apply (wp_Mutex__Unlock with "[$Hlock $locked $done]").
-    wp_auto. iApply "HΦ". done.
+    iApply "HΦ". done.
   - wp_apply (wp_Cond__Wait with "[$Hcond locked done HP]") as "H".
     { iSplit.
       - iApply (Mutex_is_Locker with "[] Hlock"). iPkgInit.
       - iFrame. }
     iDestruct "H" as "[Hlocked Hlinv]". iNamed "Hlinv".
-    wp_auto. wp_for_post. iFrame.
+    wp_for_post. iFrame.
 Qed.
 
 End wps.

--- a/new/proof/github_com/goose_lang/std/std_core.v
+++ b/new/proof/github_com/goose_lang/std/std_core.v
@@ -32,8 +32,8 @@ Lemma wp_SumAssumeNoOverflow (x y : u64) :
 Proof.
   wp_start as "_".
   wp_auto.
-  wp_apply wp_SumNoOverflow. wp_auto.
-  wp_apply wp_Assume as "%Hassume". wp_auto.
+  wp_apply wp_SumNoOverflow.
+  wp_apply wp_Assume as "%Hassume".
   rewrite bool_decide_eq_true in Hassume.
   iApply "HΦ". iPureIntro. done.
 Qed.
@@ -66,8 +66,8 @@ Lemma wp_MulAssumeNoOverflow (x y : u64) :
 Proof.
   wp_start as "_".
   wp_auto.
-  wp_apply wp_MulNoOverflow. wp_auto.
-  wp_apply wp_Assume as "%Hassume". wp_auto.
+  wp_apply wp_MulNoOverflow.
+  wp_apply wp_Assume as "%Hassume".
   rewrite bool_decide_eq_true in Hassume.
   iApply "HΦ". iPureIntro. done.
 Qed.

--- a/new/proof/github_com/mit_pdos/go_journal/alloc.v
+++ b/new/proof/github_com/mit_pdos/go_journal/alloc.v
@@ -130,7 +130,7 @@ Proof.
   wp_apply (wp_Mutex__Unlock with "[$His_lock $Hlocked $next $bitmap $Hbits]").
   { rewrite length_insert. done. }
 
-  wp_auto. iApply "HΦ". done.
+  iApply "HΦ". done.
 Qed.
 
 Lemma wp_MkMaxAlloc (max: u64) :
@@ -158,7 +158,7 @@ Proof.
   wp_auto.
   wp_apply (wp_MarkUsed with "[$Ha]").
   { word. }
-  wp_auto. iApply "HΦ".
+  iApply "HΦ".
   iExactEq "Ha".
   f_equal.
   word.
@@ -241,7 +241,7 @@ Proof.
     wp_for_post.
     wp_apply (wp_Mutex__Unlock with "[$His_lock $Hlocked $next $bitmap $Hbits]").
     { rewrite length_insert. word. }
-    wp_auto. iApply "HΦ". word.
+    iApply "HΦ". word.
   - wp_auto.
     wp_apply (wp_incNext max with "[$next $bitmap $Hbits]"); first done.
     { word. }
@@ -251,7 +251,7 @@ Proof.
     + wp_auto.
       wp_for_post.
       wp_apply (wp_Mutex__Unlock with "[$His_lock $Hlocked $Hlinv]").
-      wp_auto. iApply "HΦ". done.
+      iApply "HΦ". done.
     + wp_for_post.
       iFrame. word.
 Qed.
@@ -282,7 +282,7 @@ Proof.
   wp_auto.
   wp_apply (wp_Mutex__Unlock with "[$His_lock $Hlocked $next $bitmap $Hbits]").
   { rewrite length_insert. word. }
-  wp_auto. by iApply "HΦ".
+  by iApply "HΦ".
 Qed.
 
 Lemma wp_AllocNum max l :
@@ -313,7 +313,7 @@ Proof.
   wp_if_destruct; first word.
   wp_auto.
   wp_apply (wp_freeBit with "[$H]"); eauto.
-  wp_auto. by iApply "HΦ".
+  by iApply "HΦ".
 Qed.
 
 Lemma wp_popCnt (b: u8) :
@@ -396,7 +396,7 @@ Proof.
     wp_auto.
     wp_apply (wp_Mutex__Unlock with "[$His_lock $Hlocked $next $bitmap $Hbits]").
     { word. }
-    wp_auto. iApply "HΦ". word.
+    iApply "HΦ". word.
 Qed.
 
 End proof.

--- a/new/proof/github_com/mit_pdos/go_journal/buf_proof/buf_proof.v
+++ b/new/proof/github_com/mit_pdos/go_journal/buf_proof/buf_proof.v
@@ -860,9 +860,8 @@ Proof.
   iIntros "Hdst".
   wp_auto.
   wp_apply wp_installOneBit; first word.
-  wp_auto. wp_pure; first word.
-  wp_apply (wp_store_slice_elem with "[$Hdst]"); first word. iIntros "Hdst".
-  wp_auto.
+  wp_pure; first word.
+  wp_apply (wp_store_slice_elem with "[$Hdst]") as "Hdst"; first word.
   iApply "HΦ". iFrame.
   iExactEq "Hdst".
   f_equal.

--- a/new/proof/github_com/mit_pdos/go_journal/lockmap.v
+++ b/new/proof/github_com/mit_pdos/go_journal/lockmap.v
@@ -174,14 +174,13 @@ Proof.
 
       wp_apply (wp_Mutex__Unlock with "[$Hlock $Hlocked $Hmptr $Hghctx $Hcovered Haddrs]").
       { erewrite <- (insert_id m) at 2; eauto. }
-      wp_auto. iApply "HΦ". iFrame.
+      iApply "HΦ". iFrame.
 
   - wp_auto.
     wp_apply (wp_NewCond) as "%c #Hcond".
-    wp_auto. wp_alloc lst as "Hlst".
+    wp_alloc lst as "Hlst".
     wp_auto.
-    wp_apply (wp_map_insert with "Hmptr"). iIntros "Hmptr".
-    wp_auto.
+    wp_apply (wp_map_insert with "Hmptr") as "Hmptr".
     wp_for_post.
 
     iDestruct (big_sepM2_lookup_r_none with "Haddrs") as %Hgaddr; intuition eauto.
@@ -205,7 +204,7 @@ Proof.
       + rewrite lookup_insert_ne //.
     }
 
-    wp_auto. iApply "HΦ". iFrame.
+    iApply "HΦ". iFrame.
 Qed.
 
 Theorem wp_lockShard__release ls (addr : u64) (P : u64 -> iProp Σ) covered gh :
@@ -243,12 +242,11 @@ Proof.
     rewrite insert_delete_insert.
     rewrite (insert_id m); eauto.
 
-    wp_auto. wp_apply (wp_Mutex__Unlock with "[$Hlock $Hlocked $Hmptr $Hghctx $Haddrs $Hcovered]").
-    wp_auto. iApply "HΦ". done.
+    wp_apply (wp_Mutex__Unlock with "[$Hlock $Hlocked $Hmptr $Hghctx $Haddrs $Hcovered]").
+    iApply "HΦ". done.
 
   - wp_auto.
-    wp_apply (wp_map_delete with "Hmptr"). iIntros "Hmptr".
-    wp_auto.
+    wp_apply (wp_map_delete with "Hmptr") as "Hmptr".
 
     iMod (ghost_map_delete with "Hghctx Haddrlocked") as "Hghctx".
     iDestruct (big_sepS_delete with "Hcovered") as "[Hcaddr Hcovered]"; eauto.
@@ -266,7 +264,7 @@ Proof.
       + rewrite lookup_delete_ne //.
     }
 
-    wp_auto. iApply "HΦ". done.
+    iApply "HΦ". done.
 Qed.
 
 
@@ -541,7 +539,7 @@ Proof.
   iDestruct (big_sepL2_lookup _ _ _ _ _ gh with "Hshards") as "Hshard"; eauto.
   { rewrite -Hgh_lookup. f_equal. word. }
   wp_apply (wp_lockShard__release with "[$Hshard $HP $Hlocked]").
-  wp_auto. iApply "HΦ". eauto.
+  iApply "HΦ". eauto.
 Qed.
 
 End heap.

--- a/new/proof/github_com/mit_pdos/go_journal/util.v
+++ b/new/proof/github_com/mit_pdos/go_journal/util.v
@@ -86,9 +86,9 @@ Proof.
   iNamed "Hpkg".
   iNamed "Hinit".
   wp_auto.
-  wp_if_destruct.
-  - wp_auto. wp_apply wp_Printf.
-    wp_auto. iApply "HΦ". done.
+  wp_if_destruct; try wp_auto.
+  - wp_apply wp_Printf.
+    iApply "HΦ". done.
   - iApply "HΦ". done.
 Qed.
 

--- a/new/proof/github_com/mit_pdos/gokv/asyncfile.v
+++ b/new/proof/github_com/mit_pdos/gokv/asyncfile.v
@@ -218,7 +218,7 @@ Proof.
   iDestruct (Mutex_is_Locker with "[] [$]") as "#Hlk".
   { iPkgInit. }
   wp_apply (wp_Mutex__Lock with "[$HmuInv]") as "[Hlocked Hown]".
-  wp_auto. wp_for "Hown".
+  wp_for "Hown".
   destruct bool_decide eqn:?.
   { (* case: wait *)
     simpl.
@@ -229,7 +229,7 @@ Proof.
       iFrame "∗#%".
     }
     iDestruct "H" as "[Hlocked Hown]".
-    wp_auto. wp_for_post.
+    wp_for_post.
     by iFrame.
   }
   { (* case: i is durable *)
@@ -244,7 +244,7 @@ Proof.
       iFrame "HmuInv Hlocked".
       repeat iExists _; iFrame "∗#%".
     }
-    wp_auto. iApply "HΦ". iFrame.
+    iApply "HΦ". iFrame.
   }
 Qed.
 
@@ -362,7 +362,7 @@ Proof.
   wp_apply (wp_Mutex__Lock with "[$HmuInv]") as "[Hlocked Hown]".
   iNamed "Hown".
   wp_auto.
-  wp_apply wp_SumAssumeNoOverflow as "%Hno_overflow". wp_auto.
+  wp_apply wp_SumAssumeNoOverflow as "%Hno_overflow".
   iMod (write_step with "[$] [$] [$] [Hupd]") as "H".
   { word. }
   {
@@ -371,7 +371,7 @@ Proof.
   }
   iDestruct "H" as "(Hnoclose & Hdat & Hghost & Hesc & #Hinv)".
   iMod (own_slice_persist with "Hdata_in") as "#Hdata_in".
-  wp_apply wp_Cond__Signal; first iFrame "#". wp_auto.
+  wp_apply wp_Cond__Signal; first iFrame "#".
   wp_apply (wp_Mutex__Unlock with "[-HΦ Hnoclose Hdat Hesc s data index]").
   {
     iFrame "HmuInv Hlocked".
@@ -379,7 +379,7 @@ Proof.
     repeat iExists _.
     iFrame "∗#%".
   }
-  wp_auto. iApply "HΦ".
+  iApply "HΦ".
   iFrame "∗#".
   wp_auto.
   wp_apply (wp_AsyncFile__wait N _ _ P with "[-]").
@@ -458,7 +458,6 @@ Proof.
   iNamed "His". wp_auto.
   wp_apply (wp_Mutex__Lock with "[]") as "[Hlocked Hown]".
   { iFrame "#". }
-  wp_auto.
   iAssert (∃ curdata curidx,
               "HpreData" ∷ own_predurable_data γ curdata ∗
               "HpreIdx" ∷ own_predurable_index γ curidx ∗
@@ -491,14 +490,13 @@ Proof.
   iNamed "HH".
   iMod (get_upd with "[$] [$] [$] [$]") as "H".
   iDestruct "H" as "(HpreData & HpreIdx & HdurIdx & Hupd & Hghost)".
-  wp_apply (wp_Mutex__Unlock with "[-HΦ HpreData HpreIdx HdurIdx Hupd Hfile s index data]").
+  wp_apply (wp_Mutex__Unlock with "[-HΦ HpreData HpreIdx HdurIdx Hupd Hfile s index data]") --lc 2.
   {
     iFrame "HmuInv Hlocked".
     repeat iExists _; iFrame "∗#%".
     iFrame "#".
     done.
   }
-  wp_auto_lc 2.
   iDestruct (lc_split with "[$]") as "Hlc".
   iCombine "Hfilename_in Hfilename" gives %[_ [=<-]].
   wp_apply (wp_FileWrite with "[$Hdata]").
@@ -533,7 +531,7 @@ Proof.
   iMod (update_durable_index with "[$] HnewWits [$]") as "[HdurIdx Hghost]".
   wp_apply wp_Cond__Broadcast.
   { iFrame "#". }
-  wp_auto. wp_for_post.
+  wp_for_post.
   iFrame "HΦ Hlocked".
   iFrame "∗#%".
 Qed.
@@ -620,9 +618,9 @@ Proof.
   wp_start. iNamed "Hpre".
   wp_auto_lc 2.
   iDestruct (lc_split with "[$]") as "Hlc".
-  wp_apply (wp_NewCond) as "% #?". wp_auto.
-  wp_apply (wp_NewCond) as "% #?". wp_auto.
-  wp_apply (wp_NewCond) as "% #?". wp_auto.
+  wp_apply (wp_NewCond) as "% #?".
+  wp_apply (wp_NewCond) as "% #?".
+  wp_apply (wp_NewCond) as "% #?".
   wp_apply (wp_FileRead).
   iDestruct (own_crash_unfold with "Hfile") as "Hfile".
   unshelve iMod ("Hfile" $! _ _ with "[$]") as "[[HP $] Hau]".
@@ -658,7 +656,7 @@ Proof.
     { iFrame "∗#". }
     done.
   }
-  wp_auto. iApply "HΦ".
+  iApply "HΦ".
   iFrame "∗#".
 Qed.
 

--- a/new/proof/github_com/mit_pdos/gokv/lockservice.v
+++ b/new/proof/github_com/mit_pdos/gokv/lockservice.v
@@ -89,7 +89,7 @@ Proof.
   wp_start as "(#Hck&#Hlock)".
   iNamed "Hck".
   iNamed "Hkv_is".
-  wp_auto_lc 1.
+  wp_auto --lc 1.
   wp_for.
   wp_apply ("HcputSpec" with "[//]").
   rewrite /is_lock.

--- a/new/proof/github_com/mit_pdos/gokv/partialapp.v
+++ b/new/proof/github_com/mit_pdos/gokv/partialapp.v
@@ -41,7 +41,7 @@ Lemma wp_Foo__someMethodWithArgs (f : main.Foo.t) (y : go_string) (z : w64) :
 Proof.
   intros ?. wp_start as "_".
   wp_auto.
-  wp_apply wp_partiallyApplyMe; first done. wp_auto. by iApply "HΦ".
+  wp_apply wp_partiallyApplyMe; first done. by iApply "HΦ".
 Qed.
 
 Lemma wp_main :
@@ -53,12 +53,12 @@ Proof.
   wp_apply wp_with_defer as "%defer defer".
   simpl subst. wp_auto.
   wp_apply wp_partiallyApplyMe; first done.
-  wp_auto. wp_apply wp_Foo__someMethod.
-  wp_auto. wp_apply wp_Foo__someMethodWithArgs; first done.
-  wp_auto. wp_apply wp_Foo__someMethodWithArgs; first done.
-  wp_auto. wp_apply wp_partiallyApplyMe; first done.
-  wp_auto. wp_apply wp_partiallyApplyMe; first done.
-  wp_auto. by iApply "HΦ".
+  wp_apply wp_Foo__someMethod.
+  wp_apply wp_Foo__someMethodWithArgs; first done.
+  wp_apply wp_Foo__someMethodWithArgs; first done.
+  wp_apply wp_partiallyApplyMe; first done.
+  wp_apply wp_partiallyApplyMe; first done.
+  by iApply "HΦ".
 Qed.
 
 End proof.

--- a/new/proof/go_etcd_io/etcd/client/v3/concurrency.v
+++ b/new/proof/go_etcd_io/etcd/client/v3/concurrency.v
@@ -93,8 +93,8 @@ Lemma wp_NewSession (client : loc) γetcd :
 Proof.
   wp_start. iNamed "Hpre".
   wp_auto.
-  wp_apply (wp_Client__GetLogger with "[$]") as "% _". wp_auto.
-  wp_apply (wp_Client__Ctx with "[$]") as "% % #Hcontext". wp_auto.
+  wp_apply (wp_Client__GetLogger with "[$]") as "% _".
+  wp_apply (wp_Client__Ctx with "[$]") as "% % #Hcontext".
   wp_alloc ops as "Hops".
   wp_auto.
   (* only consider nil options *)
@@ -106,7 +106,7 @@ Proof.
   iIntros "_".
 
   wp_auto.
-  wp_apply (wp_Client__Grant with "[$]") as "* [Hresp Hl]". wp_auto.
+  wp_apply (wp_Client__Grant with "[$]") as "* [Hresp Hl]".
   destruct bool_decide eqn:Herr.
   2:{ (* got an error; early return *)
     wp_auto.
@@ -122,12 +122,11 @@ Proof.
   iDestruct "Hl" as "#Hlease0".
   wp_apply (wp_WithCancel True) as "* (Hcancel & Hctx)".
   { iFrame "#". }
-  wp_auto.
 
   wp_apply (wp_Client__KeepAlive with "[$]") as "* #Hkch".
-  wp_auto. rewrite bool_decide_decide. destruct decide.
+  rewrite bool_decide_decide. destruct decide.
   2:{ (* error *)
-    wp_auto. wp_apply "Hcancel". wp_auto. iApply "HΦ".
+    wp_auto. wp_apply "Hcancel". iApply "HΦ".
     rewrite decide_False //.
   }
   iDestruct "Hkch" as "#[Hkch #Hkrecv]".
@@ -141,7 +140,6 @@ Proof.
   }
   wp_auto.
   wp_apply (wp_chan_make (V:=())) as "* Hdonec".
-  wp_auto.
   rename s into ctx_desc.
   wp_alloc s as "Hs".
   wp_auto.
@@ -166,7 +164,7 @@ Proof.
       wp_auto.
       wp_apply (wp_closeable_chan_close with "[$Hdonec_open]") as "_".
       { iFrame "#". done. }
-      wp_auto. wp_apply "Hcancel". wp_auto.
+      wp_apply "Hcancel".
       done.
     }
     {
@@ -186,7 +184,7 @@ Proof.
   iDestruct (struct_fields_split with "Hs") as "hs".
   simpl. iClear "Hctx". iNamed "hs".
   iPersist "Hclient Hid Hdonec".
-  wp_auto. iModIntro.
+  iModIntro.
   iApply "HΦ".
   rewrite decide_True //.
   iFrame "#".

--- a/new/proof/go_etcd_io/etcd/client/v3/leasing.v
+++ b/new/proof/go_etcd_io/etcd/client/v3/leasing.v
@@ -10,6 +10,7 @@ Require Import New.proof.go_etcd_io.etcd.client.v3.
 From Perennial.algebra Require Import ghost_var.
 Require Import Perennial.base.
 
+Ltac2 Set wp_apply_auto_default := Ltac2.Init.false.
 
 Class leasingG Σ :=
   {
@@ -225,7 +226,7 @@ Proof.
     { (* not nil *)
       rewrite decide_False //. iNamed "Hsession".
       wp_auto.
-      wp_apply "HDone".
+      wp_apply "HDone". wp_auto.
       wp_apply wp_Session__Done.
       { iFrame "#". }
       iIntros "* #HsessDone".
@@ -378,7 +379,7 @@ Proof.
   iIntros (after_ch) "#[after_ch Hafter_ch]".
   wp_auto.
   iNamed "Hctx".
-  wp_apply "HDone".
+  wp_apply "HDone". wp_auto.
   wp_apply wp_chan_select_blocking.
   rewrite big_andL_cons.
   iSplit.
@@ -453,9 +454,9 @@ Proof.
   iIntros "Hmu_lkv".
   wp_auto.
   iNamed "Hctx_in".
-  wp_apply "HDone".
+  wp_apply "HDone". wp_auto.
   iNamedSuffix "Hctx_lkv" "_lkv".
-  wp_apply "HDone_lkv".
+  wp_apply "HDone_lkv". wp_auto.
   wp_apply wp_chan_select_blocking.
   rewrite !big_andL_cons big_andL_nil right_id.
   iSplit.
@@ -606,6 +607,7 @@ Proof using Type*.
   wp_start. iNamed "Hpre".
   wp_auto.
   wp_apply (wp_Client__Ctx with "[$]") as "* #Hclient_ctx".
+  wp_auto.
   iDestruct (is_Client_to_pub with "[$]") as "#Hclient_pub".
   iNamed "Hclient_pub".
   wp_apply (wp_WithCancel True with "Hclient_ctx").
@@ -613,8 +615,8 @@ Proof using Type*.
   wp_auto.
   unshelve wp_apply wp_map_make as "%revokes revokes"; try tc_solve; try tc_solve.
   { done. }
-  wp_apply (wp_chan_make (V:=unit)) as "* ?".
-  wp_alloc lkv as "Hlkv".
+  wp_auto. wp_apply (wp_chan_make (V:=unit)) as "* ?".
+  wp_auto. wp_alloc lkv as "Hlkv".
   wp_auto.
   iDestruct (struct_fields_split with "Hlkv") as "Hl".
   iEval (simpl) in "Hl".
@@ -730,26 +732,26 @@ Proof using Type*.
       (* ~13 seconds. *)
       iFrame "∗#". *)
     } *)
-    wp_apply "Hwg_done1".
-    done.
+    wp_auto. wp_apply "Hwg_done1".
+    wp_auto. done.
   }
   iPersist "cctx".
-  wp_apply (wp_fork with "[Hwg_done2 Hlc]").
+  wp_auto. wp_apply (wp_fork with "[Hwg_done2 Hlc]").
   {
     wp_auto. wp_apply wp_with_defer as "%defer defer".
     simpl subst.
     wp_auto.
     wp_apply (wp_leaseCache__clearOldRevokes with "[Hlc]").
     { iFrame "Hlc Hctx'". }
-    wp_apply "Hwg_done2".
-    done.
+    wp_auto. wp_apply "Hwg_done2".
+    wp_auto. done.
   }
 
   replace (num_lkvs) with (1 + (num_lkvs - 1)) by word.
   rewrite Z2Nat.inj_add //.
   rewrite -> replicate_S.
   iDestruct "Hmus" as "[Hmu Hmus]".
-  wp_apply (wp_leasingKV__waitSession with "[Hmu]").
+  wp_auto. wp_apply (wp_leasingKV__waitSession with "[Hmu]").
   { iFrame "∗#%". }
   iIntros (err) "[Hmu Hmaybe_ready]".
   wp_auto.

--- a/new/proof/go_etcd_io/etcd/client/v3/leasing.v
+++ b/new/proof/go_etcd_io/etcd/client/v3/leasing.v
@@ -225,7 +225,7 @@ Proof.
     { (* not nil *)
       rewrite decide_False //. iNamed "Hsession".
       wp_auto.
-      wp_apply "HDone". wp_auto.
+      wp_apply "HDone".
       wp_apply wp_Session__Done.
       { iFrame "#". }
       iIntros "* #HsessDone".
@@ -378,7 +378,7 @@ Proof.
   iIntros (after_ch) "#[after_ch Hafter_ch]".
   wp_auto.
   iNamed "Hctx".
-  wp_apply "HDone". wp_auto.
+  wp_apply "HDone".
   wp_apply wp_chan_select_blocking.
   rewrite big_andL_cons.
   iSplit.
@@ -453,9 +453,9 @@ Proof.
   iIntros "Hmu_lkv".
   wp_auto.
   iNamed "Hctx_in".
-  wp_apply "HDone". wp_auto.
+  wp_apply "HDone".
   iNamedSuffix "Hctx_lkv" "_lkv".
-  wp_apply "HDone_lkv". wp_auto.
+  wp_apply "HDone_lkv".
   wp_apply wp_chan_select_blocking.
   rewrite !big_andL_cons big_andL_nil right_id.
   iSplit.
@@ -606,7 +606,6 @@ Proof using Type*.
   wp_start. iNamed "Hpre".
   wp_auto.
   wp_apply (wp_Client__Ctx with "[$]") as "* #Hclient_ctx".
-  wp_auto.
   iDestruct (is_Client_to_pub with "[$]") as "#Hclient_pub".
   iNamed "Hclient_pub".
   wp_apply (wp_WithCancel True with "Hclient_ctx").
@@ -614,8 +613,8 @@ Proof using Type*.
   wp_auto.
   unshelve wp_apply wp_map_make as "%revokes revokes"; try tc_solve; try tc_solve.
   { done. }
-  wp_auto. wp_apply (wp_chan_make (V:=unit)) as "* ?".
-  wp_auto. wp_alloc lkv as "Hlkv".
+  wp_apply (wp_chan_make (V:=unit)) as "* ?".
+  wp_alloc lkv as "Hlkv".
   wp_auto.
   iDestruct (struct_fields_split with "Hlkv") as "Hl".
   iEval (simpl) in "Hl".
@@ -731,26 +730,26 @@ Proof using Type*.
       (* ~13 seconds. *)
       iFrame "∗#". *)
     } *)
-    wp_auto. wp_apply "Hwg_done1".
-    wp_auto. done.
+    wp_apply "Hwg_done1".
+    done.
   }
   iPersist "cctx".
-  wp_auto. wp_apply (wp_fork with "[Hwg_done2 Hlc]").
+  wp_apply (wp_fork with "[Hwg_done2 Hlc]").
   {
     wp_auto. wp_apply wp_with_defer as "%defer defer".
     simpl subst.
     wp_auto.
     wp_apply (wp_leaseCache__clearOldRevokes with "[Hlc]").
     { iFrame "Hlc Hctx'". }
-    wp_auto. wp_apply "Hwg_done2".
-    wp_auto. done.
+    wp_apply "Hwg_done2".
+    done.
   }
 
   replace (num_lkvs) with (1 + (num_lkvs - 1)) by word.
   rewrite Z2Nat.inj_add //.
   rewrite -> replicate_S.
   iDestruct "Hmus" as "[Hmu Hmus]".
-  wp_auto. wp_apply (wp_leasingKV__waitSession with "[Hmu]").
+  wp_apply (wp_leasingKV__waitSession with "[Hmu]").
   { iFrame "∗#%". }
   iIntros (err) "[Hmu Hmaybe_ready]".
   wp_auto.

--- a/new/proof/go_etcd_io/etcd/client/v3_proof/op.v
+++ b/new/proof/go_etcd_io/etcd/client/v3_proof/op.v
@@ -102,7 +102,7 @@ Proof.
   iIntros "%val_sl val_sl". progress wp_pures.
   rewrite -!default_val_eq_zero_val. progress wp_pures.
   wp_store. progress wp_pures. wp_load. progress wp_pures.
-  wp_apply wp_Op__applyOpts. progress wp_pures.
+  wp_apply wp_Op__applyOpts --no-auto. progress wp_pures.
   wp_bind.
 
   Time eapply (tac_wp_load_ty []);

--- a/new/proof/go_etcd_io/etcd/client/v3_proof/op.v
+++ b/new/proof/go_etcd_io/etcd/client/v3_proof/op.v
@@ -2,6 +2,8 @@ From New.proof.go_etcd_io.etcd.client.v3_proof Require Import base definitions.
 
 #[local] Transparent is_pkg_init_clientv3.
 
+Ltac2 Set wp_apply_auto_default := Ltac2.Init.false.
+
 (* abstraction of an etcd [Op] *)
 Module Op.
 Inductive t :=
@@ -102,7 +104,7 @@ Proof.
   iIntros "%val_sl val_sl". progress wp_pures.
   rewrite -!default_val_eq_zero_val. progress wp_pures.
   wp_store. progress wp_pures. wp_load. progress wp_pures.
-  wp_apply wp_Op__applyOpts --no-auto. progress wp_pures.
+  wp_apply wp_Op__applyOpts. progress wp_pures.
   wp_bind.
 
   Time eapply (tac_wp_load_ty []);

--- a/new/proof/sync_proof/cond.v
+++ b/new/proof/sync_proof/cond.v
@@ -61,8 +61,8 @@ Proof.
   wp_method_call. wp_call.
   iNamed "Hlock".
   wp_auto.
-  wp_apply ("H_Unlock" with "[$]"). wp_auto.
-  wp_apply ("H_Lock" with "[$]") as "?". wp_auto.
+  wp_apply ("H_Unlock" with "[$]").
+  wp_apply ("H_Lock" with "[$]") as "?".
   iApply "HΦ". done.
 Qed.
 

--- a/new/proof/sync_proof/rwmutex.v
+++ b/new/proof/sync_proof/rwmutex.v
@@ -559,7 +559,7 @@ Proof.
     rewrite bool_decide_false //. wp_auto.
     wp_apply (wp_Mutex__Unlock with "[Hlocked Hwl]").
     { iFrame "#". iFrame. }
-    wp_auto. iRight in "HΦ". iFrame.
+    iRight in "HΦ". iFrame.
 Qed.
 
 Local Hint Unfold sync.rwmutexMaxReaders actualMaxReaders : word.
@@ -601,7 +601,7 @@ Proof.
   - wp_auto.
     wp_apply (wp_Mutex__Unlock with "[Hlocked Hwl]").
     { iFrame "#". iFrame. replace (r') with (W32 0) by word. iFrame. }
-    wp_auto. iFrame.
+    iFrame.
 Qed.
 
 Local Transparent own_RWMutex_invariant own_Int32.


### PR DESCRIPTION
This is now done in a more flexible manner so the automation can be disabled, using https://github.com/rocq-community/rocq-tricks/blob/main/src/TacticNotationOptionalParams.v.

Along the way I applied the same mechanism to give `wp_auto` a `--lc <n>` argument to optionally generate later credits.