### PR TITLE
Revamp exports

### DIFF
--- a/src/base.v
+++ b/src/base.v
@@ -2,7 +2,7 @@
 files. *)
 
 From Coq Require Import ZArith.
-From stdpp Require Export base tactics.
+From iris Require Export prelude.
 
 Notation "'sealed' x" := (unseal (_ : seal x)) (at level 200, only parsing).
 


### PR DESCRIPTION
i've run into so many `Import` ordering problems that wasted a bunch of time. the thing that "put the nail in the coffin" was having no order of importing `stdpp.list` that worked (i.e., didn't break something else) in my `hashchain` proof. this PR (once done) attempts to make the situation better.

TODO:
- remove exports from as many non-standard places as possible.
- if there are lots of common imports (e.g., common iris things like `mono_nat`), add to `base`?
- add Perennial forks / extensions like the `Helpers` directory to `base`?
- it's somewhat unfortunate that random iris files `Export` things. we could try to upstream Export changes there to make it more consistent. if not, those can't be imported after `base` bc of conflicts like Z scope. so they need to come before.
- ... probably other things that i'm missing. i intend to make a design doc for this to make sure i have a systematic plan.