### PR TITLE
Add protocol folder/start proving protocols

### DIFF
--- a/new/proof/github_com/goose_lang/goose/model/channel/logatom/chan_au_base.v
+++ b/new/proof/github_com/goose_lang/goose/model/channel/logatom/chan_au_base.v
@@ -489,7 +489,7 @@ Definition send_au_slow ch (cap: Z) (v : V) (γ: chan_names) (Φ : iProp Σ) : i
     (* Case: Buffered channel with space available *)
     | chan_rep.Buffered buff => 
         if (length buff <? cap) 
-        then (own_channel ch cap (chan_rep.SndCommit v) γ ={∅,⊤}=∗ Φ)
+        then (own_channel ch cap (chan_rep.Buffered (buff ++ [v])) γ ={∅,⊤}=∗ Φ)
         else True
     | _ => True
     end).
@@ -508,7 +508,7 @@ Definition send_au_fast ch (cap: Z) (v : V) (γ: chan_names) (Φ : iProp Σ) : i
     (* Case: Buffered channel with space available *)
     | chan_rep.Buffered buff => 
         if (length buff <? cap) 
-        then (own_channel ch cap (chan_rep.SndCommit v) γ ={∅,⊤}=∗ Φ)
+        then (own_channel ch cap (chan_rep.Buffered (buff ++ [v])) γ ={∅,⊤}=∗ Φ)
         else True
     | _ => True
     end).

--- a/new/proof/github_com/goose_lang/goose/model/channel/protocol/dsp/cofe_solver_2.v
+++ b/new/proof/github_com/goose_lang/goose/model/channel/protocol/dsp/cofe_solver_2.v
@@ -1,0 +1,88 @@
+From iris.algebra Require Import cofe_solver.
+
+(** Version of the cofe_solver for a parametrized functor. Generalize and move
+to Iris. *)
+Record solution_2 (F : ofe → oFunctor) := Solution2 {
+  solution_2_car : ∀ An `{!Cofe An} A `{!Cofe A}, ofe;
+  solution_2_cofe `{!Cofe An, !Cofe A} : Cofe (solution_2_car An A);
+  solution_2_iso `{!Cofe An, !Cofe A} :>
+    ofe_iso (oFunctor_apply (F A) (solution_2_car A An)) (solution_2_car An A);
+}.
+Arguments solution_2_car {F}.
+Global Existing Instance solution_2_cofe.
+
+Section cofe_solver_2.
+  Context (F : ofe → oFunctor).
+  Context `{Fcontr : !∀ T, oFunctorContractive (F T)}.
+  Context `{Fcofe : !∀ `{!Cofe T, !Cofe Bn, !Cofe B}, Cofe (oFunctor_car (F T) Bn B)}.
+  Context `{Finh : !∀ `{!Cofe T, !Cofe Bn, !Cofe B}, Inhabited (oFunctor_car (F T) Bn B)}.
+  Notation map := (oFunctor_map (F _)).
+
+  Definition F_2 (An : ofe) `{!Cofe An} (A : ofe) `{!Cofe A} : oFunctor :=
+    oFunctor_oFunctor_compose (F A) (F An).
+
+  Definition T_result `{!Cofe An, !Cofe A} : solution (F_2 An A) := solver.result _.
+  Definition T (An : ofe) `{!Cofe An} (A : ofe) `{!Cofe A} : ofe :=
+    T_result (An:=An) (A:=A).
+  Instance T_cofe `{!Cofe An, !Cofe A} : Cofe (T An A) := _.
+  Instance T_inhabited `{!Cofe An, !Cofe A} : Inhabited (T An A) :=
+    populate (ofe_iso_1 T_result inhabitant).
+
+  Definition T_iso_fun_aux `{!Cofe An, !Cofe A}
+      (rec : prodO (oFunctor_apply (F An) (T An A) -n> T A An)
+                   (T A An -n> oFunctor_apply (F An) (T An A))) :
+      prodO (oFunctor_apply (F A) (T A An) -n> T An A)
+            (T An A -n> oFunctor_apply (F A) (T A An)) :=
+    (ofe_iso_1 T_result ◎ map (rec.1,rec.2), map (rec.2,rec.1) ◎ ofe_iso_2 T_result).
+  Instance T_iso_aux_fun_contractive `{!Cofe An, !Cofe A} :
+    Contractive (T_iso_fun_aux (An:=An) (A:=A)).
+  Proof. solve_contractive. Qed.
+
+  Definition T_iso_fun_aux_2 `{!Cofe An, !Cofe A}
+      (rec : prodO (oFunctor_apply (F A) (T A An) -n> T An A)
+                   (T An A -n> oFunctor_apply (F A) (T A An))) :
+      prodO (oFunctor_apply (F A) (T A An) -n> T An A)
+            (T An A -n> oFunctor_apply (F A) (T A An)) :=
+    T_iso_fun_aux (T_iso_fun_aux rec).
+  Instance T_iso_fun_aux_2_contractive `{!Cofe An, !Cofe A} :
+    Contractive (T_iso_fun_aux_2 (An:=An) (A:=A)).
+  Proof.
+    intros n rec1 rec2 Hrec. rewrite /T_iso_fun_aux_2.
+    f_equiv. by apply T_iso_aux_fun_contractive.
+  Qed.
+
+  Definition T_iso_fun `{!Cofe An, !Cofe A} :
+      prodO (oFunctor_apply (F A) (T A An) -n> T An A)
+            (T An A -n> oFunctor_apply (F A) (T A An)) :=
+    fixpoint T_iso_fun_aux_2.
+  Definition T_iso_fun_unfold_1 `{!Cofe An, !Cofe A} y :
+    T_iso_fun (An:=An) (A:=A).1 y ≡ (T_iso_fun_aux (T_iso_fun_aux T_iso_fun)).1 y.
+  Proof. apply (fixpoint_unfold T_iso_fun_aux_2). Qed.
+  Definition T_iso_fun_unfold_2 `{!Cofe An, !Cofe A} y :
+    T_iso_fun (An:=An) (A:=A).2 y ≡ (T_iso_fun_aux (T_iso_fun_aux T_iso_fun)).2 y.
+  Proof. apply (fixpoint_unfold T_iso_fun_aux_2). Qed.
+
+  Lemma result_2 : solution_2 F.
+  Proof using Fcontr Fcofe Finh.
+    apply (Solution2 F T _)=> An Hcn A Hc.
+    apply (OfeIso (T_iso_fun.1) (T_iso_fun.2)).
+    - intros y. apply equiv_dist=> n. revert An Hcn A Hc y.
+      induction (lt_wf n) as [n _ IH]; intros An ? A ? y.
+      rewrite T_iso_fun_unfold_1 T_iso_fun_unfold_2 /=.
+      rewrite -{2}(ofe_iso_12 T_result y). f_equiv.
+      rewrite -(oFunctor_map_id (F _) (ofe_iso_2 T_result y))
+              -!oFunctor_map_compose.
+      f_equiv; apply Fcontr; dist_later_intro as n' Hn'; split=> x /=;
+        rewrite ofe_iso_21 -{2}(oFunctor_map_id (F _) x)
+          -!oFunctor_map_compose; do 2 f_equiv; split=> z /=; auto.
+    - intros y. apply equiv_dist=> n. revert An Hcn A Hc y.
+      induction (lt_wf n) as [n _ IH]; intros An ? A ? y.
+      rewrite T_iso_fun_unfold_1 T_iso_fun_unfold_2 /= ofe_iso_21.
+      rewrite -(oFunctor_map_id (F _) y) -!oFunctor_map_compose.
+      f_equiv; apply Fcontr; dist_later_intro as n' Hn'; split=> x /=;
+        rewrite -{2}(ofe_iso_12 T_result x); f_equiv;
+        rewrite -{2}(oFunctor_map_id (F _) (ofe_iso_2 T_result x))
+                -!oFunctor_map_compose;
+        do 2 f_equiv; split=> z /=; auto.
+  Qed.
+End cofe_solver_2.

--- a/new/proof/github_com/goose_lang/goose/model/channel/protocol/dsp/dsp.v
+++ b/new/proof/github_com/goose_lang/goose/model/channel/protocol/dsp/dsp.v
@@ -1,0 +1,254 @@
+Require Import New.proof.proof_prelude.
+From New.proof.github_com.goose_lang.goose.model.channel
+     Require Export chan_au_send chan_au_recv chan_au_base chan_init.
+From New.proof.github_com.goose_lang.goose.model.channel
+     Require Export dsp_ghost_theory.
+
+(** * Dependent Separation Protocols (DSP) over Go Channels
+
+    This file implements dependent separation protocols using bidirectional Go channels.
+
+    Key concepts:
+    - Two protocol endpoints (left and right) communicate via two Go channels
+    - LR channel: left endpoint sends V_LR values to right endpoint
+    - RL channel: right endpoint sends V_RL values to left endpoint
+    - Protocol state is tracked using Actris iProto with sum types
+    - Channel closure is protocol-aware - only allowed when protocol permits
+*)
+
+(** ** Sum Type for Bidirectional Communication *)
+
+Definition DspV (V_LR V_RL : Type) := sum V_LR V_RL.
+
+#[export] Instance eqdec_sum `{EqDecision A} `{EqDecision B}
+  : EqDecision (A + B) := _.
+#[export] Instance countable_sum `{Countable A} `{Countable B}
+  : Countable (A + B) := _.
+
+Section dsp.
+Context `{hG: heapGS Σ, !ffi_semantics _ _}.
+Context `{!ghost_varG Σ ()}.
+Context `{!chanGhostStateG Σ ()}.
+Context `{!globalsGS Σ} {go_ctx : GoContext}.
+
+(** ** Buffer Matching Predicates *)
+
+(** Defines when Go channel state matches expected message queue *)
+Definition lr_buffer_matches {V_LR}
+    (lr_state : chan_rep.t V_LR) (vsl : list V_LR) : Prop :=
+  match lr_state with
+  | chan_rep.Buffered queue => vsl = queue
+  | chan_rep.SndPending v | chan_rep.SndCommit v => vsl = [v]
+  | chan_rep.Closed draining => vsl = draining
+  | _ => vsl = []
+  end.
+
+Definition rl_buffer_matches {V_RL}
+    (rl_state : chan_rep.t V_RL) (vsr : list V_RL) : Prop :=
+  match rl_state with
+  | chan_rep.Buffered queue => vsr = queue
+  | chan_rep.SndPending v | chan_rep.SndCommit v => vsr = [v]
+  | chan_rep.Closed draining => vsr = draining
+  | _ => vsr = []
+  end.
+
+(** ** Protocol Value Lifting *)
+
+(** Lift left-to-right values into sum type for protocol *)
+Definition lift_lr {V_LR V_RL} (vsl : list V_LR)
+  : list (DspV V_LR V_RL) := List.map (@inl V_LR V_RL) vsl.
+
+(** Lift right-to-left values into sum type for protocol *)
+Definition lift_rl {V_LR V_RL} (vsr : list V_RL)
+  : list (DspV V_LR V_RL) := List.map (@inr V_LR V_RL) vsr.
+
+(** ** DSP Session Context *)
+
+(** DSP session invariant - owns both channels and maintains protocol state *)
+Definition dsp_session_inv {V_LR V_RL}
+    `{!protoG Σ (DspV V_LR V_RL)}
+    `{!chanGhostStateG Σ V_LR} `{!IntoVal V_LR} `{!IntoValTyped V_LR tL}
+    `{!chanGhostStateG Σ V_RL} `{!IntoVal V_RL} `{!IntoValTyped V_RL tR}
+    (γl γr : gname)
+    (lr_chan rl_chan : loc) (γlr_names γrl_names : chan_names)
+    (lrcap rlcap: Z) : iProp Σ :=
+  ∃ lr_state rl_state vsl vsr,
+    own_channel lr_chan lrcap lr_state γlr_names ∗
+    own_channel rl_chan rlcap rl_state γrl_names ∗
+    ⌜lr_buffer_matches lr_state vsl⌝ ∗
+    ⌜rl_buffer_matches rl_state vsr⌝ ∗
+    iProto_ctx γl γr (lift_lr vsl) (lift_rl vsr).
+
+(** DSP session context - public interface with persistent channel handles *)
+Definition dsp_session {V_LR V_RL}
+    `{!protoG Σ (DspV V_LR V_RL)}
+    `{!chanGhostStateG Σ V_LR} `{!IntoVal V_LR} `{!IntoValTyped V_LR tL}
+    `{!chanGhostStateG Σ V_RL} `{!IntoVal V_RL} `{!IntoValTyped V_RL tR}
+    (γl γr : gname) (N : namespace)
+    (lr_chan rl_chan : loc) (γlr_names γrl_names : chan_names)
+    (lrcap rlcap: Z) : iProp Σ :=
+  is_channel lr_chan lrcap γlr_names ∗
+  is_channel rl_chan rlcap γrl_names ∗
+  inv N (dsp_session_inv γl γr lr_chan rl_chan γlr_names γrl_names lrcap rlcap).
+
+(** ** DSP Endpoints *)
+
+(** Left endpoint - can send V_LR via lr_chan, receive V_RL via rl_chan *)
+Definition dsp_left_endpoint {V_LR V_RL}
+    `{!protoG Σ (DspV V_LR V_RL)}
+    `{!chanGhostStateG Σ V_LR} `{!IntoVal V_LR} `{!IntoValTyped V_LR tL}
+    `{!chanGhostStateG Σ V_RL} `{!IntoVal V_RL} `{!IntoValTyped V_RL tR}
+    (γl γr : gname) (N : namespace)
+    (lr_chan rl_chan : loc) (γlr_names γrl_names : chan_names)
+    (lrcap rlcap: Z)
+    (p : iProto Σ (DspV V_LR V_RL)) : iProp Σ :=
+  dsp_session γl γr N lr_chan rl_chan γlr_names γrl_names lrcap rlcap ∗
+  iProto_own γl p.
+
+(** Right endpoint - can send V_RL via rl_chan, receive V_LR via lr_chan *)
+Definition dsp_right_endpoint {V_LR V_RL}
+    `{!protoG Σ (DspV V_LR V_RL)}
+    `{!chanGhostStateG Σ V_LR} `{!IntoVal V_LR} `{!IntoValTyped V_LR tL}
+    `{!chanGhostStateG Σ V_RL} `{!IntoVal V_RL} `{!IntoValTyped V_RL tR}
+    (γl γr : gname) (N : namespace)
+    (lr_chan rl_chan : loc) (γlr_names γrl_names : chan_names)
+    (lrcap rlcap: Z)
+    (p : iProto Σ (DspV V_LR V_RL)) : iProp Σ :=
+  dsp_session γl γr N lr_chan rl_chan γlr_names γrl_names lrcap rlcap ∗
+  iProto_own γr p.
+
+(** ** Initialization *)
+
+(** Initialize a new DSP session from basic channels *)
+Lemma dsp_session_init {V_LR V_RL}
+    `{!protoG Σ (DspV V_LR V_RL)}
+    `{!chanGhostStateG Σ V_LR} `{!IntoVal V_LR} `{!IntoValTyped V_LR tL}
+    `{!chanGhostStateG Σ V_RL} `{!IntoVal V_RL} `{!IntoValTyped V_RL tR}
+    (N : namespace) (lr_chan rl_chan : loc) (γlr_names γrl_names : chan_names)
+    (lrcap rlcap: Z) (p : iProto Σ (DspV V_LR V_RL)) :
+  is_channel lr_chan lrcap γlr_names -∗
+  is_channel rl_chan rlcap γrl_names -∗
+  own_channel lr_chan lrcap chan_rep.Idle γlr_names -∗
+  own_channel rl_chan rlcap chan_rep.Idle γrl_names ==∗
+  ∃ γl γr,
+    dsp_left_endpoint γl γr N lr_chan rl_chan γlr_names γrl_names lrcap rlcap p ∗
+    dsp_right_endpoint γl γr N lr_chan rl_chan γlr_names γrl_names lrcap rlcap (iProto_dual p).
+Proof.
+Admitted.
+
+(** ** Left Endpoint Operations *)
+
+(** Left endpoint sends V_LR value via lr_chan *)
+Lemma dsp_left_send {V_LR V_RL}
+    `{!protoG Σ (DspV V_LR V_RL)}
+    `{!chanGhostStateG Σ V_LR} `{!IntoVal V_LR} `{!IntoValTyped V_LR tL}
+    `{!chanGhostStateG Σ V_RL} `{!IntoVal V_RL} `{!IntoValTyped V_RL tR}
+    (γl γr : gname) (N : namespace)
+    (lr_chan rl_chan : loc) (γlr_names γrl_names : chan_names)
+    (lrcap rlcap: Z) (v : V_LR) (m : iMsg Σ (DspV V_LR V_RL)) :
+  {{{ is_pkg_init channel ∗
+      dsp_left_endpoint γl γr N lr_chan rl_chan γlr_names γrl_names lrcap rlcap (<!> m) ∗
+      ∃ p', iMsg_car m (inl v) (Next p') }}}
+    lr_chan @ (ptrT.id channel.Channel.id) @ "Send" #tL #v
+  {{{ p', RET #();
+      iMsg_car m (inl v) (Next p') ∗
+      dsp_left_endpoint γl γr N lr_chan rl_chan γlr_names γrl_names lrcap rlcap p' }}}.
+Proof.
+Admitted.
+
+(** Left endpoint receives V_RL value via rl_chan *)
+Lemma dsp_left_recv {V_LR V_RL}
+    `{!protoG Σ (DspV V_LR V_RL)}
+    `{!chanGhostStateG Σ V_LR} `{!IntoVal V_LR} `{!IntoValTyped V_LR tL}
+    `{!chanGhostStateG Σ V_RL} `{!IntoVal V_RL} `{!IntoValTyped V_RL tR}
+    (γl γr : gname) (N : namespace)
+    (lr_chan rl_chan : loc) (γlr_names γrl_names : chan_names)
+    (lrcap rlcap: Z) (m : iMsg Σ (DspV V_LR V_RL)) :
+  {{{ is_pkg_init channel ∗
+      dsp_left_endpoint γl γr N lr_chan rl_chan γlr_names γrl_names lrcap rlcap (<?> m) }}}
+    rl_chan @ (ptrT.id channel.Channel.id) @ "Receive" #tR #()
+  {{{ (v : V_RL) (ok : bool), RET (#v, #ok);
+      if ok then ∃ p', iMsg_car m (inr v) (Next p') ∗
+                      dsp_left_endpoint γl γr N lr_chan rl_chan γlr_names γrl_names lrcap rlcap p'
+      else (* Channel closed - only valid if protocol allows termination *)
+           iProto_le (<?> m) END ∗
+           dsp_left_endpoint γl γr N lr_chan rl_chan γlr_names γrl_names lrcap rlcap END }}}.
+Proof.
+Admitted.
+
+
+(** Left endpoint closes lr_chan (stops sending V_LR) *)
+Lemma dsp_left_close_lr {V_LR V_RL}
+    `{!protoG Σ (DspV V_LR V_RL)}
+    `{!chanGhostStateG Σ V_LR} `{!IntoVal V_LR} `{!IntoValTyped V_LR tL}
+    `{!chanGhostStateG Σ V_RL} `{!IntoVal V_RL} `{!IntoValTyped V_RL tR}
+    (γl γr : gname) (N : namespace)
+    (lr_chan rl_chan : loc) (γlr_names γrl_names : chan_names)
+    (lrcap rlcap: Z) (p : iProto Σ (DspV V_LR V_RL)) :
+  {{{ is_pkg_init channel ∗
+      dsp_left_endpoint γl γr N lr_chan rl_chan γlr_names γrl_names lrcap rlcap p ∗
+      (* Only allow closure when protocol permits it *)
+      p ⊑ END }}}
+    lr_chan @ (ptrT.id channel.Channel.id) @ "Close" #tL #()
+  {{{ RET #(); dsp_left_endpoint γl γr N lr_chan rl_chan γlr_names γrl_names lrcap rlcap END }}}.
+Proof.
+Admitted.
+
+(** ** Right Endpoint Operations *)
+
+(** Right endpoint sends V_RL value via rl_chan *)
+Lemma dsp_right_send {V_LR V_RL}
+    `{!protoG Σ (DspV V_LR V_RL)}
+    `{!chanGhostStateG Σ V_LR} `{!IntoVal V_LR} `{!IntoValTyped V_LR tL}
+    `{!chanGhostStateG Σ V_RL} `{!IntoVal V_RL} `{!IntoValTyped V_RL tR}
+    (γl γr : gname) (N : namespace)
+    (lr_chan rl_chan : loc) (γlr_names γrl_names : chan_names)
+    (lrcap rlcap: Z) (v : V_RL) (m : iMsg Σ (DspV V_LR V_RL)) :
+  {{{ is_pkg_init channel ∗
+      dsp_right_endpoint γl γr N lr_chan rl_chan γlr_names γrl_names lrcap rlcap (<!> m) ∗
+      ∃ p', iMsg_car m (inr v) (Next p') }}}
+    rl_chan @ (ptrT.id channel.Channel.id) @ "Send" #tR #v
+  {{{ p', RET #();
+      iMsg_car m (inr v) (Next p') ∗
+      dsp_right_endpoint γl γr N lr_chan rl_chan γlr_names γrl_names lrcap rlcap p' }}}.
+Proof.
+Admitted.
+
+(** Right endpoint receives V_LR value via lr_chan *)
+Lemma dsp_right_recv {V_LR V_RL}
+    `{!protoG Σ (DspV V_LR V_RL)}
+    `{!chanGhostStateG Σ V_LR} `{!IntoVal V_LR} `{!IntoValTyped V_LR tL}
+    `{!chanGhostStateG Σ V_RL} `{!IntoVal V_RL} `{!IntoValTyped V_RL tR}
+    (γl γr : gname) (N : namespace)
+    (lr_chan rl_chan : loc) (γlr_names γrl_names : chan_names)
+    (lrcap rlcap: Z) (m : iMsg Σ (DspV V_LR V_RL)) :
+  {{{ is_pkg_init channel ∗
+      dsp_right_endpoint γl γr N lr_chan rl_chan γlr_names γrl_names lrcap rlcap (<?> m) }}}
+    lr_chan @ (ptrT.id channel.Channel.id) @ "Receive" #tL #()
+  {{{ (v : V_LR) (ok : bool), RET (#v, #ok);
+      if ok then ∃ p', iMsg_car m (inl v) (Next p') ∗
+                      dsp_right_endpoint γl γr N lr_chan rl_chan γlr_names γrl_names lrcap rlcap p'
+      else (* Channel closed - only valid if protocol allows termination *)
+           (<?> m) ⊑ END ∗
+           dsp_right_endpoint γl γr N lr_chan rl_chan γlr_names γrl_names lrcap rlcap END }}}.
+Proof.
+Admitted.
+
+(** Right endpoint closes rl_chan (stops sending V_RL) *)
+Lemma dsp_right_close_rl {V_LR V_RL}
+    `{!protoG Σ (DspV V_LR V_RL)}
+    `{!chanGhostStateG Σ V_LR} `{!IntoVal V_LR} `{!IntoValTyped V_LR tL}
+    `{!chanGhostStateG Σ V_RL} `{!IntoVal V_RL} `{!IntoValTyped V_RL tR}
+    (γl γr : gname) (N : namespace)
+    (lr_chan rl_chan : loc) (γlr_names γrl_names : chan_names)
+    (lrcap rlcap: Z) (p : iProto Σ (DspV V_LR V_RL)) :
+  {{{ is_pkg_init channel ∗
+      dsp_right_endpoint γl γr N lr_chan rl_chan γlr_names γrl_names lrcap rlcap p ∗
+      (* Only allow closure when protocol permits it *)
+      p ⊑ END }}}
+    rl_chan @ (ptrT.id channel.Channel.id) @ "Close" #tR #()
+  {{{ RET #(); dsp_right_endpoint γl γr N lr_chan rl_chan γlr_names γrl_names lrcap rlcap END }}}.
+Proof.
+Admitted.
+
+End dsp.

--- a/new/proof/github_com/goose_lang/goose/model/channel/protocol/dsp/dsp_ghost_theory.v
+++ b/new/proof/github_com/goose_lang/goose/model/channel/protocol/dsp/dsp_ghost_theory.v
@@ -1,0 +1,1243 @@
+(** This file defines the core of the Actris logic: It defines dependent
+separation protocols and the various operations on it like dual, append, and
+branching.
+
+Dependent separation protocols [iProto] are defined by instantiating the
+parameterized version in [proto_model] with the type of propositions [iProp] of Iris.
+We define ways of constructing instances of the instantiated type via two
+constructors:
+- [iProto_end], which is identical to [proto_end].
+- [iProto_message], which takes an [action] and an [iMsg]. The type [iMsg] is a
+  sequence of binders [iMsg_exist], terminated by the payload constructed with
+  [iMsg_base] based on arguments [v], [P] and [prot], which are the value, the
+  carried proposition and the [iProto] tail, respectively.
+
+For convenience sake, we provide the following notations:
+- [END], which is simply [iProto_end].
+- [∃ x, m], which is [iMsg_exist] with argument [m].
+- [MSG v {{ P }}; prot], which is [iMsg_Base] with arguments [v], [P] and [prot].
+- [<a> m], which is [iProto_message] with arguments [a] and [m].
+
+We also include custom notation to more easily construct complete constructions:
+- [<a x1 .. xn> m], which is [<a> ∃ x1, .. ∃ xn, m].
+- [<a x1 .. xn> MSG v; {{ P }}; prot], which constructs a full protocol.
+
+Futhermore, we define the following operations:
+- [iProto_dual], which turns all [Send] of a protocol into [Recv] and vice-versa.
+- [iProto_app], which appends two protocols.
+
+In addition we define the subprotocol relation [iProto_le] [⊑], which generalises
+the following inductive definition for asynchronous subtyping on session types:
+
+                 p1 <: p2           p1 <: p2          p1 <: !B.p3    ?A.p3 <: p2
+----------   ----------------   ----------------     ----------------------------
+end <: end    !A.p1 <: !A.p2     ?A.p1 <: ?A.p2             ?A.p1 <: !B.p2
+
+Example:
+
+!R <: !R  ?Q <: ?Q      ?Q <: ?Q
+-------------------  --------------
+?Q.!R <: !R.?Q       ?P.?Q <: ?P.?Q
+------------------------------------
+   ?P.?Q.!R <: !R.?P.?Q
+
+Lastly, relevant type classes instances are defined for each of the above
+notions, such as contractiveness and non-expansiveness, after which the
+specifications of the message-passing primitives are defined in terms of the
+protocol connectives. *)
+From iris.algebra Require Import excl_auth.
+From iris.proofmode Require Import proofmode.
+From iris.base_logic Require Export lib.iprop.
+From iris.base_logic Require Import lib.own.
+From iris.program_logic Require Import language.
+From New.proof.github_com.goose_lang.goose.model.channel Require Import proto_model.
+Set Default Proof Using "Type".
+Export action.
+
+(** * Types *)
+Definition iProto Σ V := proto V (iPropO Σ) (iPropO Σ).
+Declare Scope proto_scope.
+Delimit Scope proto_scope with proto.
+Bind Scope proto_scope with iProto.
+Open Scope proto.
+
+(** * Setup of Iris's cameras *)
+Class protoG Σ V :=
+  protoG_authG ::
+    inG Σ (excl_authR (laterO (iProto Σ V))).
+
+Definition protoΣ V := #[
+  GFunctor (authRF (optionURF (exclRF (laterOF (protoOF (leibnizO V) idOF idOF)))))
+].
+Global Instance subG_chanΣ {Σ V} : subG (protoΣ V) Σ → protoG Σ V.
+Proof. solve_inG. Qed.
+
+(** * Messages *)
+Section iMsg.
+  Set Primitive Projections.
+  Record iMsg Σ V := IMsg { iMsg_car : V → laterO (iProto Σ V) -n> iPropO Σ }.
+End iMsg.
+Arguments IMsg {_ _} _.
+Arguments iMsg_car {_ _} _.
+
+Declare Scope msg_scope.
+Delimit Scope msg_scope with msg.
+Bind Scope msg_scope with iMsg.
+Global Instance iMsg_inhabited {Σ V} : Inhabited (iMsg Σ V) := populate (IMsg inhabitant).
+
+Section imsg_ofe.
+  Context {Σ : gFunctors} {V : Type}.
+
+  Instance iMsg_equiv : Equiv (iMsg Σ V) := λ m1 m2,
+    ∀ w p, iMsg_car m1 w p ≡ iMsg_car m2 w p.
+  Instance iMsg_dist : Dist (iMsg Σ V) := λ n m1 m2,
+    ∀ w p, iMsg_car m1 w p ≡{n}≡ iMsg_car m2 w p.
+
+  Lemma iMsg_ofe_mixin : OfeMixin (iMsg Σ V).
+  Proof. by apply (iso_ofe_mixin (iMsg_car : _ → V -d> _ -n> _)). Qed.
+  Canonical Structure iMsgO := Ofe (iMsg Σ V) iMsg_ofe_mixin.
+
+  Global Instance iMsg_cofe : Cofe iMsgO.
+  Proof. by apply (iso_cofe (IMsg : (V -d> _ -n> _) → _) iMsg_car). Qed.
+End imsg_ofe.
+
+Program Definition iMsg_base_def {Σ V}
+    (v : V) (P : iProp Σ) (p : iProto Σ V) : iMsg Σ V :=
+  IMsg (λ v', λne p', ⌜ v = v' ⌝ ∗ Next p ≡ p' ∗ P)%I.
+Next Obligation. solve_proper. Qed.
+Definition iMsg_base_aux : seal ( @iMsg_base_def). Proof. by eexists. Qed.
+Definition iMsg_base := iMsg_base_aux.(unseal).
+Definition iMsg_base_eq : @iMsg_base = @iMsg_base_def := iMsg_base_aux.(seal_eq).
+Arguments iMsg_base {_ _} _%_V _%_I _%_proto.
+Global Instance: Params ( @iMsg_base) 3 := {}.
+
+Program Definition iMsg_exist_def {Σ V A} (m : A → iMsg Σ V) : iMsg Σ V :=
+  IMsg (λ v', λne p', ∃ x, iMsg_car (m x) v' p')%I.
+Next Obligation. solve_proper. Qed.
+Definition iMsg_exist_aux : seal ( @iMsg_exist_def). by eexists. Qed.
+Definition iMsg_exist := iMsg_exist_aux.(unseal).
+Definition iMsg_exist_eq : @iMsg_exist = @iMsg_exist_def := iMsg_exist_aux.(seal_eq).
+Arguments iMsg_exist {_ _ _} _%_msg.
+Global Instance: Params ( @iMsg_exist) 3 := {}.
+
+Definition iMsg_texist {Σ V} {TT : tele} (m : TT → iMsg Σ V) : iMsg Σ V :=
+  tele_fold ( @iMsg_exist Σ V) (λ x, x) (tele_bind m).
+Arguments iMsg_texist {_ _ !_} _%_msg /.
+
+Notation "'MSG' v {{ P } } ; p" := (iMsg_base v P p)
+  (at level 200, v at level 20, right associativity,
+   format "MSG  v  {{  P  } } ;  p") : msg_scope.
+Notation "'MSG' v ; p" := (iMsg_base v True p)
+  (at level 200, v at level 20, right associativity,
+   format "MSG  v ;  p") : msg_scope.
+Notation "∃ x .. y , m" :=
+  (iMsg_exist (λ x, .. (iMsg_exist (λ y, m)) ..)%msg) : msg_scope.
+Notation "'∃..' x .. y , m" :=
+  (iMsg_texist (λ x, .. (iMsg_texist (λ y, m)) .. )%msg)
+  (at level 200, x binder, y binder, right associativity,
+   format "∃..  x  ..  y ,  m") : msg_scope.
+
+Lemma iMsg_texist_exist {Σ V} {TT : tele} w lp (m : TT → iMsg Σ V) :
+  iMsg_car (∃.. x, m x)%msg w lp ⊣⊢ (∃.. x, iMsg_car (m x) w lp).
+Proof.
+  rewrite /iMsg_texist iMsg_exist_eq.
+  induction TT as [|T TT IH]; simpl; [done|]. f_equiv=> x. apply IH.
+Qed.
+
+(** * Operators *)
+Definition iProto_end_def {Σ V} : iProto Σ V := proto_end.
+Definition iProto_end_aux : seal ( @iProto_end_def). by eexists. Qed.
+Definition iProto_end := iProto_end_aux.(unseal).
+Definition iProto_end_eq : @iProto_end = @iProto_end_def := iProto_end_aux.(seal_eq).
+Arguments iProto_end {_ _}.
+
+Definition iProto_message_def {Σ V} (a : action) (m : iMsg Σ V) : iProto Σ V :=
+  proto_message a (iMsg_car m).
+Definition iProto_message_aux : seal ( @iProto_message_def). by eexists. Qed.
+Definition iProto_message := iProto_message_aux.(unseal).
+Definition iProto_message_eq :
+  @iProto_message = @iProto_message_def := iProto_message_aux.(seal_eq).
+Arguments iProto_message {_ _} _ _%_msg.
+Global Instance: Params ( @iProto_message) 3 := {}.
+
+Notation "'END'" := iProto_end : proto_scope.
+
+Notation "< a > m" := (iProto_message a m)
+  (at level 200, a at level 10, m at level 200,
+   format "< a >  m") : proto_scope.
+Notation "< a @ x1 .. xn > m" := (iProto_message a (∃ x1, .. (∃ xn, m) ..))
+  (at level 200, a at level 10, x1 closed binder, xn closed binder, m at level 200,
+   format "< a  @  x1  ..  xn >  m") : proto_scope.
+Notation "< a @.. x1 .. xn > m" := (iProto_message a (∃.. x1, .. (∃.. xn, m) ..))
+  (at level 200, a at level 10, x1 closed binder, xn closed binder, m at level 200,
+   format "< a  @..  x1  ..  xn >  m") : proto_scope.
+
+Notation "<!> m" := (<Send> m) (at level 200, m at level 200) : proto_scope.
+Notation "<! x1 .. xn > m" := (<!> ∃ x1, .. (∃ xn, m) ..)
+  (at level 200, x1 closed binder, xn closed binder, m at level 200,
+   format "<!  x1  ..  xn >  m") : proto_scope.
+Notation "<!.. x1 .. xn > m" := (<!> ∃.. x1, .. (∃.. xn, m) ..)
+  (at level 200, x1 closed binder, xn closed binder, m at level 200,
+   format "<!..  x1  ..  xn >  m") : proto_scope.
+
+Notation "<?> m" := (<Recv> m) (at level 200, m at level 200) : proto_scope.
+Notation "<? x1 .. xn > m" := (<?> ∃ x1, .. (∃ xn, m) ..)
+  (at level 200, x1 closed binder, xn closed binder, m at level 200,
+   format "<?  x1  ..  xn >  m") : proto_scope.
+Notation "<?.. x1 .. xn > m" := (<?> ∃.. x1, .. (∃.. xn, m) ..)
+  (at level 200, x1 closed binder, xn closed binder, m at level 200,
+   format "<?..  x1  ..  xn >  m") : proto_scope.
+
+Class MsgTele {Σ V} {TT : tele} (m : iMsg Σ V)
+    (tv : TT -t> V) (tP : TT -t> iProp Σ) (tp : TT -t> iProto Σ V) :=
+  msg_tele : m ≡ (∃.. x, MSG tele_app tv x {{ tele_app tP x }}; tele_app tp x)%msg.
+Global Hint Mode MsgTele ! ! - ! - - - : typeclass_instances.
+
+(** * Operations *)
+Program Definition iMsg_map {Σ V}
+    (rec : iProto Σ V → iProto Σ V) (m : iMsg Σ V) : iMsg Σ V :=
+  IMsg (λ v, λne p1', ∃ p1, iMsg_car m v (Next p1) ∗ p1' ≡ Next (rec p1))%I.
+Next Obligation. solve_proper. Qed.
+
+Program Definition iProto_map_app_aux {Σ V}
+    (f : action → action) (p2 : iProto Σ V)
+    (rec : iProto Σ V -n> iProto Σ V) : iProto Σ V -n> iProto Σ V := λne p,
+  proto_elim p2 (λ a m,
+    proto_message (f a) (iMsg_car (iMsg_map rec (IMsg m)))) p.
+Next Obligation.
+  intros Σ V f p2 rec n p1 p1' Hp. apply proto_elim_ne=> // a m1 m2 Hm.
+  apply proto_message_ne=> v p' /=. by repeat f_equiv.
+Qed.
+
+Global Instance iProto_map_app_aux_contractive {Σ V} f (p2 : iProto Σ V) :
+  Contractive (iProto_map_app_aux f p2).
+Proof.
+  intros n rec1 rec2 Hrec p1; simpl. apply proto_elim_ne=> // a m1 m2 Hm.
+  apply proto_message_ne=> v p' /=. by repeat (f_contractive || f_equiv).
+Qed.
+
+Definition iProto_map_app {Σ V} (f : action → action)
+    (p2 : iProto Σ V) : iProto Σ V -n> iProto Σ V :=
+  fixpoint (iProto_map_app_aux f p2).
+
+Definition iProto_app_def {Σ V} (p1 p2 : iProto Σ V) : iProto Σ V :=
+  iProto_map_app id p2 p1.
+Definition iProto_app_aux : seal ( @iProto_app_def). Proof. by eexists. Qed.
+Definition iProto_app := iProto_app_aux.(unseal).
+Definition iProto_app_eq : @iProto_app = @iProto_app_def := iProto_app_aux.(seal_eq).
+Arguments iProto_app {_ _} _%_proto _%_proto.
+Global Instance: Params ( @iProto_app) 2 := {}.
+Infix "<++>" := iProto_app (at level 60) : proto_scope.
+Notation "m <++> p" := (iMsg_map (flip iProto_app p) m) : msg_scope.
+
+Definition iProto_dual_def {Σ V} (p : iProto Σ V) : iProto Σ V :=
+  iProto_map_app action_dual proto_end p.
+Definition iProto_dual_aux : seal ( @iProto_dual_def). Proof. by eexists. Qed.
+Definition iProto_dual := iProto_dual_aux.(unseal).
+Definition iProto_dual_eq :
+  @iProto_dual = @iProto_dual_def := iProto_dual_aux.(seal_eq).
+Arguments iProto_dual {_ _} _%_proto.
+Global Instance: Params ( @iProto_dual) 2 := {}.
+Notation iMsg_dual := (iMsg_map iProto_dual).
+
+Definition iProto_dual_if {Σ V} (d : bool) (p : iProto Σ V) : iProto Σ V :=
+  if d then iProto_dual p else p.
+Arguments iProto_dual_if {_ _} _ _%_proto.
+Global Instance: Params ( @iProto_dual_if) 3 := {}.
+
+(** * Protocol entailment *)
+Definition iProto_le_pre {Σ V}
+    (rec : iProto Σ V → iProto Σ V → iProp Σ) (p1 p2 : iProto Σ V) : iProp Σ :=
+  (p1 ≡ END ∗ p2 ≡ END) ∨
+  ∃ a1 a2 m1 m2,
+    (p1 ≡ <a1> m1) ∗ (p2 ≡ <a2> m2) ∗
+    match a1, a2 with
+    | Recv, Recv => ∀ v p1',
+       iMsg_car m1 v (Next p1') -∗ ∃ p2', ▷ rec p1' p2' ∗ iMsg_car m2 v (Next p2')
+    | Send, Send => ∀ v p2',
+       iMsg_car m2 v (Next p2') -∗ ∃ p1', ▷ rec p1' p2' ∗ iMsg_car m1 v (Next p1')
+    | Recv, Send => ∀ v1 v2 p1' p2',
+       iMsg_car m1 v1 (Next p1') -∗ iMsg_car m2 v2 (Next p2') -∗ ∃ pt,
+         ▷ rec p1' (<!> MSG v2; pt) ∗ ▷ rec (<?> MSG v1; pt) p2'
+    | Send, Recv => False
+    end.
+Global Instance iProto_le_pre_ne {Σ V} (rec : iProto Σ V → iProto Σ V → iProp Σ) :
+  NonExpansive2 (iProto_le_pre rec).
+Proof. solve_proper. Qed.
+
+Program Definition iProto_le_pre' {Σ V}
+    (rec : iProto Σ V -n> iProto Σ V -n> iPropO Σ) :
+    iProto Σ V -n> iProto Σ V -n> iPropO Σ := λne p1 p2,
+  iProto_le_pre (λ p1' p2', rec p1' p2') p1 p2.
+Solve Obligations with solve_proper.
+Local Instance iProto_le_pre_contractive {Σ V} : Contractive ( @iProto_le_pre' Σ V).
+Proof.
+  intros n rec1 rec2 Hrec p1 p2. rewrite /iProto_le_pre' /iProto_le_pre /=.
+  by repeat (f_contractive || f_equiv).
+Qed.
+Definition iProto_le {Σ V} (p1 p2 : iProto Σ V) : iProp Σ :=
+  fixpoint iProto_le_pre' p1 p2.
+Arguments iProto_le {_ _} _%_proto _%_proto.
+Global Instance: Params ( @iProto_le) 2 := {}.
+Notation "p ⊑ q" := (iProto_le p q) : bi_scope.
+
+Global Instance iProto_le_ne {Σ V} : NonExpansive2 ( @iProto_le Σ V).
+Proof. solve_proper. Qed.
+Global Instance iProto_le_proper {Σ V} : Proper ((≡) ==> (≡) ==> (⊣⊢)) ( @iProto_le Σ V).
+Proof. solve_proper. Qed.
+
+Fixpoint iProto_app_recvs {Σ V} (vs : list V) (p : iProto Σ V) : iProto Σ V :=
+  match vs with
+  | [] => p
+  | v :: vs => <?> MSG v; iProto_app_recvs vs p
+  end.
+Definition iProto_interp {Σ V} (vsl vsr : list V) (pl pr : iProto Σ V) : iProp Σ :=
+  ∃ p, iProto_app_recvs vsr p ⊑ pl ∗ iProto_app_recvs vsl (iProto_dual p) ⊑ pr.
+
+Definition iProto_own_frag `{!protoG Σ V} (γ : gname)
+    (p : iProto Σ V) : iProp Σ :=
+  own γ (◯E (Next p)).
+Definition iProto_own_auth `{!protoG Σ V} (γ : gname)
+    (p : iProto Σ V) : iProp Σ :=
+  own γ (●E (Next p)).
+
+(** In the original Actris papers we a single ghost name for [iProto_ctx] and
+[iProto_own]. To distinguish the two [iProto_own]s for both sides, we used
+an enum [Left]/[Right]. This turned out to be cumbersome because at various
+places we need to case at this enum. The current version of [iProto_ctx] has two
+ghost names, one for each [iProto_own], enabling more uniform definitions. *)
+Definition iProto_ctx `{protoG Σ V}
+    (γl γr : gname) (vsl vsr : list V) : iProp Σ :=
+  ∃ pl pr,
+    iProto_own_auth γl pl ∗
+    iProto_own_auth γr pr ∗
+    ▷ iProto_interp vsl vsr pl pr.
+
+(** * The connective for ownership of channel ends *)
+Definition iProto_own `{!protoG Σ V} (γ : gname) (p : iProto Σ V) : iProp Σ :=
+  ∃ p', ▷ (p' ⊑ p) ∗ iProto_own_frag γ p'.
+Arguments iProto_own {_ _ _} _ _%_proto.
+Global Instance: Params ( @iProto_own) 4 := {}.
+
+Global Instance iProto_own_contractive `{protoG Σ V} γ :
+  Contractive (iProto_own γ).
+Proof. solve_contractive. Qed.
+
+(** * Proofs *)
+Section proto.
+  Context `{!protoG Σ V}.
+  Implicit Types v : V.
+  Implicit Types p pl pr : iProto Σ V.
+  Implicit Types m : iMsg Σ V.
+
+  (** ** Equality *)
+  Lemma iProto_case p : p ≡ END ∨ ∃ a m, p ≡ <a> m.
+  Proof.
+    rewrite iProto_message_eq iProto_end_eq.
+    destruct (proto_case p) as [|(a&m&?)]; [by left|right].
+    by exists a, (IMsg m).
+  Qed.
+  Lemma iProto_message_equivI `{!BiInternalEq SPROP} a1 a2 m1 m2 :
+    (<a1> m1) ≡ (<a2> m2) ⊣⊢@{SPROP} ⌜ a1 = a2 ⌝ ∧
+      (∀ v lp, iMsg_car m1 v lp ≡ iMsg_car m2 v lp).
+  Proof. rewrite iProto_message_eq. apply proto_message_equivI. Qed.
+
+  Lemma iProto_message_end_equivI `{!BiInternalEq SPROP} a m :
+    (<a> m) ≡ END ⊢@{SPROP} False.
+  Proof. rewrite iProto_message_eq iProto_end_eq. apply proto_message_end_equivI. Qed.
+  Lemma iProto_end_message_equivI `{!BiInternalEq SPROP} a m :
+    END ≡ (<a> m) ⊢@{SPROP} False.
+  Proof. by rewrite internal_eq_sym iProto_message_end_equivI. Qed.
+
+  (** ** Non-expansiveness of operators *)
+  Global Instance iMsg_car_proper :
+    Proper (iMsg_equiv ==> (=) ==> (≡) ==> (≡)) (iMsg_car (Σ:=Σ) (V:=V)).
+  Proof.
+    intros m1 m2 meq v1 v2 veq p1 p2 peq. rewrite meq.
+    f_equiv; [ by f_equiv | done ].
+  Qed.
+  Global Instance iMsg_car_ne n :
+    Proper (iMsg_dist n ==> (=) ==> (dist n) ==> (dist n)) (iMsg_car (Σ:=Σ) (V:=V)).
+  Proof.
+    intros m1 m2 meq v1 v2 veq p1 p2 peq. rewrite meq.
+    f_equiv; [ by f_equiv | done ].
+  Qed.
+
+  Global Instance iMsg_contractive v n :
+    Proper (dist n ==> dist_later n ==> dist n) (iMsg_base (Σ:=Σ) (V:=V) v).
+  Proof. rewrite iMsg_base_eq=> P1 P2 HP p1 p2 Hp w q /=. solve_contractive. Qed.
+  Global Instance iMsg_ne v : NonExpansive2 (iMsg_base (Σ:=Σ) (V:=V) v).
+  Proof. rewrite iMsg_base_eq=> P1 P2 HP p1 p2 Hp w q /=. solve_proper. Qed.
+  Global Instance iMsg_proper v :
+    Proper ((≡) ==> (≡) ==> (≡)) (iMsg_base (Σ:=Σ) (V:=V) v).
+  Proof. apply (ne_proper_2 _). Qed.
+
+  Global Instance iMsg_exist_ne A n :
+    Proper (pointwise_relation _ (dist n) ==> (dist n)) ( @iMsg_exist Σ V A).
+  rewrite iMsg_exist_eq=> m1 m2 Hm v p /=. f_equiv=> x. apply Hm. Qed.
+  Global Instance iMsg_exist_proper A :
+    Proper (pointwise_relation _ (≡) ==> (≡)) ( @iMsg_exist Σ V A).
+  Proof. rewrite iMsg_exist_eq=> m1 m2 Hm v p /=. f_equiv=> x. apply Hm. Qed.
+
+  Global Instance msg_tele_base (v:V) (P : iProp Σ) (p : iProto Σ V) :
+    MsgTele (TT:=TeleO) (MSG v {{ P }}; p) v P p.
+  Proof. done. Qed.
+  Global Instance msg_tele_exist {A} {TT : A → tele} (m : A → iMsg Σ V) tv tP tp :
+  (∀ x, MsgTele (TT:=TT x) (m x) (tv x) (tP x) (tp x)) →
+  MsgTele (TT:=TeleS TT) (∃ x, m x) tv tP tp.
+  Proof. intros Hm. rewrite /MsgTele /=. f_equiv=> x. apply Hm. Qed.
+
+  Global Instance iProto_message_ne a :
+    NonExpansive (iProto_message (Σ:=Σ) (V:=V) a).
+  Proof. rewrite iProto_message_eq. solve_proper. Qed.
+  Global Instance iProto_message_proper a :
+    Proper ((≡) ==> (≡)) (iProto_message (Σ:=Σ) (V:=V) a).
+  Proof. apply (ne_proper _). Qed.
+
+  Lemma iProto_message_equiv {TT1 TT2 : tele} a1 a2
+        (m1 m2 : iMsg Σ V)
+        (v1 : TT1 -t> V) (v2 : TT2 -t> V)
+        (P1 : TT1 -t> iProp Σ) (P2 : TT2 -t> iProp Σ)
+        (prot1 : TT1 -t> iProto Σ V) (prot2 : TT2 -t> iProto Σ V) :
+    MsgTele m1 v1 P1 prot1 →
+    MsgTele m2 v2 P2 prot2 →
+    ⌜ a1 = a2 ⌝ -∗
+    (■ ∀.. (xs1 : TT1), tele_app P1 xs1 -∗
+       ∃.. (xs2 : TT2), ⌜tele_app v1 xs1 = tele_app v2 xs2⌝ ∗
+                        ▷ (tele_app prot1 xs1 ≡ tele_app prot2 xs2) ∗
+                        tele_app P2 xs2) -∗
+    (■ ∀.. (xs2 : TT2), tele_app P2 xs2 -∗
+       ∃.. (xs1 : TT1), ⌜tele_app v1 xs1 = tele_app v2 xs2⌝ ∗
+                        ▷ (tele_app prot1 xs1 ≡ tele_app prot2 xs2) ∗
+                        tele_app P1 xs1) -∗
+      (<a1> m1) ≡ (<a2> m2).
+  Proof.
+    iIntros (Hm1 Hm2 Heq) "#Heq1 #Heq2".
+    unfold MsgTele in Hm1. rewrite Hm1. clear Hm1.
+    unfold MsgTele in Hm2. rewrite Hm2. clear Hm2.
+    rewrite iProto_message_eq proto_message_equivI.
+    iSplit; [ done | ].
+    iIntros (v p').
+    do 2 rewrite iMsg_texist_exist.
+    rewrite iMsg_base_eq /=.
+    iApply prop_ext.
+    iIntros "!>". iSplit.
+    - iDestruct 1 as (xs1 Hveq1) "[Hrec1 HP1]".
+      iDestruct ("Heq1" with "HP1") as (xs2 Hveq2) "[Hrec2 HP2]".
+      iExists xs2. rewrite -Hveq1 Hveq2.
+      iSplitR; [ done | ]. iSplitR "HP2"; [ | done ].
+      iRewrite -"Hrec1". iApply later_equivI. iIntros "!>". by iRewrite "Hrec2".
+    - iDestruct 1 as (xs2 Hveq2) "[Hrec2 HP2]".
+      iDestruct ("Heq2" with "HP2") as (xs1 Hveq1) "[Hrec1 HP1]".
+      iExists xs1. rewrite -Hveq2 Hveq1.
+      iSplitR; [ done | ]. iSplitR "HP1"; [ | done ].
+      iRewrite -"Hrec2". iApply later_equivI. iIntros "!>". by iRewrite "Hrec1".
+  Qed.
+
+  (** Helpers *)
+  Lemma iMsg_map_base f v P p :
+    NonExpansive f →
+    iMsg_map f (MSG v {{ P }}; p) ≡ (MSG v {{ P }}; f p)%msg.
+  Proof.
+    rewrite iMsg_base_eq. intros ? v' p'; simpl. iSplit.
+    - iDestruct 1 as (p'') "[(->&Hp&$) Hp']". iSplit; [done|].
+      iRewrite "Hp'". iIntros "!>". by iRewrite "Hp".
+    - iIntros "(->&Hp'&$)". iExists p. iRewrite -"Hp'". auto.
+  Qed.
+  Lemma iMsg_map_exist {A} f (m : A → iMsg Σ V) :
+    iMsg_map f (∃ x, m x) ≡ (∃ x, iMsg_map f (m x))%msg.
+  Proof.
+    rewrite iMsg_exist_eq. intros v' p'; simpl. iSplit.
+    - iDestruct 1 as (p'') "[H Hp']". iDestruct "H" as (x) "H"; auto.
+    - iDestruct 1 as (x p'') "[Hm Hp']". auto.
+  Qed.
+
+  (** ** Dual *)
+  Global Instance iProto_dual_ne : NonExpansive ( @iProto_dual Σ V).
+   rewrite iProto_dual_eq. solve_proper. Qed.
+  Global Instance iProto_dual_proper : Proper ((≡) ==> (≡)) ( @iProto_dual Σ V).
+  Proof. apply (ne_proper _). Qed.
+  Global Instance iProto_dual_if_ne d : NonExpansive ( @iProto_dual_if Σ V d).
+  Proof. solve_proper. Qed.
+  Global Instance iProto_dual_if_proper d :
+    Proper ((≡) ==> (≡)) ( @iProto_dual_if Σ V d).
+  Proof. apply (ne_proper _). Qed.
+
+  Lemma iProto_dual_end : iProto_dual (Σ:=Σ) (V:=V) END ≡ END.
+  Proof.
+    rewrite iProto_end_eq iProto_dual_eq /iProto_dual_def /iProto_map_app.
+    etrans; [apply (fixpoint_unfold (iProto_map_app_aux _ _))|]; simpl.
+    by rewrite proto_elim_end.
+  Qed.
+  Lemma iProto_dual_message a m :
+    iProto_dual (<a> m) ≡ <action_dual a> iMsg_dual m.
+  Proof.
+    rewrite iProto_message_eq iProto_dual_eq /iProto_dual_def /iProto_map_app.
+    etrans; [apply (fixpoint_unfold (iProto_map_app_aux _ _))|]; simpl.
+    rewrite /iProto_message_def. rewrite ->proto_elim_message; [done|].
+    intros a' m1 m2 Hm; f_equiv; solve_proper.
+  Qed.
+  Lemma iMsg_dual_base v P p :
+    iMsg_dual (MSG v {{ P }}; p) ≡ (MSG v {{ P }}; iProto_dual p)%msg.
+  Proof. apply iMsg_map_base, _. Qed.
+  Lemma iMsg_dual_exist {A} (m : A → iMsg Σ V) :
+    iMsg_dual (∃ x, m x) ≡ (∃ x, iMsg_dual (m x))%msg.
+  Proof. apply iMsg_map_exist. Qed.
+
+  Global Instance iProto_dual_involutive : Involutive (≡) ( @iProto_dual Σ V).
+  Proof.
+    intros p. apply (uPred.internal_eq_soundness (M:=iResUR Σ)).
+    iLöb as "IH" forall (p). destruct (iProto_case p) as [->|(a&m&->)].
+    { by rewrite !iProto_dual_end. }
+    rewrite !iProto_dual_message involutive.
+    iApply iProto_message_equivI; iSplit; [done|]; iIntros (v p') "/=".
+    iApply prop_ext; iIntros "!>"; iSplit.
+    - iDestruct 1 as (pd) "[H Hp']". iRewrite "Hp'".
+      iDestruct "H" as (pdd) "[H #Hpd]".
+      iApply (internal_eq_rewrite); [|done]; iIntros "!>".
+      iRewrite "Hpd". by iRewrite ("IH" $! pdd).
+    - iIntros "H". destruct (Next_uninj p') as [p'' Hp']. iExists _.
+      rewrite Hp'. iSplitL; [by auto|]. iIntros "!>". by iRewrite ("IH" $! p'').
+  Qed.
+
+  (** ** Append *)
+  Global Instance iProto_app_end_l : LeftId (≡) END ( @iProto_app Σ V).
+  Proof.
+    intros p. rewrite iProto_end_eq iProto_app_eq /iProto_app_def /iProto_map_app.
+    etrans; [apply (fixpoint_unfold (iProto_map_app_aux _ _))|]; simpl.
+    by rewrite proto_elim_end.
+  Qed.
+  Lemma iProto_app_message a m p2 : (<a> m) <++> p2 ≡ <a> m <++> p2.
+  Proof.
+    rewrite iProto_message_eq iProto_app_eq /iProto_app_def /iProto_map_app.
+    etrans; [apply (fixpoint_unfold (iProto_map_app_aux _ _))|]; simpl.
+    rewrite /iProto_message_def. rewrite ->proto_elim_message; [done|].
+    intros a' m1 m2 Hm. f_equiv; solve_proper.
+  Qed.
+
+  Global Instance iProto_app_ne : NonExpansive2 ( @iProto_app Σ V).
+  Proof.
+    assert (∀ n, Proper (dist n ==> (=) ==> dist n) ( @iProto_app Σ V)).
+    { intros n p1 p1' Hp1 p2 p2' <-. by rewrite iProto_app_eq /iProto_app_def Hp1. }
+    assert (Proper ((≡) ==> (=) ==> (≡)) ( @iProto_app Σ V)).
+    { intros p1 p1' Hp1 p2 p2' <-. by rewrite iProto_app_eq /iProto_app_def Hp1. }
+    intros n p1 p1' Hp1 p2 p2' Hp2. rewrite Hp1. clear p1 Hp1.
+    revert p1'. induction (lt_wf n) as [n _ IH]; intros p1.
+    destruct (iProto_case p1) as [->|(a&m&->)].
+    { by rewrite !left_id. }
+    rewrite !iProto_app_message. f_equiv=> v p' /=. do 4 f_equiv.
+    f_contractive. apply IH; eauto using dist_lt.
+  Qed.
+  Global Instance iProto_app_proper : Proper ((≡) ==> (≡) ==> (≡)) ( @iProto_app Σ V).
+  Proof. apply (ne_proper_2 _). Qed.
+
+  Lemma iMsg_app_base v P p1 p2 :
+    ((MSG v {{ P }}; p1) <++> p2)%msg ≡ (MSG v {{ P }}; p1 <++> p2)%msg.
+  Proof. apply: iMsg_map_base. Qed.
+  Lemma iMsg_app_exist {A} (m : A → iMsg Σ V) p2 :
+    ((∃ x, m x) <++> p2)%msg ≡ (∃ x, m x <++> p2)%msg.
+  Proof. apply iMsg_map_exist. Qed.
+
+  Global Instance iProto_app_end_r : RightId (≡) END ( @iProto_app Σ V).
+  Proof.
+    intros p. apply (uPred.internal_eq_soundness (M:=iResUR Σ)).
+    iLöb as "IH" forall (p). destruct (iProto_case p) as [->|(a&m&->)].
+    { by rewrite left_id. }
+    rewrite iProto_app_message.
+    iApply iProto_message_equivI; iSplit; [done|]; iIntros (v p') "/=".
+    iApply prop_ext; iIntros "!>". iSplit.
+    - iDestruct 1 as (p1') "[H Hp']". iRewrite "Hp'".
+      iApply (internal_eq_rewrite); [|done]; iIntros "!>".
+      by iRewrite ("IH" $! p1').
+    - iIntros "H". destruct (Next_uninj p') as [p'' Hp']. iExists p''.
+      rewrite Hp'. iSplitL; [by auto|]. iIntros "!>". by iRewrite ("IH" $! p'').
+  Qed.
+  Global Instance iProto_app_assoc : Assoc (≡) ( @iProto_app Σ V).
+  Proof.
+    intros p1 p2 p3. apply (uPred.internal_eq_soundness (M:=iResUR Σ)).
+    iLöb as "IH" forall (p1). destruct (iProto_case p1) as [->|(a&m&->)].
+    { by rewrite !left_id. }
+    rewrite !iProto_app_message.
+    iApply iProto_message_equivI; iSplit; [done|]; iIntros (v p123) "/=".
+    iApply prop_ext; iIntros "!>". iSplit.
+    - iDestruct 1 as (p1') "[H #Hp']".
+      iExists (p1' <++> p2). iSplitL; [by auto|].
+      iRewrite "Hp'". iIntros "!>". iApply "IH".
+    - iDestruct 1 as (p12) "[H #Hp123]". iDestruct "H" as (p1') "[H #Hp12]".
+      iExists p1'. iFrame "H". iRewrite "Hp123".
+      iIntros "!>". iRewrite "Hp12". by iRewrite ("IH" $! p1').
+  Qed.
+
+  Lemma iProto_dual_app p1 p2 :
+    iProto_dual (p1 <++> p2) ≡ iProto_dual p1 <++> iProto_dual p2.
+  Proof.
+    apply (uPred.internal_eq_soundness (M:=iResUR Σ)).
+    iLöb as "IH" forall (p1 p2). destruct (iProto_case p1) as [->|(a&m&->)].
+    { by rewrite iProto_dual_end !left_id. }
+    rewrite iProto_dual_message !iProto_app_message iProto_dual_message /=.
+    iApply iProto_message_equivI; iSplit; [done|]; iIntros (v p12) "/=".
+    iApply prop_ext; iIntros "!>". iSplit.
+    - iDestruct 1 as (p12d) "[H #Hp12]". iDestruct "H" as (p1') "[H #Hp12d]".
+      iExists (iProto_dual p1'). iSplitL; [by auto|].
+      iRewrite "Hp12". iIntros "!>". iRewrite "Hp12d". iApply "IH".
+    - iDestruct 1 as (p1') "[H #Hp12]". iDestruct "H" as (p1d) "[H #Hp1']".
+      iExists (p1d <++> p2). iSplitL; [by auto|].
+      iRewrite "Hp12". iIntros "!>". iRewrite "Hp1'". by iRewrite ("IH" $! p1d p2).
+  Qed.
+
+  (** ** Protocol entailment **)
+  Lemma iProto_le_unfold p1 p2 : iProto_le p1 p2 ≡ iProto_le_pre iProto_le p1 p2.
+  Proof. apply: (fixpoint_unfold iProto_le_pre'). Qed.
+
+  Lemma iProto_le_end : ⊢ END ⊑ (END : iProto Σ V).
+  Proof. rewrite iProto_le_unfold. iLeft. auto 10. Qed.
+
+  Lemma iProto_le_send m1 m2 :
+    (∀ v p2', iMsg_car m2 v (Next p2') -∗ ∃ p1',
+      ▷ (p1' ⊑ p2') ∗ iMsg_car m1 v (Next p1')) -∗
+    (<!> m1) ⊑ (<!> m2).
+  Proof. rewrite iProto_le_unfold. iIntros "H". iRight. auto 10. Qed.
+  Lemma iProto_le_recv m1 m2 :
+    (∀ v p1', iMsg_car m1 v (Next p1') -∗ ∃ p2',
+      ▷ (p1' ⊑ p2') ∗ iMsg_car m2 v (Next p2')) -∗
+    (<?> m1) ⊑ (<?> m2).
+  Proof. rewrite iProto_le_unfold. iIntros "H". iRight. auto 10. Qed.
+  Lemma iProto_le_swap m1 m2 :
+    (∀ v1 v2 p1' p2',
+       iMsg_car m1 v1 (Next p1') -∗ iMsg_car m2 v2 (Next p2') -∗ ∃ pt,
+         ▷ (p1' ⊑ <!> MSG v2; pt) ∗ ▷ ((<?> MSG v1; pt) ⊑ p2')) -∗
+    (<?> m1) ⊑ (<!> m2).
+  Proof. rewrite iProto_le_unfold. iIntros "H". iRight. auto 10. Qed.
+
+  Lemma iProto_le_end_inv_l p : p ⊑ END -∗ (p ≡ END).
+  Proof.
+    rewrite iProto_le_unfold. iIntros "[[Hp _]|H] //".
+    iDestruct "H" as (a1 a2 m1 m2) "(_ & Heq & _)".
+    by iDestruct (iProto_end_message_equivI with "Heq") as %[].
+  Qed.
+
+  Lemma iProto_le_end_inv_r p : END ⊑ p -∗ (p ≡ END).
+  Proof.
+    rewrite iProto_le_unfold. iIntros "[[_ Hp]|H] //".
+    iDestruct "H" as (a1 a2 m1 m2) "(Heq & _ & _)".
+    iDestruct (iProto_end_message_equivI with "Heq") as %[].
+  Qed.
+
+  Lemma iProto_le_send_inv p1 m2 :
+    p1 ⊑ (<!> m2) -∗ ∃ a1 m1,
+      (p1 ≡ <a1> m1) ∗
+      match a1 with
+      | Send => ∀ v p2',
+         iMsg_car m2 v (Next p2') -∗ ∃ p1',
+           ▷ (p1' ⊑ p2') ∗ iMsg_car m1 v (Next p1')
+      | Recv => ∀ v1 v2 p1' p2',
+         iMsg_car m1 v1 (Next p1') -∗ iMsg_car m2 v2 (Next p2') -∗ ∃ pt,
+           ▷ (p1' ⊑ <!> MSG v2; pt) ∗ ▷ ((<?> MSG v1; pt) ⊑ p2')
+      end.
+  Proof.
+    rewrite iProto_le_unfold. iIntros "[[_ Heq]|H]".
+    { iDestruct (iProto_message_end_equivI with "Heq") as %[]. }
+    iDestruct "H" as (a1 a2 m1 m2') "(Hp1 & Hp2 & H)".
+    iExists _, _; iSplit; [done|]. destruct a1, a2.
+    - iIntros (v p2') "Hm2".
+      iDestruct (iProto_message_equivI with "Hp2") as (_) "{Hp2} #Hm".
+      iApply "H". by iRewrite -("Hm" $! v (Next p2')).
+    - done.
+    - iIntros (v1 v2 p1' p2') "Hm1 Hm2".
+      iDestruct (iProto_message_equivI with "Hp2") as (_) "{Hp2} #Hm".
+      iApply ("H" with "Hm1"). by iRewrite -("Hm" $! v2 (Next p2')).
+    - iDestruct (iProto_message_equivI with "Hp2") as ([=]) "_".
+  Qed.
+  Lemma iProto_le_send_send_inv m1 m2 v p2' :
+    (<!> m1) ⊑ (<!> m2) -∗
+    iMsg_car m2 v (Next p2') -∗ ∃ p1', ▷ (p1' ⊑ p2') ∗ iMsg_car m1 v (Next p1').
+  Proof.
+    iIntros "H Hm2". iDestruct (iProto_le_send_inv with "H") as (a m1') "[Hm1 H]".
+    iDestruct (iProto_message_equivI with "Hm1") as (<-) "Hm1".
+    iDestruct ("H" with "Hm2") as (p1') "[Hle Hm]".
+    iRewrite -("Hm1" $! v (Next p1')) in "Hm". auto with iFrame.
+  Qed.
+  Lemma iProto_le_recv_send_inv m1 m2 v1 v2 p1' p2' :
+    (<?> m1) ⊑ (<!> m2) -∗
+    iMsg_car m1 v1 (Next p1') -∗ iMsg_car m2 v2 (Next p2') -∗ ∃ pt,
+      ▷ (p1' ⊑ <!> MSG v2; pt) ∗ ▷ ((<?> MSG v1; pt) ⊑ p2').
+  Proof.
+    iIntros "H Hm1 Hm2". iDestruct (iProto_le_send_inv with "H") as (a m1') "[Hm H]".
+    iDestruct (iProto_message_equivI with "Hm") as (<-) "{Hm} #Hm".
+    iApply ("H" with "[Hm1] Hm2"). by iRewrite -("Hm" $! v1 (Next p1')).
+  Qed.
+
+  Lemma iProto_le_recv_inv p1 m2 :
+    p1 ⊑ (<?> m2) -∗ ∃ m1,
+      (p1 ≡ <?> m1) ∗
+      ∀ v p1', iMsg_car m1 v (Next p1') -∗ ∃ p2',
+        ▷ (p1' ⊑ p2') ∗ iMsg_car m2 v (Next p2').
+  Proof.
+    rewrite iProto_le_unfold. iIntros "[[_ Heq]|H]".
+    { iDestruct (iProto_message_end_equivI with "Heq") as %[]. }
+    iDestruct "H" as (a1 a2 m1 m2') "(Hp1 & Hp2 & H)".
+    iExists m1.
+    iDestruct (iProto_message_equivI with "Hp2") as (<-) "{Hp2} #Hm2".
+    destruct a1; [done|]. iSplit; [done|].
+    iIntros (v p1') "Hm". iDestruct ("H" with "Hm") as (p2') "[Hle Hm]".
+    iExists p2'. iIntros "{$Hle}". by iRewrite ("Hm2" $! v (Next p2')).
+  Qed.
+  Lemma iProto_le_recv_recv_inv m1 m2 v p1' :
+    (<?> m1) ⊑ (<?> m2) -∗
+    iMsg_car m1 v (Next p1') -∗ ∃ p2', ▷ (p1' ⊑ p2') ∗ iMsg_car m2 v (Next p2').
+  Proof.
+    iIntros "H Hm2". iDestruct (iProto_le_recv_inv with "H") as (m1') "[Hm1 H]".
+    iApply "H". iDestruct (iProto_message_equivI with "Hm1") as (_) "Hm1".
+    by iRewrite -("Hm1" $! v (Next p1')).
+  Qed.
+
+  Lemma iProto_le_refl p : ⊢ p ⊑ p.
+  Proof.
+    iLöb as "IH" forall (p). destruct (iProto_case p) as [->|([]&m&->)].
+    - iApply iProto_le_end.
+    - iApply iProto_le_send. auto 10 with iFrame.
+    - iApply iProto_le_recv. auto 10 with iFrame.
+  Qed.
+
+  Lemma iProto_le_trans p1 p2 p3 : p1 ⊑ p2 -∗ p2 ⊑ p3 -∗ p1 ⊑ p3.
+  Proof.
+    iIntros "H1 H2". iLöb as "IH" forall (p1 p2 p3).
+    destruct (iProto_case p3) as [->|([]&m3&->)].
+    - iDestruct (iProto_le_end_inv_l with "H2") as "H2". by iRewrite "H2" in "H1".
+    - iDestruct (iProto_le_send_inv with "H2") as (a2 m2) "[Hp2 H2]".
+      iRewrite "Hp2" in "H1"; clear p2. destruct a2.
+      + iDestruct (iProto_le_send_inv with "H1") as (a1 m1) "[Hp1 H1]".
+        iRewrite "Hp1"; clear p1. destruct a1.
+        * iApply iProto_le_send. iIntros (v p3') "Hm3".
+          iDestruct ("H2" with "Hm3") as (p2') "[Hle Hm2]".
+          iDestruct ("H1" with "Hm2") as (p1') "[Hle' Hm1]".
+          iExists p1'. iIntros "{$Hm1} !>". by iApply ("IH" with "Hle'").
+        * iApply iProto_le_swap. iIntros (v1 v3 p1' p3') "Hm1 Hm3".
+          iDestruct ("H2" with "Hm3") as (p2') "[Hle Hm2]".
+          iDestruct ("H1" with "Hm1 Hm2") as (pt) "[Hp1' Hp2']".
+          iExists pt. iIntros "{$Hp1'} !>". by iApply ("IH" with "Hp2'").
+      + iDestruct (iProto_le_recv_inv with "H1") as (m1) "[Hp1 H1]".
+        iRewrite "Hp1"; clear p1. iApply iProto_le_swap.
+        iIntros (v1 v3 p1' p3') "Hm1 Hm3".
+        iDestruct ("H1" with "Hm1") as (p2') "[Hle Hm2]".
+        iDestruct ("H2" with "Hm2 Hm3") as (pt) "[Hp2' Hp3']".
+        iExists pt. iIntros "{$Hp3'} !>". by iApply ("IH" with "Hle").
+    - iDestruct (iProto_le_recv_inv with "H2") as (m2) "[Hp2 H3]".
+      iRewrite "Hp2" in "H1".
+      iDestruct (iProto_le_recv_inv with "H1") as (m1) "[Hp1 H2]".
+      iRewrite "Hp1". iApply iProto_le_recv. iIntros (v p1') "Hm1".
+      iDestruct ("H2" with "Hm1") as (p2') "[Hle Hm2]".
+      iDestruct ("H3" with "Hm2") as (p3') "[Hle' Hm3]".
+      iExists p3'. iIntros "{$Hm3} !>". by iApply ("IH" with "Hle").
+  Qed.
+
+  Lemma iProto_le_payload_elim_l a m v P p :
+    (P -∗ (<?> MSG v; p) ⊑ (<a> m)) ⊢
+    (<?> MSG v {{ P }}; p) ⊑ (<a> m).
+  Proof.
+    rewrite iMsg_base_eq. iIntros "H". destruct a.
+    - iApply iProto_le_swap. iIntros (v1 v2 p1' p2') "/= (#?&#?&HP) Hm2 /=".
+      iApply (iProto_le_recv_send_inv with "(H HP)"); simpl; auto.
+    - iApply iProto_le_recv. iIntros (v' p') "(->&Hp&HP)".
+      iApply (iProto_le_recv_recv_inv with "(H HP)"); simpl; auto.
+  Qed.
+  Lemma iProto_le_payload_elim_r a m v P p :
+    (P -∗ (<a> m) ⊑ (<!> MSG v; p)) ⊢
+    (<a> m) ⊑ (<!> MSG v {{ P }}; p).
+  Proof.
+    rewrite iMsg_base_eq. iIntros "H". destruct a.
+    - iApply iProto_le_send. iIntros (v' p') "(->&Hp&HP)".
+      iApply (iProto_le_send_send_inv with "(H HP)"); simpl; auto.
+    - iApply iProto_le_swap. iIntros (v1 v2 p1' p2') "/= Hm1 (->&#?&HP) /=".
+      iApply (iProto_le_recv_send_inv with "(H HP) Hm1"); simpl; auto.
+  Qed.
+  Lemma iProto_le_payload_intro_l v P p :
+    P -∗ (<!> MSG v {{ P }}; p) ⊑ (<!> MSG v; p).
+  Proof.
+    rewrite iMsg_base_eq.
+    iIntros "HP". iApply iProto_le_send. iIntros (v' p') "(->&Hp&_) /=".
+    iExists p'. iSplitR; [iApply iProto_le_refl|]. auto.
+  Qed.
+  Lemma iProto_le_payload_intro_r v P p :
+    P -∗ (<?> MSG v; p) ⊑ (<?> MSG v {{ P }}; p).
+  Proof.
+    rewrite iMsg_base_eq.
+    iIntros "HP". iApply iProto_le_recv. iIntros (v' p') "(->&Hp&_) /=".
+    iExists p'. iSplitR; [iApply iProto_le_refl|]. auto.
+  Qed.
+
+  Lemma iProto_le_exist_elim_l {A} (m1 : A → iMsg Σ V) a m2 :
+    (∀ x, (<?> m1 x) ⊑ (<a> m2)) ⊢
+    (<? x> m1 x) ⊑ (<a> m2).
+  Proof.
+    rewrite iMsg_exist_eq. iIntros "H". destruct a.
+    - iApply iProto_le_swap. iIntros (v1 v2 p1' p2') "/= Hm1 Hm2 /=".
+      iDestruct "Hm1" as (x) "Hm1".
+      iApply (iProto_le_recv_send_inv with "H Hm1 Hm2").
+    - iApply iProto_le_recv. iIntros (v p1') "/=". iDestruct 1 as (x) "Hm".
+      by iApply (iProto_le_recv_recv_inv with "H").
+  Qed.
+
+  Lemma iProto_le_exist_elim_l_inhabited `{!Inhabited A} (m : A → iMsg Σ V) p :
+    (∀ x, (<?> m x) ⊑ p) ⊢
+    (<? x> m x) ⊑ p.
+  Proof.
+    rewrite iMsg_exist_eq. iIntros "H".
+    destruct (iProto_case p) as [Heq | [a [m' Heq]]].
+    - unshelve iSpecialize ("H" $!inhabitant); first by apply _.
+      rewrite Heq.
+      iDestruct (iProto_le_end_inv_l with "H") as "H".
+      rewrite iProto_end_eq iProto_message_eq.
+      iDestruct (proto_message_end_equivI with "H") as "[]".
+    - iEval (rewrite Heq). destruct a.
+      + iApply iProto_le_swap. iIntros (v1 v2 p1' p2') "/= Hm1 Hm2 /=".
+        iDestruct "Hm1" as (x) "Hm1".
+        iSpecialize ("H" $! x). rewrite Heq.
+        iApply (iProto_le_recv_send_inv with "H Hm1 Hm2").
+      + iApply iProto_le_recv. iIntros (v p1') "/=". iDestruct 1 as (x) "Hm".
+        iSpecialize ("H" $! x). rewrite Heq.
+        by iApply (iProto_le_recv_recv_inv with "H").
+  Qed.
+
+  Lemma iProto_le_exist_elim_r {A} a m1 (m2 : A → iMsg Σ V) :
+    (∀ x, (<a> m1) ⊑ (<!> m2 x)) ⊢
+    (<a> m1) ⊑ (<! x> m2 x).
+  Proof.
+    rewrite iMsg_exist_eq. iIntros "H". destruct a.
+    - iApply iProto_le_send. iIntros (v p2'). iDestruct 1 as (x) "Hm".
+      by iApply (iProto_le_send_send_inv with "H").
+    - iApply iProto_le_swap. iIntros (v1 v2 p1' p2') "/= Hm1".
+      iDestruct 1 as (x) "Hm2".
+      iApply (iProto_le_recv_send_inv with "H Hm1 Hm2").
+  Qed.
+  Lemma iProto_le_exist_elim_r_inhabited `{Hinh : Inhabited A} p (m : A → iMsg Σ V) :
+    (∀ x, p ⊑ (<!> m x)) ⊢
+    p ⊑ (<! x> m x).
+  Proof.
+    rewrite iMsg_exist_eq. iIntros "H".
+    destruct (iProto_case p) as [Heq | [a [m' Heq]]].
+    - unshelve iSpecialize ("H" $!inhabitant); first by apply _.
+      rewrite Heq.
+      iDestruct (iProto_le_end_inv_r with "H") as "H".
+      rewrite iProto_end_eq iProto_message_eq.
+      iDestruct (proto_message_end_equivI with "H") as "[]".
+    - iEval (rewrite Heq). destruct a.
+      + iApply iProto_le_send. iIntros (v p2'). iDestruct 1 as (x) "Hm".
+        iSpecialize ("H" $! x). rewrite Heq.
+        by iApply (iProto_le_send_send_inv with "H").
+      + iApply iProto_le_swap. iIntros (v1 v2 p1' p2') "/= Hm1".
+        iDestruct 1 as (x) "Hm2".
+        iSpecialize ("H" $! x). rewrite Heq.
+        iApply (iProto_le_recv_send_inv with "H Hm1 Hm2").
+  Qed.
+  Lemma iProto_le_exist_intro_l {A} (m : A → iMsg Σ V) a :
+    ⊢ (<! x> m x) ⊑ (<!> m a).
+  Proof.
+    rewrite iMsg_exist_eq. iApply iProto_le_send. iIntros (v p') "Hm /=".
+    iExists p'. iSplitR; last by auto. iApply iProto_le_refl.
+  Qed.
+  Lemma iProto_le_exist_intro_r {A} (m : A → iMsg Σ V) a :
+    ⊢ (<?> m a) ⊑ (<? x> m x).
+  Proof.
+    rewrite iMsg_exist_eq. iApply iProto_le_recv. iIntros (v p') "Hm /=".
+    iExists p'. iSplitR; last by auto. iApply iProto_le_refl.
+  Qed.
+
+  Lemma iProto_le_texist_elim_l {TT : tele} (m1 : TT → iMsg Σ V) a m2 :
+    (∀ x, (<?> m1 x) ⊑ (<a> m2)) ⊢
+    (<?.. x> m1 x) ⊑ (<a> m2).
+  Proof.
+    iIntros "H". iInduction TT as [|T TT] "IH"; simpl; [done|].
+    iApply iProto_le_exist_elim_l; iIntros (x).
+    iApply "IH". iIntros (xs). iApply "H".
+  Qed.
+  Lemma iProto_le_texist_elim_r {TT : tele} a m1 (m2 : TT → iMsg Σ V) :
+    (∀ x, (<a> m1) ⊑ (<!> m2 x)) -∗
+    (<a> m1) ⊑ (<!.. x> m2 x).
+  Proof.
+    iIntros "H". iInduction TT as [|T TT] "IH"; simpl; [done|].
+    iApply iProto_le_exist_elim_r; iIntros (x).
+    iApply "IH". iIntros (xs). iApply "H".
+  Qed.
+
+  Lemma iProto_le_texist_intro_l {TT : tele} (m : TT → iMsg Σ V) x :
+    ⊢ (<!.. x> m x) ⊑ (<!> m x).
+  Proof.
+    induction x as [|T TT x xs IH] using tele_arg_ind; simpl.
+    { iApply iProto_le_refl. }
+    iApply iProto_le_trans; [by iApply iProto_le_exist_intro_l|]. iApply IH.
+  Qed.
+  Lemma iProto_le_texist_intro_r {TT : tele} (m : TT → iMsg Σ V) x :
+    ⊢ (<?> m x) ⊑ (<?.. x> m x).
+  Proof.
+    induction x as [|T TT x xs IH] using tele_arg_ind; simpl.
+    { iApply iProto_le_refl. }
+    iApply iProto_le_trans; [|by iApply iProto_le_exist_intro_r]. iApply IH.
+  Qed.
+
+  Lemma iProto_le_base a v P p1 p2 :
+    ▷ (p1 ⊑ p2) ⊢
+    (<a> MSG v {{ P }}; p1) ⊑ (<a> MSG v {{ P }}; p2).
+  Proof.
+    rewrite iMsg_base_eq. iIntros "H". destruct a.
+    - iApply iProto_le_send. iIntros (v' p') "(->&Hp&$)".
+      iExists p1. iSplit; [|by auto]. iIntros "!>". by iRewrite -"Hp".
+    - iApply iProto_le_recv. iIntros (v' p') "(->&Hp&$)".
+      iExists p2. iSplit; [|by auto]. iIntros "!>". by iRewrite -"Hp".
+  Qed.
+
+  Lemma iProto_le_base_swap v1 v2 P1 P2 p :
+    ⊢ (<?> MSG v1 {{ P1 }}; <!> MSG v2 {{ P2 }}; p)
+    ⊑ (<!> MSG v2 {{ P2 }}; <?> MSG v1 {{ P1 }}; p).
+  Proof.
+    rewrite {1 3}iMsg_base_eq. iApply iProto_le_swap.
+    iIntros (v1' v2' p1' p2') "/= (->&#Hp1&HP1) (->&#Hp2&HP2)". iExists p.
+    iSplitL "HP2".
+    - iIntros "!>". iRewrite -"Hp1". by iApply iProto_le_payload_intro_l.
+    - iIntros "!>". iRewrite -"Hp2". by iApply iProto_le_payload_intro_r.
+  Qed.
+
+  Lemma iProto_le_dual p1 p2 : p2 ⊑ p1 -∗ iProto_dual p1 ⊑ iProto_dual p2.
+  Proof.
+    iIntros "H". iLöb as "IH" forall (p1 p2).
+    destruct (iProto_case p1) as [->|([]&m1&->)].
+    - iDestruct (iProto_le_end_inv_l with "H") as "H".
+      iRewrite "H". iApply iProto_le_refl.
+    - iDestruct (iProto_le_send_inv with "H") as (a2 m2) "[Hp2 H]".
+      iRewrite "Hp2"; clear p2. iEval (rewrite !iProto_dual_message).
+      destruct a2; simpl.
+      + iApply iProto_le_recv. iIntros (v p1d).
+        iDestruct 1 as (p1') "[Hm1 #Hp1d]".
+        iDestruct ("H" with "Hm1") as (p2') "[H Hm2]".
+        iDestruct ("IH" with "H") as "H". iExists (iProto_dual p2').
+        iSplitL "H"; [iIntros "!>"; by iRewrite "Hp1d"|]. simpl; auto.
+      + iApply iProto_le_swap. iIntros (v1 v2 p1d p2d).
+        iDestruct 1 as (p1') "[Hm1 #Hp1d]". iDestruct 1 as (p2') "[Hm2 #Hp2d]".
+        iDestruct ("H" with "Hm2 Hm1") as (pt) "[H1 H2]".
+        iDestruct ("IH" with "H1") as "H1". iDestruct ("IH" with "H2") as "H2 {IH}".
+        rewrite !iProto_dual_message /=. iExists (iProto_dual pt). iSplitL "H2".
+        * iIntros "!>". iRewrite "Hp1d". by rewrite -iMsg_dual_base.
+        * iIntros "!>". iRewrite "Hp2d". by rewrite -iMsg_dual_base.
+    - iDestruct (iProto_le_recv_inv with "H") as (m2) "[Hp2 H]".
+      iRewrite "Hp2"; clear p2. iEval (rewrite !iProto_dual_message /=).
+      iApply iProto_le_send. iIntros (v p2d).
+      iDestruct 1 as (p2') "[Hm2 #Hp2d]".
+      iDestruct ("H" with "Hm2") as (p1') "[H Hm1]".
+      iDestruct ("IH" with "H") as "H". iExists (iProto_dual p1').
+      iSplitL "H"; [iIntros "!>"; by iRewrite "Hp2d"|]. simpl; auto.
+  Qed.
+
+  Lemma iProto_le_amber_internal (p1 p2 : iProto Σ V → iProto Σ V)
+      `{Contractive p1, Contractive p2}:
+    □ (∀ rec1 rec2, ▷ (rec1 ⊑ rec2) → p1 rec1 ⊑ p2 rec2) ⊢
+    fixpoint p1 ⊑ fixpoint p2.
+  Proof.
+    iIntros "#H". iLöb as "IH".
+    iEval (rewrite (fixpoint_unfold p1)).
+    iEval (rewrite (fixpoint_unfold p2)).
+    iApply "H". iApply "IH".
+  Qed.
+  Lemma iProto_le_amber_external (p1 p2 : iProto Σ V → iProto Σ V)
+      `{Contractive p1, Contractive p2}:
+    (∀ rec1 rec2, (⊢ rec1 ⊑ rec2) → ⊢ p1 rec1 ⊑ p2 rec2) →
+    ⊢ fixpoint p1 ⊑ fixpoint p2.
+  Proof.
+    intros IH. apply fixpoint_ind.
+    - by intros p1' p2' -> ?.
+    - exists (fixpoint p2). iApply iProto_le_refl.
+    - intros p' ?. rewrite (fixpoint_unfold p2). by apply IH.
+    - apply bi.limit_preserving_entails; [done|solve_proper].
+  Qed.
+
+  Lemma iProto_le_dual_l p1 p2 : iProto_dual p2 ⊑ p1 ⊢ iProto_dual p1 ⊑ p2.
+  Proof.
+    iIntros "H". iEval (rewrite -(involutive iProto_dual p2)).
+    by iApply iProto_le_dual.
+  Qed.
+  Lemma iProto_le_dual_r p1 p2 : p2 ⊑ iProto_dual p1 ⊢ p1 ⊑ iProto_dual p2.
+  Proof.
+    iIntros "H". iEval (rewrite -(involutive iProto_dual p1)).
+    by iApply iProto_le_dual.
+  Qed.
+
+  Lemma iProto_le_app p1 p2 p3 p4 :
+    p1 ⊑ p2 -∗ p3 ⊑ p4 -∗ p1 <++> p3 ⊑ p2 <++> p4.
+  Proof.
+    iIntros "H1 H2". iLöb as "IH" forall (p1 p2 p3 p4).
+    destruct (iProto_case p2) as [->|([]&m2&->)].
+    - iDestruct (iProto_le_end_inv_l with "H1") as "H1".
+      iRewrite "H1". by rewrite !left_id.
+    - iDestruct (iProto_le_send_inv with "H1") as (a1 m1) "[Hp1 H1]".
+      iRewrite "Hp1"; clear p1. rewrite !iProto_app_message. destruct a1; simpl.
+      + iApply iProto_le_send. iIntros (v p24).
+        iDestruct 1 as (p2') "[Hm2 #Hp24]".
+        iDestruct ("H1" with "Hm2") as (p1') "[H1 Hm1]".
+        iExists (p1' <++> p3). iSplitR "Hm1"; [|by simpl; eauto].
+        iIntros "!>". iRewrite "Hp24". by iApply ("IH" with "H1").
+      + iApply iProto_le_swap. iIntros (v1 v2 p13 p24).
+        iDestruct 1 as (p1') "[Hm1 #Hp13]". iDestruct 1 as (p2') "[Hm2 #Hp24]".
+        iSpecialize ("H1" with "Hm1 Hm2").
+        iDestruct "H1" as (pt) "[H1 H1']".
+        iExists (pt <++> p3). iSplitL "H1".
+        * iIntros "!>". iRewrite "Hp13".
+          rewrite /= -iMsg_app_base -iProto_app_message.
+          iApply ("IH" with "H1"). iApply iProto_le_refl.
+        * iIntros "!>". iRewrite "Hp24".
+          rewrite /= -iMsg_app_base -iProto_app_message.
+          iApply ("IH" with "H1' H2").
+    - iDestruct (iProto_le_recv_inv with "H1") as (m1) "[Hp1 H1]".
+      iRewrite "Hp1"; clear p1. rewrite !iProto_app_message. iApply iProto_le_recv.
+      iIntros (v p13). iDestruct 1 as (p1') "[Hm1 #Hp13]".
+      iDestruct ("H1" with "Hm1") as (p2'') "[H1 Hm2]".
+      iExists (p2'' <++> p4). iSplitR "Hm2"; [|by simpl; eauto].
+      iIntros "!>". iRewrite "Hp13". by iApply ("IH" with "H1").
+  Qed.
+
+  (** ** Lemmas about the auxiliary definitions and invariants *)
+  Global Instance iProto_app_recvs_ne vs :
+    NonExpansive (iProto_app_recvs (Σ:=Σ) (V:=V) vs).
+  Proof. induction vs; solve_proper. Qed.
+  Global Instance iProto_app_recvs_proper vs :
+    Proper ((≡) ==> (≡)) (iProto_app_recvs (Σ:=Σ) (V:=V) vs).
+  Proof. induction vs; solve_proper. Qed.
+  Global Instance iProto_interp_ne vsl vsr :
+    NonExpansive2 (iProto_interp (Σ:=Σ) (V:=V) vsl vsr).
+  Proof. solve_proper. Qed.
+  Global Instance iProto_interp_proper vsl vsr :
+    Proper ((≡) ==> (≡) ==> (≡)) (iProto_interp (Σ:=Σ) (V:=V) vsl vsr).
+  Proof. apply (ne_proper_2 _). Qed.
+
+  Global Instance iProto_own_frag_ne γ : NonExpansive (iProto_own_frag γ).
+  Proof. solve_proper. Qed.
+
+  Lemma iProto_own_auth_agree γ p p' :
+    iProto_own_auth γ p -∗ iProto_own_frag γ p' -∗ ▷ (p ≡ p').
+  Proof.
+    iIntros "H● H◯". iCombine "H● H◯" gives "H✓".
+    iDestruct (excl_auth_agreeI with "H✓") as "{H✓} H✓".
+    iApply (later_equivI_1 with "H✓").
+  Qed.
+
+  Lemma iProto_own_auth_update γ p p' p'' :
+    iProto_own_auth γ p -∗ iProto_own_frag γ p' ==∗
+    iProto_own_auth γ p'' ∗ iProto_own_frag γ p''.
+  Proof.
+    iIntros "H● H◯". iDestruct (own_update_2 with "H● H◯") as "H".
+    { eapply (excl_auth_update _ _ (Next p'')). }
+    by rewrite own_op.
+  Qed.
+
+  Lemma iProto_interp_nil p : ⊢ iProto_interp [] [] p (iProto_dual p).
+  Proof. iExists p; simpl. iSplitL; iApply iProto_le_refl. Qed.
+
+  Lemma iProto_interp_sym vsl vsr pl pr :
+    iProto_interp vsl vsr pl pr ⊢ iProto_interp vsr vsl pr pl.
+  Proof.
+    iDestruct 1 as (p) "[Hp Hdp]". iExists (iProto_dual p).
+    rewrite (involutive iProto_dual). iFrame.
+  Qed.
+
+  Lemma iProto_interp_le_l vsl vsr pl pl' pr :
+    iProto_interp vsl vsr pl pr -∗ pl ⊑ pl' -∗ iProto_interp vsl vsr pl' pr.
+  Proof.
+    iDestruct 1 as (p) "[Hp Hdp]". iIntros "Hle". iExists p.
+    iFrame "Hdp". by iApply (iProto_le_trans with "Hp").
+  Qed.
+  Lemma iProto_interp_le_r vsl vsr pl pr pr' :
+    iProto_interp vsl vsr pl pr -∗ pr ⊑ pr' -∗ iProto_interp vsl vsr pl pr'.
+  Proof.
+    iIntros "H Hle". iApply iProto_interp_sym.
+    iApply (iProto_interp_le_l with "[H] Hle"). by iApply iProto_interp_sym.
+  Qed.
+
+  Lemma iProto_interp_send vl ml vsl vsr pr pl' :
+    iProto_interp vsl vsr (<!> ml) pr -∗
+    iMsg_car ml vl (Next pl') -∗
+    ▷^(length vsr) iProto_interp (vsl ++ [vl]) vsr pl' pr.
+  Proof.
+    iDestruct 1 as (p) "[Hp Hdp] /="; iIntros "Hml".
+    iDestruct (iProto_le_trans _ _ (<!> MSG vl; pl') with "Hp [Hml]") as "Hp".
+    { iApply iProto_le_send. rewrite iMsg_base_eq. iIntros (v' p') "(->&Hp&_) /=".
+      iExists p'. iSplitR; [iApply iProto_le_refl|]. by iRewrite -"Hp". }
+    iInduction vsr as [|vr vsr] "IH" forall (pl'); simpl.
+    { iExists pl'; simpl. iSplitR; [iApply iProto_le_refl|].
+      iApply (iProto_le_trans with "[Hp] Hdp").
+      iInduction vsl as [|vl' vsl] "IH"; simpl.
+      { iApply iProto_le_dual_r. rewrite iProto_dual_message iMsg_dual_base /=.
+        by rewrite involutive. }
+      iApply iProto_le_base; iIntros "!>". by iApply "IH". }
+    iDestruct (iProto_le_recv_send_inv _ _ vr vl
+      (iProto_app_recvs vsr p) pl' with "Hp [] []") as (p') "[H1 H2]";
+      [rewrite iMsg_base_eq; by auto..|].
+    iIntros "!>". iSpecialize ("IH" with "Hdp H1"). iIntros "!>".
+    iDestruct "IH" as (p'') "[Hp'' Hdp'']". iExists p''. iFrame "Hdp''".
+    iApply (iProto_le_trans with "[Hp''] H2"); simpl. by iApply iProto_le_base.
+  Qed.
+
+  Lemma iProto_interp_recv vl vsl vsr pl mr :
+    iProto_interp (vl :: vsl) vsr pl (<?> mr) -∗
+    ∃ pr, iMsg_car mr vl (Next pr) ∗ ▷ iProto_interp vsl vsr pl pr.
+  Proof.
+    iDestruct 1 as (p) "[Hp Hdp] /=".
+    iDestruct (iProto_le_recv_inv with "Hdp") as (m) "[#Hm Hpr]".
+    iDestruct (iProto_message_equivI with "Hm") as (_) "{Hm} #Hm".
+    iDestruct ("Hpr" $! vl (iProto_app_recvs vsl (iProto_dual p)) with "[]")
+      as (pr'') "[Hler Hpr]".
+    { iRewrite -("Hm" $! vl (Next (iProto_app_recvs vsl (iProto_dual p)))).
+      rewrite iMsg_base_eq; auto. }
+    iExists pr''. iIntros "{$Hpr} !>". iExists p. iFrame.
+  Qed.
+
+  Lemma iProto_ctx_sym γl γr vsl vsr :
+    iProto_ctx γl γr vsl vsr ⊢ iProto_ctx γr γl vsr vsl.
+  Proof.
+    iIntros "(%pl & %pr & Hauthl & Hauthr & Hinterp)".
+    iDestruct (iProto_interp_sym with "Hinterp") as "Hinterp".
+    iExists pr, pl; iFrame.
+  Qed.
+
+  Global Instance iProto_own_ne γ : NonExpansive (iProto_own γ).
+  Proof. solve_proper. Qed.
+  Global Instance iProto_own_proper γ : Proper ((≡) ==> (≡)) (iProto_own γ).
+  Proof. apply (ne_proper _). Qed.
+
+  Lemma iProto_own_le γ p1 p2 :
+    iProto_own γ p1 -∗ ▷ (p1 ⊑ p2) -∗ iProto_own γ p2.
+  Proof.
+    iDestruct 1 as (p1') "[Hle H]". iIntros "Hle'".
+    iExists p1'. iFrame "H". by iApply (iProto_le_trans with "Hle").
+  Qed.
+
+  Lemma iProto_init p :
+    ⊢ |==> ∃ γl γr,
+      iProto_ctx γl γr [] [] ∗
+      iProto_own γl p ∗ iProto_own γr (iProto_dual p).
+  Proof.
+    iMod (own_alloc (●E (Next p) ⋅ ◯E (Next p))) as (γl) "[H●l H◯l]".
+    { by apply excl_auth_valid. }
+    iMod (own_alloc (●E (Next (iProto_dual p)) ⋅
+      ◯E (Next (iProto_dual p)))) as (γr) "[H●r H◯r]".
+    { by apply excl_auth_valid. }
+    iModIntro. iExists γl, γr. iSplitL "H●l H●r".
+    { iExists p, (iProto_dual p). iFrame. iApply iProto_interp_nil. }
+    iSplitL "H◯l"; iExists _; iFrame; iApply iProto_le_refl.
+  Qed.
+
+  Lemma iProto_send γl γr m vsr vsl vl p :
+    iProto_ctx γl γr vsl vsr -∗
+    iProto_own γl (<!> m) -∗
+    iMsg_car m vl (Next p) ==∗
+      ▷^(length vsr) iProto_ctx γl γr (vsl ++ [vl]) vsr ∗
+      iProto_own γl p.
+  Proof.
+    iDestruct 1 as (pl pr) "(H●l & H●r & Hinterp)".
+    iDestruct 1 as (pl') "[Hle H◯]". iIntros "Hm".
+    iDestruct (iProto_own_auth_agree with "H●l H◯") as "#Hp".
+    iAssert (▷ (pl ⊑ <!> m))%I
+      with "[Hle]" as "{Hp} Hle"; first (iNext; by iRewrite "Hp").
+    iDestruct (iProto_interp_le_l with "Hinterp Hle") as "Hinterp".
+    iDestruct (iProto_interp_send with "Hinterp [Hm //]") as "Hinterp".
+    iMod (iProto_own_auth_update _ _ _ p with "H●l H◯") as "[H●l H◯]".
+    iIntros "!>". iSplitR "H◯".
+    - iIntros "!>". iExists p, pr. iFrame.
+    - iExists p. iFrame. iApply iProto_le_refl.
+  Qed.
+
+  Lemma iProto_recv γl γr m vr vsr vsl :
+    iProto_ctx γl γr vsl (vr :: vsr) -∗
+    iProto_own γl (<?> m) ==∗
+    ▷ ∃ p,
+      iProto_ctx γl γr vsl vsr ∗
+      iProto_own γl p ∗
+      iMsg_car m vr (Next p).
+  Proof.
+    iDestruct 1 as (pl pr) "(H●l & H●r & Hinterp)".
+    iDestruct 1 as (p) "[Hle H◯]".
+    iDestruct (iProto_own_auth_agree with "H●l H◯") as "#Hp".
+    iDestruct (iProto_interp_le_l with "Hinterp [Hle]") as "Hinterp".
+    { iIntros "!>". by iRewrite "Hp". }
+    iDestruct (iProto_interp_sym with "Hinterp") as "Hinterp".
+    iDestruct (iProto_interp_recv with "Hinterp") as (q) "[Hm Hinterp]".
+    iMod (iProto_own_auth_update _ _ _ q with "H●l H◯") as "[H●l H◯]".
+    iIntros "!> !> /=". iExists q. iFrame "Hm". iSplitR "H◯".
+    - iExists q, pr. iFrame. by iApply iProto_interp_sym.
+    - iExists q. iIntros "{$H◯} !>". iApply iProto_le_refl.
+  Qed.
+
+  (** The instances below make it possible to use the tactics [iIntros],
+  [iExist], [iSplitL]/[iSplitR], [iFrame] and [iModIntro] on [iProto_le] goals. *)
+  Global Instance iProto_le_from_forall_l {A} a (m1 : A → iMsg Σ V) m2 name :
+    AsIdentName m1 name →
+    FromForall (iProto_message Recv (iMsg_exist m1) ⊑ (<a> m2))
+               (λ x, (<?> m1 x) ⊑ (<a> m2))%I name | 10.
+  Proof. intros _. apply iProto_le_exist_elim_l. Qed.
+  Global Instance iProto_le_from_forall_r {A} a m1 (m2 : A → iMsg Σ V) name :
+    AsIdentName m2 name →
+    FromForall ((<a> m1) ⊑ iProto_message Send (iMsg_exist m2))
+               (λ x, (<a> m1) ⊑ (<!> m2 x))%I name | 11.
+  Proof. intros _. apply iProto_le_exist_elim_r. Qed.
+
+  Global Instance iProto_le_from_wand_l a m v P p :
+    TCIf (TCEq P True%I) False TCTrue →
+    FromWand ((<?> MSG v {{ P }}; p) ⊑ (<a> m)) P ((<?> MSG v; p) ⊑ (<a> m)) | 10.
+  Proof. intros _. apply iProto_le_payload_elim_l. Qed.
+  Global Instance iProto_le_from_wand_r a m v P p :
+    FromWand ((<a> m) ⊑ (<!> MSG v {{ P }}; p)) P ((<a> m) ⊑ (<!> MSG v; p)) | 11.
+  Proof. apply iProto_le_payload_elim_r. Qed.
+
+  Global Instance iProto_le_from_exist_l {A} (m : A → iMsg Σ V) p :
+    FromExist ((<! x> m x) ⊑ p) (λ a, (<!> m a) ⊑ p)%I | 10.
+  Proof.
+    rewrite /FromExist. iDestruct 1 as (x) "H".
+    iApply (iProto_le_trans with "[] H"). iApply iProto_le_exist_intro_l.
+  Qed.
+  Global Instance iProto_le_from_exist_r {A} (m : A → iMsg Σ V) p :
+    FromExist (p ⊑ <? x> m x) (λ a, p ⊑ (<?> m a))%I | 11.
+  Proof.
+    rewrite /FromExist. iDestruct 1 as (x) "H".
+    iApply (iProto_le_trans with "H"). iApply iProto_le_exist_intro_r.
+  Qed.
+
+  Global Instance iProto_le_from_sep_l m v P p :
+    FromSep ((<!> MSG v {{ P }}; p) ⊑ (<!> m)) P ((<!> MSG v; p) ⊑ (<!> m)) | 10.
+  Proof.
+    rewrite /FromSep. iIntros "[HP H]".
+    iApply (iProto_le_trans with "[HP] H"). by iApply iProto_le_payload_intro_l.
+  Qed.
+  Global Instance iProto_le_from_sep_r m v P p :
+    FromSep ((<?> m) ⊑ (<?> MSG v {{ P }}; p)) P ((<?> m) ⊑ (<?> MSG v; p)) | 11.
+  Proof.
+    rewrite /FromSep. iIntros "[HP H]".
+    iApply (iProto_le_trans with "H"). by iApply iProto_le_payload_intro_r.
+  Qed.
+
+  Global Instance iProto_le_frame_l q m v R P Q p :
+    Frame q R P Q →
+    Frame q R ((<!> MSG v {{ P }}; p) ⊑ (<!> m))
+              ((<!> MSG v {{ Q }}; p) ⊑ (<!> m)) | 10.
+  Proof.
+    rewrite /Frame /=. iIntros (HP) "[HR H]".
+    iApply (iProto_le_trans with "[HR] H"). iApply iProto_le_payload_elim_r.
+    iIntros "HQ". iApply iProto_le_payload_intro_l. iApply HP; iFrame.
+  Qed.
+  Global Instance iProto_le_frame_r q m v R P Q p :
+    Frame q R P Q →
+    Frame q R ((<?> m) ⊑ (<?> MSG v {{ P }}; p))
+              ((<?> m) ⊑ (<?> MSG v {{ Q }}; p)) | 11.
+  Proof.
+    rewrite /Frame /=. iIntros (HP) "[HR H]".
+    iApply (iProto_le_trans with "H"). iApply iProto_le_payload_elim_l.
+    iIntros "HQ". iApply iProto_le_payload_intro_r. iApply HP; iFrame.
+  Qed.
+
+  Global Instance iProto_le_from_modal a v p1 p2 :
+    FromModal True (modality_instances.modality_laterN 1) (p1 ⊑ p2)
+              ((<a> MSG v; p1) ⊑ (<a> MSG v; p2)) (p1 ⊑ p2).
+  Proof. intros _. apply iProto_le_base. Qed.
+
+End proto.
+
+Global Typeclasses Opaque iProto_ctx iProto_own.
+
+Global Hint Extern 0 (environments.envs_entails _ (?x ⊑ ?y)) =>
+  first [is_evar x; fail 1 | is_evar y; fail 1|iApply iProto_le_refl] : core.

--- a/new/proof/github_com/goose_lang/goose/model/channel/protocol/dsp/proto_model.v
+++ b/new/proof/github_com/goose_lang/goose/model/channel/protocol/dsp/proto_model.v
@@ -1,0 +1,310 @@
+(** This file defines the model of dependent separation protocols as the
+solution of a recursive domain equation, along with various primitive
+operations, such as append and map.
+
+Important: This file should not be used directly, but rather the wrappers in
+[proto] should be used.
+
+Dependent Separation Protocols are modeled as the solution of the following
+recursive domain equation:
+
+[proto = 1 + (action * (V → ▶ proto → PROP))]
+
+Here, the left-hand side of the sum is used for the terminated process, while
+the right-hand side is used for the communication constructors. The type
+[action] is an inductively defined datatype with two constructors [Send] and
+[Recv]. Compared to having an additional sum in [proto], this makes it
+possible to factorize the code in a better way.
+
+The remainder [V → ▶ proto → PROP] is a predicate that ranges over the
+communicated value [V] and the tail protocol [proto]. Note that to solve this
+recursive domain equation using Iris's COFE solver, the recursive occurrence
+of [proto] appear under the later [▶].
+
+On top of the type [proto], we define the constructors:
+
+- [proto_end], which constructs the left-side of the sum.
+- [proto_msg], which takes an action and a predicate and constructs the
+  right-hand side of the sum accordingly.
+
+The defined functions on the type [proto] are:
+
+- [proto_map], which can be used to map the actions and the propositions of
+  a given protocol.
+- [proto_app], which appends two protocols [p1] and [p2], by substituting
+  all terminations [END] in [p1] with [p2]. *)
+From iris.base_logic Require Import base_logic.
+From iris.proofmode Require Import proofmode.
+From New.proof.github_com.goose_lang.goose.model.channel Require Import cofe_solver_2.
+
+Set Default Proof Using "Type".
+
+Module Export action.
+  Inductive action := Send | Recv.
+  Global Instance action_inhabited : Inhabited action := populate Send.
+  Definition action_dual (a : action) : action :=
+    match a with Send => Recv | Recv => Send end.
+  Global Instance action_dual_involutive : Involutive (=) action_dual.
+  Proof. by intros []. Qed.
+  Canonical Structure actionO := leibnizO action.
+End action.
+
+Definition proto_auxO (V : Type) (PROP : ofe) (A : ofe) : ofe :=
+  optionO (prodO actionO (V -d> laterO A -n> PROP)).
+Definition proto_auxOF (V : Type) (PROP : ofe) : oFunctor :=
+  optionOF (actionO * (V -d> ▶ ∙ -n> PROP)).
+
+Definition pre_proto_result (V : Type) := result_2 (proto_auxOF V).
+Definition pre_proto (V : Type) (PROPn PROP : ofe) `{!Cofe PROPn, !Cofe PROP} : ofe :=
+  solution_2_car (pre_proto_result V) PROPn _ PROP _.
+Global Instance pre_proto_cofe {V} `{!Cofe PROPn, !Cofe PROP} :
+  Cofe (pre_proto V PROPn PROP).
+Proof. apply _. Qed.
+
+Definition proto (V : Type) (PROPn PROP : ofe) `{!Cofe PROPn, !Cofe PROP} : ofe :=
+  proto_auxO V PROP (pre_proto V PROP PROPn).
+Global Instance proto_cofe {V} `{!Cofe PROPn, !Cofe PROP} :
+  Cofe (proto V PROPn PROP).
+Proof. apply _. Qed.
+
+Lemma proto_iso {V} `{!Cofe PROPn, !Cofe PROP} :
+  ofe_iso (proto V PROPn PROP) (pre_proto V PROPn PROP).
+Proof. apply pre_proto_result. Qed.
+
+Definition proto_fold {V} `{!Cofe PROPn, !Cofe PROP} :
+  pre_proto V PROPn PROP -n> proto V PROPn PROP := ofe_iso_2 proto_iso.
+Definition proto_unfold {V} `{!Cofe PROPn, !Cofe PROP} :
+  proto V PROPn PROP -n> pre_proto V PROPn PROP := ofe_iso_1 proto_iso.
+Lemma proto_fold_unfold {V} `{!Cofe PROPn, !Cofe PROP} (p : proto V PROPn PROP) :
+  proto_fold (proto_unfold p) ≡ p.
+Proof. apply (ofe_iso_21 proto_iso). Qed.
+Lemma proto_unfold_fold {V} `{!Cofe PROPn, !Cofe PROP} (p : pre_proto V PROPn PROP) :
+  proto_unfold (proto_fold p) ≡ p.
+Proof. apply (ofe_iso_12 proto_iso). Qed.
+
+Definition proto_end {V} `{!Cofe PROPn, !Cofe PROP} : proto V PROPn PROP :=
+  None.
+Definition proto_message {V} `{!Cofe PROPn, !Cofe PROP} (a : action)
+    (m : V → laterO (proto V PROP PROPn) -n> PROP) : proto V PROPn PROP :=
+  Some (a, λ v, m v ◎ laterO_map proto_fold).
+
+Global Instance proto_message_ne {V} `{!Cofe PROPn, !Cofe PROP} a n :
+  Proper (pointwise_relation V (dist n) ==> dist n)
+         (proto_message (PROPn:=PROPn) (PROP:=PROP) a).
+Proof.
+  intros c1 c2 Hc. rewrite /proto_message.
+  (repeat constructor)=> //= v. by f_equiv.
+Qed.
+Global Instance proto_message_proper {V} `{!Cofe PROPn, !Cofe PROP} a :
+  Proper (pointwise_relation V (≡) ==> (≡))
+         (proto_message (PROPn:=PROPn) (PROP:=PROP) a).
+Proof.
+  intros c1 c2 Hc. rewrite /proto_message.
+  (repeat constructor)=> //= v. by f_equiv.
+Qed.
+
+Lemma proto_case {V} `{!Cofe PROPn, !Cofe PROP} (p : proto V PROPn PROP) :
+  p ≡ proto_end ∨ ∃ a m, p ≡ proto_message a m.
+Proof.
+  destruct p as [[a m]|]; [|by left].
+  right. exists a, (λ v, m v ◎ laterO_map proto_unfold).
+  rewrite /proto_message. do 2 f_equiv. intros v p; simpl. f_equiv.
+  rewrite -later_map_compose -{1}(later_map_id p).
+  apply later_map_ext=> p' /=. by rewrite proto_unfold_fold.
+Qed.
+Global Instance proto_inhabited {V} `{!Cofe PROPn, !Cofe PROP} :
+  Inhabited (proto V PROPn PROP) := populate proto_end.
+
+Lemma proto_message_equivI `{!BiInternalEq SPROP} {V} `{!Cofe PROPn, !Cofe PROP} a1 a2 m1 m2 :
+  proto_message (V:=V) (PROPn:=PROPn) (PROP:=PROP) a1 m1 ≡ proto_message a2 m2
+  ⊣⊢@{SPROP} ⌜ a1 = a2 ⌝ ∧ (∀ v p', m1 v p' ≡ m2 v p').
+Proof.
+  rewrite /proto_message option_equivI prod_equivI /=.
+  rewrite discrete_eq discrete_fun_equivI. f_equiv; [done|]. f_equiv=> x.
+  rewrite ofe_morO_equivI /=. iSplit; iIntros "H %p //".
+  assert (p ≡ later_map proto_fold (later_map proto_unfold p)) as ->; last done.
+  rewrite -later_map_compose -{1}(later_map_id p).
+  apply later_map_ext=> p' /=. by rewrite proto_fold_unfold.
+Qed.
+Lemma proto_message_end_equivI `{!BiInternalEq SPROP} {V} `{!Cofe PROPn, !Cofe PROP} a m :
+  proto_message (V:=V) (PROPn:=PROPn) (PROP:=PROP) a m ≡ proto_end ⊢@{SPROP} False.
+Proof. by rewrite option_equivI. Qed.
+Lemma proto_end_message_equivI `{!BiInternalEq SPROP} {V} `{!Cofe PROPn, !Cofe PROP} a m :
+  proto_end ≡ proto_message (V:=V) (PROPn:=PROPn) (PROP:=PROP) a m ⊢@{SPROP} False.
+Proof. by rewrite internal_eq_sym proto_message_end_equivI. Qed.
+
+Definition proto_elim {V} `{!Cofe PROPn, !Cofe PROP} {A}
+    (x : A) (f : action → (V → laterO (proto V PROP PROPn) -n> PROP) → A)
+    (p : proto V PROPn PROP) : A :=
+  match p with
+  | None => x
+  | Some (a, m) => f a (λ v, m v ◎ laterO_map proto_unfold)
+  end.
+Global Arguments proto_elim : simpl never.
+
+Lemma proto_elim_ne {V} `{!Cofe PROPn, !Cofe PROP} {A : ofe}
+    (x : A) (f1 f2 : action → (V → laterO (proto V PROP PROPn) -n> PROP) → A) p1 p2 n :
+  (∀ a m1 m2, (∀ v, m1 v ≡{n}≡ m2 v) → f1 a m1 ≡{n}≡ f2 a m2) →
+  p1 ≡{n}≡ p2 →
+  proto_elim x f1 p1 ≡{n}≡ proto_elim x f2 p2.
+Proof.
+  intros Hf [[a1 m1] [a2 m2] [[=->] ?]|]; rewrite /proto_elim //=.
+  apply Hf=> v. by f_equiv.
+Qed.
+
+Lemma proto_elim_end {V} `{!Cofe PROPn, !Cofe PROP} {A : ofe}
+    (x : A) (f : action → (V → laterO (proto V PROP PROPn) -n> PROP) → A) :
+  proto_elim x f proto_end ≡ x.
+Proof. done. Qed.
+Lemma proto_elim_message {V} `{!Cofe PROPn, !Cofe PROP} {A : ofe}
+    (x : A) (f : action → (V → laterO (proto V PROP PROPn) -n> PROP) → A) a m :
+  (∀ a, Proper (pointwise_relation _ (≡) ==> (≡)) (f a)) →
+  proto_elim x f (proto_message a m) ≡ f a m.
+Proof.
+  intros. rewrite /proto_elim /proto_message /=. f_equiv=> v p /=. f_equiv.
+  rewrite -later_map_compose -{2}(later_map_id p).
+  apply later_map_ext=> p' /=. by rewrite proto_fold_unfold.
+Qed.
+
+(** Functor *)
+Program Definition proto_map_aux {V} `{!Cofe PROPn, !Cofe PROPn', !Cofe PROP, !Cofe PROP'}
+    (g : PROP -n> PROP') (rec : proto V PROP' PROPn' -n> proto V PROP PROPn) :
+    proto V PROPn PROP -n> proto V PROPn' PROP' := λne p,
+  proto_elim proto_end (λ a m, proto_message a (λ v, g ◎ m v ◎ laterO_map rec)) p.
+Next Obligation.
+  intros V PROPn ? PROPn' ? PROP ? PROP' ? g rec n p1 p2 Hp.
+  apply proto_elim_ne=> // a m1 m2 Hm. by repeat f_equiv.
+Qed.
+
+Global Instance proto_map_aux_contractive {V}
+   `{!Cofe PROPn, !Cofe PROPn', !Cofe PROP, !Cofe PROP'} (g : PROP -n> PROP') :
+  Contractive (proto_map_aux (V:=V) (PROPn:=PROPn) (PROPn':=PROPn') g).
+Proof.
+  intros n rec1 rec2 Hrec p. simpl. apply proto_elim_ne=> // a m1 m2 Hm.
+  f_equiv=> v p' /=. do 2 f_equiv; [done|].
+  apply Next_contractive; by dist_later_intro as n' Hn'.
+Qed.
+
+Definition proto_map_aux_2 {V}
+   `{!Cofe PROPn, !Cofe PROPn', !Cofe PROP, !Cofe PROP'}
+    (gn : PROPn' -n> PROPn) (g : PROP -n> PROP')
+    (rec : proto V PROPn PROP -n> proto V PROPn' PROP') :
+    proto V PROPn PROP -n> proto V PROPn' PROP' :=
+  proto_map_aux g (proto_map_aux gn rec).
+Global Instance proto_map_aux_2_contractive {V}
+   `{!Cofe PROPn, !Cofe PROPn', !Cofe PROP, !Cofe PROP'}
+    (gn : PROPn' -n> PROPn) (g : PROP -n> PROP') :
+  Contractive (proto_map_aux_2 (V:=V) gn g).
+Proof.
+  intros n rec1 rec2 Hrec. rewrite /proto_map_aux_2.
+  f_equiv. by apply proto_map_aux_contractive.
+Qed.
+Definition proto_map {V}
+   `{!Cofe PROPn, !Cofe PROPn', !Cofe PROP, !Cofe PROP'}
+    (gn : PROPn' -n> PROPn) (g : PROP -n> PROP') :
+    proto V PROPn PROP -n> proto V PROPn' PROP' :=
+  fixpoint (proto_map_aux_2 gn g).
+
+Lemma proto_map_unfold {V}
+    `{Hcn:!Cofe PROPn, Hcn':!Cofe PROPn', Hc:!Cofe PROP, Hc':!Cofe PROP'}
+    (gn : PROPn' -n> PROPn) (g : PROP -n> PROP') p :
+  proto_map (V:=V) gn g p ≡ proto_map_aux g (proto_map g gn) p.
+Proof.
+  apply equiv_dist=> n. revert PROPn Hcn PROPn' Hcn' PROP Hc PROP' Hc' gn g p.
+  induction (lt_wf n) as [n _ IH]=>
+    PROPn Hcn PROPn' Hcn' PROP Hc PROP' Hc' gn g p.
+  etrans; [apply equiv_dist, (fixpoint_unfold (proto_map_aux_2 gn g))|].
+  apply proto_map_aux_contractive; constructor=> n' ?. symmetry. by apply: IH.
+Qed.
+Lemma proto_map_end {V} `{!Cofe PROPn, !Cofe PROPn', !Cofe PROP, !Cofe PROP'}
+    (gn : PROPn' -n> PROPn) (g : PROP -n> PROP') :
+  proto_map (V:=V) gn g proto_end ≡ proto_end.
+Proof. by rewrite proto_map_unfold /proto_map_aux. Qed.
+Lemma proto_map_message {V} `{!Cofe PROPn, !Cofe PROPn', !Cofe PROP, !Cofe PROP'}
+    (gn : PROPn' -n> PROPn) (g : PROP -n> PROP') a m :
+  proto_map (V:=V) gn g (proto_message a m)
+  ≡ proto_message a (λ v, g ◎ m v ◎ laterO_map (proto_map g gn)).
+Proof.
+  rewrite proto_map_unfold /proto_map_aux /=.
+  rewrite ->proto_elim_message; [done|].
+  intros a' m1 m2 Hm. f_equiv; solve_proper.
+Qed.
+
+Lemma proto_map_ne {V}
+    `{Hcn:!Cofe PROPn, Hcn':!Cofe PROPn', Hc:!Cofe PROP, Hc':!Cofe PROP'}
+    (gn1 gn2 : PROPn' -n> PROPn) (g1 g2 : PROP -n> PROP') p n :
+  gn1 ≡{n}≡ gn2 → g1 ≡{n}≡ g2 →
+  proto_map (V:=V) gn1 g1 p ≡{n}≡ proto_map (V:=V) gn2 g2 p.
+Proof.
+  revert PROPn Hcn PROPn' Hcn' PROP Hc PROP' Hc' gn1 gn2 g1 g2 p.
+  induction (lt_wf n) as [n _ IH]=>
+    PROPn ? PROPn' ? PROP ? PROP' ? gn1 gn2 g1 g2 p Hgn Hg /=.
+  destruct (proto_case p) as [->|(a & m & ->)]; [by rewrite !proto_map_end|].
+  rewrite !proto_map_message /=.
+  apply proto_message_ne=> // v p' /=. f_equiv; [done|]. f_equiv.
+  apply Next_contractive; dist_later_intro as n' Hn'; eauto using dist_lt.
+Qed.
+Lemma proto_map_ext {V} `{!Cofe PROPn, !Cofe PROPn', !Cofe PROP, !Cofe PROP'}
+    (gn1 gn2 : PROPn' -n> PROPn) (g1 g2 : PROP -n> PROP') p :
+  gn1 ≡ gn2 → g1 ≡ g2 → proto_map (V:=V) gn1 g1 p ≡ proto_map (V:=V) gn2 g2 p.
+Proof.
+  intros Hgn Hg. apply equiv_dist=> n.
+  apply proto_map_ne=> // ?; by apply equiv_dist.
+Qed.
+Lemma proto_map_id {V} `{Hcn:!Cofe PROPn, Hc:!Cofe PROP} (p : proto V PROPn PROP) :
+  proto_map cid cid p ≡ p.
+Proof.
+  apply equiv_dist=> n. revert PROPn Hcn PROP Hc p.
+  induction (lt_wf n) as [n _ IH]=> PROPn ? PROP ? p /=.
+  destruct (proto_case p) as [->|(a & m & ->)]; [by rewrite !proto_map_end|].
+  rewrite !proto_map_message /=. apply proto_message_ne=> // v p' /=. f_equiv.
+  apply Next_contractive; dist_later_intro as n' Hn'; auto.
+Qed.
+Lemma proto_map_compose {V}
+   `{Hcn:!Cofe PROPn, Hcn':!Cofe PROPn', Hcn'':!Cofe PROPn'',
+     Hc:!Cofe PROP, Hc':!Cofe PROP', Hc'':!Cofe PROP''}
+    (gn1 : PROPn'' -n> PROPn') (gn2 : PROPn' -n> PROPn)
+    (g1 : PROP -n> PROP') (g2 : PROP' -n> PROP'') (p : proto V PROPn PROP) :
+  proto_map (gn2 ◎ gn1) (g2 ◎ g1) p ≡ proto_map gn1 g2 (proto_map gn2 g1 p).
+Proof.
+  apply equiv_dist=> n. revert PROPn Hcn PROPn' Hcn' PROPn'' Hcn''
+    PROP Hc PROP' Hc' PROP'' Hc'' gn1 gn2 g1 g2 p.
+  induction (lt_wf n) as [n _ IH]=> PROPn ? PROPn' ? PROPn'' ?
+    PROP ? PROP' ? PROP'' ? gn1 gn2 g1 g2 p /=.
+  destruct (proto_case p) as [->|(a & c & ->)]; [by rewrite !proto_map_end|].
+  rewrite !proto_map_message /=. apply proto_message_ne=> // v p' /=.
+  do 3 f_equiv. apply Next_contractive; dist_later_intro as n' Hn'; simpl; auto.
+Qed.
+
+Program Definition protoOF (V : Type) (Fn F : oFunctor)
+    `{!∀ A B `{!Cofe A, !Cofe B}, Cofe (oFunctor_car Fn A B)}
+    `{!∀ A B `{!Cofe A, !Cofe B}, Cofe (oFunctor_car F A B)} : oFunctor := {|
+  oFunctor_car A _ B _ := proto V (oFunctor_car Fn B A) (oFunctor_car F A B);
+  oFunctor_map A1 _ A2 _ B1 _ B2 _ fg :=
+    proto_map (oFunctor_map Fn (fg.2, fg.1)) (oFunctor_map F fg)
+|}.
+Next Obligation.
+  intros V Fn F ?? A1 ? A2 ? B1 ? B2 ? n f g [??] p; simpl in *.
+  apply proto_map_ne=> // y; by apply oFunctor_map_ne.
+Qed.
+Next Obligation.
+  intros V Fn F ?? A ? B ? p; simpl in *. rewrite /= -{2}(proto_map_id p).
+  apply proto_map_ext=> //= y; by rewrite oFunctor_map_id.
+Qed.
+Next Obligation.
+  intros V Fn F ?? A1 ? A2 ? A3 ? B1 ? B2 ? B3 ? f g f' g' p; simpl in *.
+  rewrite -proto_map_compose.
+  apply proto_map_ext=> //= y; by rewrite ofe.oFunctor_map_compose.
+Qed.
+
+Global Instance protoOF_contractive (V : Type) (Fn F : oFunctor)
+    `{!∀ A B `{!Cofe A, !Cofe B}, Cofe (oFunctor_car Fn A B)}
+    `{!∀ A B `{!Cofe A, !Cofe B}, Cofe (oFunctor_car F A B)} :
+  oFunctorContractive Fn → oFunctorContractive F → 
+  oFunctorContractive (protoOF V Fn F).
+Proof.
+  intros HFn HF A1 ? A2 ? B1 ? B2 ? n f g Hfg p; simpl in *.
+  apply proto_map_ne=> y //=.
+  + apply HFn. dist_later_intro as n' Hn'. f_equiv; apply Hfg.
+  + apply HF. by dist_later_intro as n' Hn'.
+Qed.

--- a/new/proof/github_com/goose_lang/goose/model/channel/protocol/future/future.v
+++ b/new/proof/github_com/goose_lang/goose/model/channel/protocol/future/future.v
@@ -1,0 +1,283 @@
+Require Import New.proof.proof_prelude.
+From New.proof.github_com.goose_lang.goose.model.channel Require Export chan_au_send chan_au_recv chan_au_base chan_init.
+
+(** * Future Channel Verification
+
+    This file provides a high-level abstraction for future channels built on top
+    of the low-level channel verification. A future represents a one-shot communication
+    pattern where exactly one value is sent (fulfill) and exactly one value is
+    received (await).
+
+    Key features:
+    - Exactly one fulfill operation allowed per future
+    - Exactly one await operation allowed per future
+    - Uses buffered channel with capacity 1
+    - Ghost state tracks whether fulfill/await tokens have been consumed
+    - Close operations are banned 
+*)
+
+Section future.
+Context `{hG: heapGS Σ, !ffi_semantics _ _}.
+Context `{!chanGhostStateG Σ V}.
+Context `{!IntoVal V}.
+Context `{!IntoValTyped V t}.
+Context `{!globalsGS Σ} {go_ctx : GoContext}.
+Context `{!ghost_varG Σ bool}.
+
+(** ** Ghost State Names *)
+
+Record future_names := {
+  chan_name : chan_names;      (* Underlying channel ghost state *)
+  await_name : gname;          (* One-shot await token *)
+  fulfill_name : gname         (* One-shot fulfill token *)
+}.
+
+Notation half := (1/2)%Qp.
+
+(** ** One-shot Token Predicates *)
+
+(** Await token - permission to receive exactly once *)
+Definition await_token (γ : future_names) : iProp Σ :=
+  ghost_var γ.(await_name) half true.
+
+(** Fulfill token - permission to send exactly once *)
+Definition fulfill_token (γ : future_names) : iProp Σ :=
+  ghost_var γ.(fulfill_name) half true.
+
+(** ** Future Channel Invariant *)
+
+(** The main Future channel predicate.
+
+    Parameters:
+    - P: Resource associated with the value (travels from fulfill to await)
+
+    The invariant maintains:
+    - Channel has capacity exactly 1 (buffered)
+    - Empty buffer: both await and fulfill tokens available
+    - Buffer with one value: fulfill token consumed, await token available, P(v) holds
+    - Close operations are forbidden
+    - After await: both tokens consumed, buffer empty
+*)
+Definition is_future (γ : future_names) (ch : loc)
+                     (P : V → iProp Σ) : iProp Σ :=
+  is_channel ch 1 γ.(chan_name) ∗
+  inv nroot (
+    ∃ s await_avail fulfill_avail,
+      "Hch" ∷ own_channel ch 1 s γ.(chan_name) ∗
+      "Hawait" ∷ ghost_var γ.(await_name) half await_avail ∗
+      "Hfulfill" ∷ ghost_var γ.(fulfill_name) half fulfill_avail ∗
+      (match s with
+      (* Empty buffer: either initial state or final state *)
+      | chan_rep.Buffered [] =>
+          ⌜(await_avail = true ∧ fulfill_avail = true) ∨
+           (await_avail = false ∧ fulfill_avail = false)⌝
+      (* Fulfilled state: value in buffer, only await token available *)
+      | chan_rep.Buffered [v] =>
+          ⌜await_avail = true ∧ fulfill_avail = false⌝ ∗ P v
+      (* No unbuffered or closing allowed *)
+      | _ => False
+      end)
+  )%I.
+
+(** ** Initialization *)
+
+(** Create a Future channel from a capacity-1 buffered channel *)
+Lemma start_future ch (P : V → iProp Σ) γ :
+  is_channel ch 1 γ -∗
+  (own_channel ch 1 (chan_rep.Buffered []) γ) ={⊤}=∗
+  (∃ γfuture, is_future γfuture ch P ∗ await_token γfuture ∗ fulfill_token γfuture).
+Proof.
+  iIntros "#Hch Hoc".
+
+  (* Allocate ghost variables for await and fulfill tokens *)
+  iMod (ghost_var_alloc true) as (γawait) "[HawaitA HawaitF]".
+  iMod (ghost_var_alloc true) as (γfulfill) "[HfulfillA HfulfillF]".
+
+  (* Create the future_names record *)
+  set (γfuture := {| chan_name := γ; await_name := γawait; fulfill_name := γfulfill |}).
+
+  (* Allocate the invariant *)
+  iMod (inv_alloc nroot _ (
+    ∃ s await_avail fulfill_avail,
+      "Hch" ∷ own_channel ch 1 s γ ∗
+      "Hawait" ∷ ghost_var γawait half await_avail ∗
+      "Hfulfill" ∷ ghost_var γfulfill half fulfill_avail ∗
+      (match s with
+       | chan_rep.Buffered [] =>
+           ⌜(await_avail = true ∧ fulfill_avail = true) ∨
+            (await_avail = false ∧ fulfill_avail = false)⌝
+       | chan_rep.Buffered [v] =>
+           ⌜await_avail = true ∧ fulfill_avail = false⌝ ∗ P v
+       | _ =>
+           False
+       end)
+  ) with "[Hoc HawaitA HfulfillA]") as "#Hinv".
+  {
+    (* Prove the invariant holds initially *)
+    iNext. iExists (chan_rep.Buffered []), true, true. iFrame.
+    iPureIntro. left. split; done.
+  }
+
+  (* Construct the final result *)
+  iModIntro. iExists γfuture.
+  unfold is_future, await_token, fulfill_token.
+  iFrame "#". iFrame.
+Qed.
+
+(** ** Fulfill Operation (Send) *)
+
+(** Future fulfill operation - consumes fulfill token and P(v) to send value *)
+Lemma wp_future_fulfill γ ch (P : V → iProp Σ) (v : V) :
+  {{{
+   £ 1 ∗
+        is_pkg_init channel ∗ is_future γ ch P ∗ fulfill_token γ ∗ P v }}}
+    ch @ (ptrT.id channel.Channel.id) @ "Send" #t #v
+  {{{ RET #(); True }}}.
+Proof.
+  iIntros (Φ) "(Hlc1 & #Hinit & #Hfuture & Hfulfillt & HP) Hcont".
+
+  (* Extract channel info from Future predicate *)
+  unfold is_future.
+  iDestruct "Hfuture" as "[Hchan Hinv]".
+
+  iApply (wp_Send ch 1 v γ.(chan_name) with "[$Hinit $Hchan]").
+
+  (* Open the Future invariant to provide the atomic update *)
+  iInv "Hinv" as "Hinv_open" "Hinv_close".
+  iMod (lc_fupd_elim_later with "Hlc1 Hinv_open") as "Hinv_open".
+  iNamed "Hinv_open".
+
+  (* Establish agreement between our fulfill token and invariant's fulfill state *)
+  iDestruct (ghost_var_agree with "Hfulfill Hfulfillt") as %Hagree.
+
+  iApply fupd_mask_intro; [solve_ndisj|iIntros "Hmask"].
+  iNext. iFrame.
+
+  (* Case analysis on channel state *)
+  destruct s; try done.
+
+  { (* Case: Buffered channel *)
+    destruct buff as [|v_buf rest].
+    { (* Empty buffer - this is the expected case *)
+      iDestruct "Hinv_open" as %Hdisj.
+      destruct Hdisj as [[Hawait Hfulfill_state] | [Hawait Hfulfill_state]].
+      { (* Initial state case *)
+        subst await_avail fulfill_avail.
+
+        iIntros "Hoc".
+
+        (* Update fulfill token to false (consumed) *)
+        iCombine "Hfulfill Hfulfillt" as "Hfulfill_full".
+        iMod (ghost_var_update false with "Hfulfill_full") as "[HfulfillI_new _]".
+
+        (* Close invariant with value in buffer *)
+        iMod "Hmask".
+        iMod ("Hinv_close" with "[Hoc Hawait HfulfillI_new HP]") as "_".
+        {
+          iNext. iExists (chan_rep.Buffered [v]), true, false.
+          iFrame.
+          iPureIntro. split; done.
+        }
+
+        (* Apply continuation *)
+        iModIntro. iApply "Hcont". done.
+      }
+      { (* Final state case - both tokens already consumed, should not happen *)
+        subst await_avail fulfill_avail.
+        iExFalso. done.
+      }
+    }
+    { (* Non-empty buffer - should not happen with proper usage *)
+      destruct rest. all: done.
+    }
+  }
+
+Qed.
+
+(** ** Await Operation (Receive) *)
+
+(** Future await operation - consumes await token to receive value and P(v) *)
+Lemma wp_future_await γ ch (P : V → iProp Σ) :
+  {{{
+   £ 1 ∗
+        is_pkg_init channel ∗ is_future γ ch P ∗ await_token γ }}}
+    ch @ (ptrT.id channel.Channel.id) @ "Receive" #t #()
+  {{{ (v : V) , RET (#v, #true);
+      P v }}}.
+Proof.
+  iIntros (Φ) "(Hlc1 & #Hinit & #Hfuture & HawaitI) Hcont".
+
+  (* Extract channel info from Future predicate *)
+  unfold is_future.
+  iDestruct "Hfuture" as "[Hchan Hinv]".
+
+  (* Use wp_Receive with our atomic update *)
+  iApply (wp_Receive ch 1 γ.(chan_name) with "[$Hinit $Hchan]").
+
+  (* Open the Future invariant to provide the atomic update *)
+  iInv "Hinv" as "Hinv_open" "Hinv_close".
+  iMod (lc_fupd_elim_later with "Hlc1 Hinv_open") as "Hinv_open".
+  iNamed "Hinv_open".
+
+  (* Establish agreement between our await token and invariant's await state *)
+  iDestruct (ghost_var_agree with "HawaitI Hawait") as %Hagree.
+
+  (* Provide rcv_au_slow *)
+  unfold rcv_au_slow.
+  iExists s. iFrame "Hch".
+  iApply fupd_mask_intro; [solve_ndisj|iIntros "Hmask"].
+  iNext. iFrame.
+
+  (* Case analysis on channel state *)
+  destruct s; try done.
+
+  { (* Case: Buffered channel *)
+    destruct buff as [|v rest].
+    { (* Empty buffer - await must wait for fulfill *)
+      iDestruct "Hinv_open" as %Hdisj.
+      destruct Hdisj as [[Hawait_state Hfulfill_state] | [Hawait_state Hfulfill_state]].
+      { (* Initial state case *)
+        subst await_avail fulfill_avail.
+        (* With await_avail = true, we should not be able to receive yet *)
+        done.
+      }
+      { (* Final state case - both tokens consumed, should not happen *)
+        subst await_avail fulfill_avail.
+        (* This contradicts having the await token *)
+        iExFalso. done.
+      }
+    }
+    { (* Non-empty buffer - this is the expected case after fulfill *)
+      destruct rest.
+      { (* Exactly one value - expected case *)
+        iDestruct "Hinv_open" as "[%Hstates HPv]".
+        destruct Hstates as [Hawait_state Hfulfill_state].
+        subst await_avail fulfill_avail.
+
+        iIntros "Hoc".
+
+        (* Update await token to false (consumed) *)
+        iCombine "Hawait HawaitI" as "Hawait_full".
+        iMod (ghost_var_update false with "Hawait_full") as "[HawaitI_new _]".
+
+        (* Close invariant with empty buffer and both tokens consumed *)
+        iMod "Hmask".
+        iMod ("Hinv_close" with "[Hoc HawaitI_new Hfulfill]") as "_".
+        {
+          iNext. iExists (chan_rep.Buffered []), false, false.
+          iFrame "Hoc HawaitI_new Hfulfill".
+          iPureIntro. right. split; done.
+        }
+
+        (* Apply continuation with the value and its resource *)
+        iModIntro. iApply "Hcont". iFrame.
+      }
+      { (* More than one value - impossible with capacity 1 *)
+        iDestruct "Hinv_open" as "HFalse".
+        iExFalso. done.
+      }
+    }
+  }
+Qed.
+
+End future.

--- a/new/proof/github_com/goose_lang/goose/model/channel/protocol/handshake/handshake.v
+++ b/new/proof/github_com/goose_lang/goose/model/channel/protocol/handshake/handshake.v
@@ -1,0 +1,132 @@
+Require Import New.proof.proof_prelude.
+From New.proof.github_com.goose_lang.goose.model.channel Require Export chan_au_send chan_au_recv chan_au_base chan_init.
+
+Section handshake.
+Context `{hG: heapGS Σ, !ffi_semantics _ _}.
+Context `{!ghost_varG Σ ()}.
+Context `{!IntoVal V}.
+Context `{!IntoValTyped V t}.
+Context `{!chanGhostStateG Σ V}.
+Context `{!globalsGS Σ} {go_ctx : GoContext}.
+
+(*----------------------------------------------------------------------------
+  Invariant for a simple handshake on an unbuffered channel with unit payloads.
+
+  - When the channel has an in-flight *send* (SndWait/SndDone), predicate [P]
+    must hold (producer-side obligation).
+  - When the channel has an in-flight *receive* (RcvWait/RcvDone), predicate [Q]
+    must hold (consumer-side obligation).
+  - Buffered channels are intentionally disallowed.
+  - Closing is also disallowed in this protocol ([_ => False]).
+
+  ---------------------------------------------------------------------------*)
+Definition is_handshake γ (ch : loc)  (P: V -> iProp Σ) Q : iProp Σ :=
+  is_channel ch 0 γ  ∗
+  inv nroot (
+      ∃ s,
+        "Hch" ∷ own_channel ch 0 s γ ∗
+    (match s with
+     | chan_rep.Idle =>
+        True
+     | chan_rep.SndPending v | chan_rep.SndCommit v =>
+         P v
+     | chan_rep.RcvPending | chan_rep.RcvCommit =>
+         Q
+     (* Can't use buffered channel and we don't close here. *)
+     | _ => False
+     end
+    )).
+
+Lemma start_handshake ch P Q  γ:
+  is_channel  ch 0 γ  -∗
+  own_channel  ch 0 chan_rep.Idle γ ={⊤}=∗
+  is_handshake γ ch P Q .
+Proof.
+    intros.
+  iIntros "#? Hchan".
+  iFrame "#". iFrame. simpl.
+  iApply inv_alloc.
+ iExists chan_rep.Idle.
+ iFrame "∗%#".
+Qed.
+
+Lemma wp_handshake_receive γ ch P Q :
+  {{{
+         £ 1 ∗  £ 1 ∗  £ 1 ∗
+      is_pkg_init channel ∗
+      is_handshake γ ch P Q  ∗
+      Q
+  }}}
+    ch @ (ptrT.id channel.Channel.id) @ "Receive" #t #()
+  {{{
+      v, RET (#v, #true); P v
+  }}}.
+Proof.
+  iIntros (?) "(Hlc1 & Hlc2 & Hlc3 & Hpc & (#Hchan & #Hinv) & HQ) HΦ".
+  iApply ((wp_Receive ch 0  γ Φ  ) with "[$Hpc $Hchan]").
+   iMod (lc_fupd_elim_later with "[$] HΦ") as "Hau".
+  iFrame "#".
+  iInv "Hinv" as "Hi" "Hclose".
+   iMod (lc_fupd_elim_later with "[$] Hi") as "Hi".
+   iNamed "Hi".
+   iApply fupd_mask_intro; [ solve_ndisj | iIntros "Hmask"].
+  iNext. iNamed "Hi". iFrame.
+   destruct s. all:try done.
+   -   iIntros "H".
+    iMod "Hmask" as "_". iMod ("Hclose" with "[-Hau Hlc1]").
+    +  iModIntro. iExists chan_rep.RcvPending.  iFrame.
+    + iModIntro.  iInv "Hinv" as "Hi" "Hclose".
+      iMod (lc_fupd_elim_later with "[$] Hi") as "Hi".
+   iNamed "Hi".  iApply fupd_mask_intro; [ solve_ndisj | iIntros "Hmask"].
+   iModIntro. iExists s. iFrame. destruct s. all: try done.
+   { iMod "Hmask" as "_". iIntros "Hid". iMod ("Hclose" with "[-Hau Hi]").
+     { iModIntro.  iFrame. }
+     iModIntro.  { iApply "Hau". done. }
+   }
+   -  iIntros "H".
+    iMod "Hmask" as "_". iMod ("Hclose" with "[-Hau Hlc1 Hi]").
+    + iModIntro. iFrame.
+    + iModIntro.
+       iApply "Hau". done.
+Qed.
+
+Lemma wp_handshake_send γ ch v P Q :
+  {{{
+         £ 1 ∗  £ 1 ∗  £ 1 ∗
+      is_pkg_init channel ∗
+      is_handshake γ ch P Q ∗
+      P v
+  }}}
+    ch @ (ptrT.id channel.Channel.id) @ "Send" #t #v
+  {{{
+      RET (#()); Q
+  }}}.
+Proof.
+  iIntros (?) "(Hlc1 & Hlc2 & Hlc3 & Hpc & (#Hchan & #Hinv) & HP) HΦ".
+  iApply ((wp_Send ch 0 v γ Φ  ) with "[$Hpc $Hchan]").
+   iMod (lc_fupd_elim_later with "[$] HΦ") as "Hau".
+  iFrame "#".
+  iInv "Hinv" as "Hi" "Hclose".
+   iMod (lc_fupd_elim_later with "[$] Hi") as "Hi".
+   iNamed "Hi".
+   iApply fupd_mask_intro; [ solve_ndisj | iIntros "Hmask"].
+  iNext. iNamed "Hi". iFrame.
+   destruct s. all:try done.
+   -   iIntros "H".
+    iMod "Hmask" as "_". iMod ("Hclose" with "[-Hau Hlc1]").
+    +  iModIntro. iExists (chan_rep.SndPending v).  iFrame.
+    + iModIntro.  iInv "Hinv" as "Hi" "Hclose".
+      iMod (lc_fupd_elim_later with "[$] Hi") as "Hi".
+   iNamed "Hi".  iApply fupd_mask_intro; [ solve_ndisj | iIntros "Hmask"].
+   iModIntro. iExists s. iFrame. destruct s. all: try done.
+   { iMod "Hmask" as "_". iIntros "Hid". iMod ("Hclose" with "[-Hau Hi]").
+     { iModIntro.  iFrame. }
+     iModIntro.  iApply "Hau". done.
+   }
+   - iIntros "Hsd".
+    iMod "Hmask" as "_". iMod ("Hclose" with "[-Hau Hlc1 Hi]").
+    + iModIntro.  iFrame.
+    + iModIntro.  iApply "Hau". done.
+Qed.
+
+End handshake.

--- a/new/proof/github_com/goose_lang/goose/model/channel/protocol/spsc/spsc.v
+++ b/new/proof/github_com/goose_lang/goose/model/channel/protocol/spsc/spsc.v
@@ -1,0 +1,557 @@
+Require Import New.proof.proof_prelude.
+From New.proof.github_com.goose_lang.goose.model.channel Require Export chan_au_send chan_au_recv chan_au_base chan_init.
+
+(** * Single Producer Single Consumer (SPSC) Channel Verification
+
+    This file provides a high-level abstraction for single-producer single-consumer
+    channels built on top of the low-level channel verification. The SPSC abstraction
+    provides stronger guarantees by tracking the history of sent and received values.
+
+    Key features:
+    - Producer maintains exclusive send permission with history tracking
+    - Consumer maintains exclusive receive permission with history tracking  
+    - Ghost state tracks sent/received histories with fractional permissions
+    - Invariant maintains relationship: sent = received ++ in_flight
+    - Support for resource protocols P (per-value) and R (final state)
+*)
+
+Section spsc.
+Context `{hG: heapGS Σ, !ffi_semantics _ _}.
+Context `{!chanGhostStateG Σ V}.
+Context `{!IntoVal V}.
+Context `{!IntoValTyped V t}.
+Context `{!globalsGS Σ} {go_ctx : GoContext}.
+Context `{!ghost_varG Σ (list V)}.
+
+(** ** Ghost State Names *)
+
+Record spsc_names := {
+  chan_name : chan_names;      (* Underlying channel ghost state *)
+  spsc_sent_name : gname;      (* History of sent values *)
+  spsc_recv_name : gname       (* History of received values *)
+}.
+
+Notation half := (1/2)%Qp.
+
+(* Producer and Consumer Predicates *)
+
+(** Producer maintains half permission of sent history *)
+Definition spsc_producer (γ:spsc_names) (sent:list V) : iProp Σ :=
+    ghost_var γ.(spsc_sent_name) half sent.
+
+(** Consumer maintains half permission of received history *)
+Definition spsc_consumer (γ:spsc_names) (received:list V) : iProp Σ :=
+    ghost_var γ.(spsc_recv_name) half received.
+
+(** ** In-Flight Values *)
+
+(** Values that have been sent but not yet received *)
+Definition inflight (s : chan_rep.t V) : list V :=
+  match s with
+  | chan_rep.Buffered buff => buff
+  | chan_rep.SndPending v | chan_rep.SndCommit v => [v]
+  | chan_rep.Closed draining => draining
+  | _ => []
+  end.
+
+(** ** SPSC Channel Invariant *)
+
+(** The main SPSC channel predicate.
+    
+    Parameters:
+    - P: Resource associated with each value (maintained while in-flight)
+    - R: Final resource when channel is closed and drained
+    
+    The invariant maintains:
+    - sent = received + inflight(channel_state)
+    - P holds for all in-flight values
+    - When closed, producer permission is parked to prevent further sends
+    - When closed and drained, consumer gets R
+*)
+Definition is_spsc (γ:spsc_names) (ch:loc) 
+                   (P: V → iProp Σ) (R: list V → iProp Σ) : iProp Σ :=
+  ∃ (cap:Z),
+    is_channel ch cap γ.(chan_name) ∗
+    inv nroot (
+      ∃ s sent recv,
+        "Hch"    ∷ own_channel ch cap s γ.(chan_name) ∗
+        "HsentI" ∷ ghost_var γ.(spsc_sent_name) half sent ∗
+        "HrecvI" ∷ ghost_var γ.(spsc_recv_name) half recv ∗
+        "%Hrel"  ∷ ⌜sent = recv ++ inflight s⌝ ∗
+        (match s with
+        (* P holds for all buffered values *)
+        | chan_rep.Buffered buff => 
+            [∗ list] v ∈ buff, P v
+        (* P holds for pending/committed values *)    
+        | chan_rep.SndPending v | chan_rep.SndCommit v => 
+            P v
+        (* Closed channel: park producer permission, provide R when drained *)    
+        | chan_rep.Closed [] =>
+            spsc_producer γ sent ∗ (R sent ∨ spsc_consumer γ sent)
+        | chan_rep.Closed draining =>
+            ([∗ list] v ∈ draining, P v) ∗
+            spsc_producer γ sent ∗ 
+            (R sent ∨ spsc_consumer γ sent)
+        | _ => True
+        end)
+    )%I.
+
+(** ** Initialization *)
+
+(** Create an SPSC channel from a basic channel *)
+Lemma start_spsc ch (P : V → iProp Σ) (R : list V → iProp Σ) γ:
+  is_channel ch 0 γ -∗
+  (own_channel ch 0 chan_rep.Idle γ) ={⊤}=∗
+  (∃ γspsc, is_spsc γspsc ch P R).
+Proof.
+  iIntros "#Hch Hoc".
+
+  (* Allocate ghost variables for sent and received histories *)
+  iMod (ghost_var_alloc ([] : list V)) as (γsent) "[HsentA HsentF]".
+  iMod (ghost_var_alloc ([] : list V)) as (γrecv) "[HrecvA HrecvF]".
+
+  (* Create the spsc_names record *)
+  set (γspsc := {| chan_name := γ; spsc_sent_name := γsent; spsc_recv_name := γrecv |}).
+
+  (* Allocate the invariant *)
+  iMod (inv_alloc nroot _ (
+    ∃ s sent recv,
+      "Hch" ∷ own_channel ch 0 s γ ∗
+      "HsentI" ∷ ghost_var γsent half sent ∗
+      "HrecvI" ∷ ghost_var γrecv half recv ∗
+      "%Hrel" ∷ ⌜sent = recv ++ inflight s⌝ ∗
+      (match s with
+       | chan_rep.Buffered buff => [∗ list] v ∈ buff, P v
+       | chan_rep.SndPending v | chan_rep.SndCommit v => P v
+       | chan_rep.Closed [] =>
+           spsc_producer γspsc sent ∗ (R sent ∨ spsc_consumer γspsc sent)
+       | chan_rep.Closed draining =>
+           ([∗ list] v ∈ draining, P v) ∗
+           spsc_producer γspsc sent ∗ 
+           (R sent ∨ spsc_consumer γspsc sent)
+       | _ => True
+       end)
+  ) with "[Hoc HsentA HrecvA]") as "#Hinv".
+  {
+    (* Prove the invariant holds initially *)
+    iNext. iExists chan_rep.Idle, [], []. iFrame.
+    iPureIntro. simpl. done.
+  }
+
+  (* Construct the final result *)
+  iModIntro. iExists γspsc.
+  unfold is_spsc. iExists 0. iFrame "#".
+Qed.
+
+(** ** Receive Operation *)
+
+(** SPSC receive operation with history tracking *)
+Lemma wp_spsc_receive γ ch (ns:spsc_names) (P : V → iProp Σ) (R : list V → iProp Σ)
+                      (received : list V) :
+  {{{
+   £ 1 ∗ £ 1 ∗ £ 1 ∗ £ 1 ∗
+        is_pkg_init channel ∗ is_spsc γ ch P R ∗ spsc_consumer γ received }}}
+    ch @ (ptrT.id channel.Channel.id) @ "Receive" #t #()
+  {{{ (v:V) (ok:bool), RET (#v, #ok);
+      (if ok then P v ∗ spsc_consumer γ (received ++ [v])
+            else R received)%I }}}.
+Proof.
+  iIntros (Φ) "(Hlc1 & Hlc2 & Hlc3 & Hlc4 & #Hinit & #Hspsc & Hcons) Hcont".
+
+  (* Extract channel info from SPSC predicate *)
+  unfold is_spsc. iNamed "Hspsc".
+  iDestruct "Hspsc" as "[Hchan Hinv]".
+
+  (* Use wp_Receive with our atomic update *)
+  iApply (wp_Receive ch cap γ.(chan_name) with "[$Hinit $Hchan]").
+
+  (* Open the SPSC invariant to provide the atomic update *)
+  iInv "Hinv" as "Hinv_open" "Hinv_close".
+  iMod (lc_fupd_elim_later with "Hlc1 Hinv_open") as "Hinv_open".
+  iNamed "Hinv_open".
+
+  (* Establish agreement between our received and invariant's recv *)
+  iDestruct (ghost_var_agree with "Hcons HrecvI") as %->.
+
+  (* Provide rcv_au_slow *)
+  unfold rcv_au_slow.
+  iExists s. iFrame "Hch".
+  iApply fupd_mask_intro; [solve_ndisj|iIntros "Hmask"].
+  iNext. iFrame.
+
+  (* Case analysis on channel state *)
+  destruct s; try done.
+
+  { (* Case: Buffered channel *)
+    destruct buff as [|v rest].
+    { (* Empty buffer - no change to invariant *) done. }
+    { (* Non-empty buffer - can receive immediately *)
+      iIntros "Hoc".
+
+      (* Update received history *)
+      iCombine "Hcons HrecvI" as "Hrecv_full".
+      iMod (ghost_var_update (recv ++ [v]) with "Hrecv_full") as "[HrecvI_new Hcons_new]".
+
+      (* Extract P v from the big star list *)
+      iDestruct (big_sepL_cons with "Hinv_open") as "[HPv Hrest]".
+
+      (* Close invariant with updated state *)
+      iMod "Hmask".
+      iMod ("Hinv_close" with "[Hoc HsentI HrecvI_new Hrest]") as "_".
+      {
+        iNext. iExists (chan_rep.Buffered rest), sent, (recv ++ [v]).
+        iFrame.
+        iPureIntro. rewrite Hrel. simpl. rewrite <- app_assoc. reflexivity.
+      }
+
+      (* Apply continuation with ok=true *)
+      iModIntro. iApply "Hcont". iFrame.
+    }
+  }
+
+  { (* Case: Idle channel - register as receiver *)
+    iIntros "Hoc".
+
+    (* Close invariant with RcvPending state *)
+    iMod "Hmask".
+    iMod ("Hinv_close" with "[Hoc HsentI HrecvI]") as "_".
+    {
+      iNext. iExists chan_rep.RcvPending, sent, recv.
+      iFrame.
+      iPureIntro. rewrite Hrel. simpl. done.
+    }
+
+    (* Provide rcv_au_inner for completion *)
+    iModIntro. unfold rcv_au_inner.
+    iInv "Hinv" as "Hinv_open2" "Hinv_close".
+    iMod (lc_fupd_elim_later with "Hlc2 Hinv_open2") as "Hinv_open2".
+    iNamed "Hinv_open2".
+
+    (* Establish agreement between our received and invariant's recv *)
+    iDestruct (ghost_var_agree with "Hcons HrecvI") as %->.
+    
+    unfold rcv_au_slow.
+    iExists s. iFrame "Hch".
+    iApply fupd_mask_intro; [solve_ndisj|iIntros "Hmask1"].
+    iNext.
+
+    (* Should be SndCommit v when sender completes *)
+    destruct s; try done.
+    {
+      (* SndCommit case - complete the handshake *)
+      iCombine "Hcons HrecvI" as "Hrcv_full".
+      iMod (ghost_var_update (recv0 ++ [v]) with "Hrcv_full") as "[HrecvI_new Hcons_new]".
+      iIntros "Hoc".
+      iMod "Hmask1".
+      iMod ("Hinv_close" with "[HsentI HrecvI_new Hoc]") as "_".
+      {
+        iNext. iExists chan_rep.Idle, sent0, (recv0 ++ [v]).
+        iFrame.
+        iPureIntro. rewrite Hrel0. simpl. rewrite app_nil_r. done.
+      } 
+      iModIntro. iApply "Hcont". iFrame.
+    }
+    { (* Closed empty case *)
+      destruct draining as [|v rest].
+      { 
+        iIntros "Hoc".
+        iMod "Hmask1".
+        iDestruct "Hinv_open2" as "(H1 & H2)".
+        iDestruct "H2" as "[H2 | H3]".
+        {
+          iMod ("Hinv_close" with "[HsentI HrecvI Hoc H1 Hcons]") as "H".
+          {
+            iNext. iFrame.
+            iSplitR "HrecvI".
+            { iPureIntro. done. }
+            iRight. unfold spsc_consumer. subst sent0. unfold inflight. rewrite app_nil_r. done.
+          } 
+          iModIntro. iApply "Hcont". iFrame.
+          subst sent0. unfold inflight. rewrite app_nil_r. done.
+        }
+        {
+          iExFalso.
+          unfold spsc_consumer.
+          iCombine "Hcons HrecvI" as "Hfull".
+          iDestruct (ghost_var_valid_2 with "Hfull H3") as "[%Hvalid _]".
+          done.
+        }
+      }
+      { done. }
+    }
+  }
+
+  { (* Case: SndPending - fast path completion *)
+    iIntros "Hcont1".
+    iMod "Hmask".
+    iCombine "Hcons HrecvI" as "Hrcv_full".
+    iMod (ghost_var_update (recv ++ [v]) with "Hrcv_full") as "[HrecvI_new Hcons_new]".
+    iMod ("Hinv_close" with "[HsentI HrecvI_new Hcont1]") as "H".
+    {
+      iNext. iFrame. iPureIntro.
+      unfold inflight in *. rewrite app_nil_r. done. 
+    }
+    iModIntro. iApply "Hcont". iFrame.
+  }
+
+  { (* Case: Closed channel *)
+    destruct draining as [|v rest].
+    { (* Empty closed channel - return R *)
+      iIntros "Hoc".
+      iMod "Hmask".
+      iDestruct "Hinv_open" as "(H1 & H2)".
+      iDestruct "H2" as "[H2 | H3]".
+      {
+        iMod ("Hinv_close" with "[HsentI HrecvI Hoc H1 Hcons]") as "H".
+        {
+          iNext. iFrame.
+          iSplitR "HrecvI".
+          { iPureIntro. done. }
+          iRight. unfold spsc_consumer. subst sent. unfold inflight. rewrite app_nil_r. done.
+        } 
+        iModIntro. iApply "Hcont". iFrame.
+        subst sent. unfold inflight. rewrite app_nil_r. done.
+      }
+      {
+        iExFalso.
+        unfold spsc_consumer.
+        iCombine "Hcons HrecvI" as "Hfull".
+        iDestruct (ghost_var_valid_2 with "Hfull H3") as "[%Hvalid _]".
+        done.
+      }
+    }
+    { (* Closed channel with draining values *)
+      iIntros "Hoc".
+      iCombine "Hcons HrecvI" as "Hrcv_full".
+      iMod (ghost_var_update (recv ++ [v]) with "Hrcv_full") as "[HrecvI_new Hcons_new]".
+      iMod "Hmask".
+      iDestruct "Hinv_open" as "(H1 & H2 & H3)".
+      iDestruct "H3" as "[H4 | H5]".
+      {
+        destruct rest.
+        {
+          iMod ("Hinv_close" with "[HsentI Hoc H2 H4 Hcons_new]") as "H".
+          {
+            iNext. iFrame. iSplitR "H4". { iPureIntro.  unfold inflight in *. rewrite <- app_assoc. done.   }
+            iLeft. done.
+          }
+          iApply "Hcont". iModIntro. iFrame.
+          iDestruct "H1" as "[HPv _]". iFrame.
+        }
+        {
+          iDestruct (big_sepL_cons with "H1") as "[HPv Hrest]".
+          iMod ("Hinv_close" with "[HsentI Hoc Hrest H2 H4 Hcons_new]") as "H".
+          {
+            iNext. iFrame. iSplitR "H4 Hrest". { iPureIntro.  unfold inflight in *. rewrite <- app_assoc. done.   }
+            iFrame.
+          }
+          iApply "Hcont". iModIntro. iFrame.
+        }
+      }
+      {
+        destruct rest.
+        {
+          iMod ("Hinv_close" with "[HsentI Hoc H2 H5 Hcons_new]") as "H".
+          {
+            iNext. iFrame. iSplitR "H5". { iPureIntro.  unfold inflight in *. rewrite <- app_assoc. done.   }
+            iRight. iFrame.
+          }
+          iApply "Hcont". iModIntro. iFrame.
+          iDestruct "H1" as "[HPv _]". iFrame.
+        }
+        {
+          iDestruct (big_sepL_cons with "H1") as "[HPv Hrest]".
+          iMod ("Hinv_close" with "[HsentI Hoc Hrest H2 H5 Hcons_new]") as "H".
+          {
+            iNext. iFrame. iSplitR "H5 Hrest". { iPureIntro.  unfold inflight in *. rewrite <- app_assoc. done.   }
+             iFrame.
+          }
+          iApply "Hcont". iModIntro. iFrame.
+        }
+      }
+    }
+  }
+Qed.
+
+(** ** Send Operation *)
+
+(** SPSC send operation with history tracking *)
+Lemma wp_spsc_send γ ch (P : V → iProp Σ) (R : list V → iProp Σ)
+                   (sent : list V) (v : V) :
+  {{{
+   £ 1 ∗ £ 1 ∗ £ 1 ∗ £ 1 ∗
+        is_pkg_init channel ∗ is_spsc γ ch P R ∗ spsc_producer γ sent ∗ P v }}}
+    ch @ (ptrT.id channel.Channel.id) @ "Send" #t #v
+  {{{ RET #(); spsc_producer γ (sent ++ [v]) }}}.
+Proof.
+  iIntros (Φ) "(Hlc1 & Hlc2 & Hlc3 & Hlc4 & #Hinit & #Hspsc & Hprod & HP) Hcont".
+
+  (* Extract channel info from SPSC predicate *)
+  unfold is_spsc. iNamed "Hspsc". 
+  iDestruct "Hspsc" as "[Hchan Hinv]".
+  
+  (* Use wp_Send with our atomic update *)
+  iApply (wp_Send ch cap v γ.(chan_name) with "[$Hinit $Hchan]").
+  
+  (* Provide the send atomic update *)
+  iMod (lc_fupd_elim_later with "Hlc1 Hcont") as "Hcont".
+  
+  (* Open the SPSC invariant to provide the atomic update *)
+  iInv "Hinv" as "Hinv_open" "Hinv_close".
+  iMod (lc_fupd_elim_later with "Hlc2 Hinv_open") as "Hinv_open".
+  iNamed "Hinv_open".
+  
+  (* Establish agreement between our sent and invariant's sent *)
+  iDestruct (ghost_var_agree with "Hprod HsentI") as %->.
+  
+  iApply fupd_mask_intro; [solve_ndisj|iIntros "Hmask"].
+  iNext. iFrame.
+  
+  (* Case analysis on channel state *)
+  destruct s; try done.
+  
+  { (* Case: Buffered channel *)
+    destruct (length buff <? cap) eqn:Hlen; [|done].
+    iIntros "Hoc".
+    
+    (* Update sent history *)
+    iCombine "Hprod HsentI" as "Hsent_full".
+    iMod (ghost_var_update (sent0 ++ [v]) with "Hsent_full") as "[HsentI_new Hprod_new]".
+    
+    (* Close invariant *)
+    iMod "Hmask".
+    iMod ("Hinv_close" with "[Hoc HsentI_new HrecvI Hinv_open HP]") as "_".
+    {
+      iNext. iExists (chan_rep.Buffered (buff ++ [v])), (sent0 ++ [v]), recv.
+      iFrame. simpl.
+      subst sent0. iFrame.
+      iPureIntro. simpl. split. { rewrite app_assoc. done. } { done. }
+    }
+
+    (* Apply continuation *)
+    iModIntro. iApply "Hcont". unfold spsc_producer. iFrame.
+  }
+
+  { (* Case: Idle channel - need to wait for receiver *)
+    iIntros "Hoc".
+
+    (* Update sent history *)
+    iCombine "Hprod HsentI" as "Hsent_full".
+    iMod (ghost_var_update (sent0 ++ [v]) with "Hsent_full") as "[HsentI_new Hprod_new]".
+
+    iMod "Hmask".
+    iNamed "Hoc".
+    iAssert (own_channel ch cap (chan_rep.SndPending v) γ.(chan_name))%I
+      with "[Hchanrepfrag]" as "Hoc".
+    { iFrame. iPureIntro. unfold chan_cap_valid. done. }
+
+    (* Close invariant with SndPending state *)
+    iMod ("Hinv_close" with "[Hoc HsentI_new HrecvI HP]") as "_".
+    {
+      iNext. iExists (chan_rep.SndPending v), (sent0 ++ [v]), recv.
+      iFrame.
+      iPureIntro. rewrite Hrel. simpl. rewrite app_nil_r. reflexivity.
+    }
+
+    (* Provide send_au_inner *)
+    iModIntro. unfold send_au_inner.
+
+    iInv "Hinv" as "Hinv_open2" "Hinv_close2".
+    iMod (lc_fupd_elim_later with "[$] Hinv_open2") as "Hi".
+    iNamed "Hi".
+    iApply fupd_mask_intro; [solve_ndisj | iIntros "Hmask1"].
+    iNext. iNamed "Hi". iFrame.
+    iDestruct (ghost_var_agree with "Hprod_new HsentI") as %Heq.
+
+    (* Case analysis on current state *)
+    unfold chan_cap_valid in Hcapvalid.
+    subst cap.
+    destruct s; try done.
+    {
+      (* RcvCommit case - complete handshake *)
+      iIntros "Hoc".
+      iMod "Hmask1".
+      iMod ("Hinv_close2" with "[HsentI HrecvI Hoc]") as "_".
+      {
+        iNext. iExists chan_rep.Idle, sent, recv0.
+        iFrame.
+        iPureIntro. rewrite Hrel0. simpl. done.
+      } 
+      iModIntro. iApply "Hcont" in "Hprod_new". done.
+    }
+    {
+      (* Closed channel - invalid (producer permission conflict) *)
+      destruct draining.
+      {
+        iDestruct "Hi" as "(Hd & Hspp)".
+        unfold spsc_producer.
+        iCombine "HsentI Hd" as "Hfull".
+        iExFalso.
+        iDestruct (ghost_var_valid_2 with "Hfull Hprod_new") as "[%Hvalid _]".
+        done.
+      }
+      {
+        iDestruct "Hi" as "(Hd & Hspp & H3)".
+        unfold spsc_producer.
+        iCombine "HsentI Hspp" as "Hfull".
+        iExFalso.
+        iDestruct (ghost_var_valid_2 with "Hfull Hprod_new") as "[%Hvalid _]".
+        done.
+      }
+    }
+  }
+
+  { (* Case: RcvPending - fast path completion *)
+    iIntros "Hoc".
+
+    (* Update sent history *)
+    iCombine "Hprod HsentI" as "Hsent_full".
+    iMod (ghost_var_update (sent0 ++ [v]) with "Hsent_full") as "[HsentI_new Hprod_new]".
+
+    iMod "Hmask".
+
+    (* Close invariant with SndCommit state *)
+    iMod ("Hinv_close" with "[Hoc HsentI_new HrecvI HP]") as "_".
+    {
+      iNext. iExists (chan_rep.SndCommit v), (sent0 ++ [v]), recv.
+      iFrame.
+      iPureIntro. rewrite Hrel. simpl. rewrite app_nil_r. reflexivity.
+    }
+
+    (* Apply the final continuation *)
+    iModIntro. iApply "Hcont".
+    unfold spsc_producer. iFrame.
+  }
+
+  { (* Case: Closed channel - invalid (producer permission conflict) *)
+    destruct draining.
+    {
+      iDestruct "Hinv_open" as "(Hd & Hspp)".
+      unfold spsc_producer.
+      iCombine "HsentI Hd" as "Hfull".
+      iExFalso.
+      iDestruct (ghost_var_valid_2 with "Hfull Hprod") as "[%Hvalid _]".
+      done.
+    }
+    {
+      iDestruct "Hinv_open" as "(Hd & Hspp & H3)".
+      unfold spsc_producer.
+      iCombine "HsentI Hspp" as "Hfull".
+      iExFalso.
+      iDestruct (ghost_var_valid_2 with "Hfull Hprod") as "[%Hvalid _]".
+      done.
+    }
+  }
+Qed.
+
+(** ** Close Operation *)
+
+(** SPSC close operation *)
+Lemma wp_spsc_close γ ch P R sent :
+  {{{ is_pkg_init channel ∗ is_spsc γ ch P R ∗ spsc_producer γ sent ∗ R sent }}}
+    ch @ (ptrT.id channel.Channel.id) @ "Close" #t #()
+  {{{ RET #(); True }}}.
+Proof.
+Admitted.
+
+End spsc.


### PR DESCRIPTION
Add protocol/ folder with reusable invariants/specs built on the logically-atomic channel specs.

Handshake (unbuffered): proved end-to-end, simple resource exchange on unbuffered channel.

Future: Channel used as a future value, transfers a predicate P v and has 1 shot tokens called "await" and "fulfill"

SPSC : producer/consumer pipeline, has producer/consumer handles that store history and predicate P v for each value and R sent for the list at the time of close.

DSP: two goroutine endpoints/two go channels, uses Actris ghost theory. This is at an early stage but has boilerplate and some definitions/admitted lemmas.
