### PR TITLE
Verify Channel Receive Operations with Select Support

### DIFF
--- a/new/proof/github_com/goose_lang/goose/model/channel/logatom/chan_au_base.v
+++ b/new/proof/github_com/goose_lang/goose/model/channel/logatom/chan_au_base.v
@@ -8,51 +8,85 @@ From New.generatedproof.github_com.goose_lang.goose Require Import model.channel
 From New.proof.github_com.goose_lang Require Import primitive.
 From New.proof.github_com.goose_lang.std Require Import std_core.
 
-(* Inductive mathematical representation *)
+(** The mathematical model of channel states. This represents the logical
+    behavior of channels independent of the implementation details. *)
 Module chan_rep.
 Inductive t (V : Type) : Type :=
-| Buffered (buff : list V)
-| Idle
-| SndWait (v : V)
-| RcvWait  
-| SndDone (v : V)
-| RcvDone
-| Closed (draining : list V).
-  
-  (* Global Arguments for clean syntax *)
+| Buffered (buff: list V)     (* Buffered channel with pending messages *)
+| Idle                        (* Empty unbuffered channel, ready for operations *)
+| SndPending (v: V)          (* Unbuffered channel with sender waiting *)
+| RcvPending                 (* Unbuffered channel with receiver waiting *)
+| SndCommit (v: V)           (* Sender committed, waiting for receiver to complete *)
+| RcvCommit                  (* Receiver committed, waiting for sender to complete *)
+| Closed (draining: list V)  (* Closed channel, possibly draining remaining messages *)
+.
+
   Global Arguments Buffered {V}.
+  Global Arguments Idle {V}.
+  Global Arguments SndPending {V}.
+  Global Arguments RcvPending {V}.
+  Global Arguments SndCommit {V}.
+  Global Arguments RcvCommit {V}.
+  Global Arguments Closed {V}.
+
+End chan_rep.
+
+(** The state machine representation matching the model implementation.
+    This is slightly different from the mathematical representation
+    in that we don't go to the SndWait state logically until an offer 
+    is about to be accepted. *)
+Inductive chan_phys_state (V : Type) : Type :=
+| Buffered (buff: list V)     (* Channel with buffered messages *)
+| Idle                        (* Ready for operations *)
+| SndWait (v : V)            (* Sender offers *)
+| RcvWait                    (* Receiver offers *)
+| SndDone (v : V)            (* Sender operation completed, handshake in progress *)
+| RcvDone (v : V)            (* Receiver operation completed, handshake in progress *)
+| Closed (draining: list V)  (* Closed channel *)
+.
+
   Global Arguments Idle {V}.
   Global Arguments SndWait {V}.
   Global Arguments RcvWait {V}.
   Global Arguments SndDone {V}.
   Global Arguments RcvDone {V}.
-  Global Arguments Buffered {V}.
   Global Arguments Closed {V}.
+  Global Arguments Buffered {V}.
 
-  Definition buffer_valid {V} (c : chan_rep.t V) (cap: w64) : Prop :=
-  match c with
-  | chan_rep.Buffered buff =>
-    length buff ≤ uint.Z cap
-  | chan_rep.Closed draining =>
-    length draining ≤ uint.Z cap
-  | _ => True (* Invariant is vacuously true for unbuffered or empty closed states *)
-  end.
+(** The offer protocol coordinates handshakes between senders and receivers
+    in unbuffered channels. An "offer" represents a pending operation that
+    can be accepted by the other party. This ghost state ensures that 
+    an outstanding offer can only be accepted or left as-is for when we lock
+    the channel to check the status. *)
+Inductive offer_lock (V : Type) : Type :=
+| Snd (v : V)                (* Sender has made an offer *)
+| Rcv                        (* Receiver has made an offer *)
+.
 
-End chan_rep.
+  Global Arguments Snd {V}.
+  Global Arguments Rcv {V}.
 
-(* Ghost state management *)
+(** Ghost names for tracking various aspects of channel state in the logic *)
 Record chan_names := {
-  offer_name : gname;   (* For unbuffered offer/accept protocol *)
-  state_name : gname;   (* For the main channel state *)
+  state_name : gname;                    (* Main channel state *)
+  offer_lock_name : gname;               (* Offer protocol lock *)
+  offer_parked_prop_name : gname;        (* The saved prop that we can leave with the channel to support select *)
+  offer_parked_pred_name : gname;        (* The saved continuation for receive, which is a predicate on v, ok *)
+  offer_continuation_name : gname;       (* The continuation for send *)
 }.
 
+(** Type class for ghost state associated with channels *)
 Class chanGhostStateG Σ V := ChanGhostStateG {
-  offer_tokG :: ghost_varG Σ (option V);
-  chan_repG :: ghost_varG Σ (chan_rep.t V);
+  offerG :: ghost_varG Σ (chan_rep.t V);
+  offer_lockG :: ghost_varG Σ (option (offer_lock V));
+  offer_parked_propG :: savedPropG Σ;
+  offer_parked_predG :: savedPredG Σ (V * bool);
+  continuation_parkedG :: savedPropG Σ;
 }.
 
 Definition chanGhostStateΣ V : gFunctors :=
-  #[ ghost_varΣ (option V); ghost_varΣ (chan_rep.t V) ].
+  #[ ghost_varΣ (chan_rep.t V); ghost_varΣ (option (offer_lock V));
+     savedPropΣ; savedPredΣ  (V * bool) ].
 
 #[global] Instance subG_chanGhostStateG Σ V :
   subG (chanGhostStateΣ V) Σ → chanGhostStateG Σ V.
@@ -63,124 +97,265 @@ Context `{hG: heapGS Σ, !ffi_semantics _ _}.
 Context `{!chanGhostStateG Σ V}.
 Context `{!IntoVal V}.
 Context `{!IntoValTyped V t}.
-  
-(* Offer tokens for unbuffered channels *)
-Definition idle_tok (γ : gname) : iProp Σ :=
-    ghost_var γ 1%Qp None.
-  
-(* Send offer is outgoing, we can unlock the channel and know that the channel was
-  untouched other then by a receiver accepting the offer *)
-Definition snd_wait_tok (γ : gname) (v: V) : iProp Σ :=
-    ghost_var γ (1/2%Qp) (Some v).
 
-(* Almost symmetric to snd_wait_tok, but we don't need to encode a value *)
-Definition rcv_wait_tok (γ : gname) : iProp Σ :=
-    ghost_var γ (1/2%Qp) None.
-
-Lemma idle_to_two_snd_wait γ v :
-  idle_tok γ ==∗ snd_wait_tok γ v ∗ snd_wait_tok γ v.
+(* Remove the later from a saved prop if we have later credits. *)
+Lemma saved_prop_lc_agree γ dq1 dq2 P Q :
+   £ 1 -∗ saved_prop_own γ dq1 P -∗ saved_prop_own γ dq2 Q -∗ |={⊤}=> (P ≡ Q).
 Proof.
-  iIntros "Hidle".
-  iMod (ghost_var_update (Some v) γ _ with "Hidle") as "Hfull".
-  iDestruct "Hfull" as "[Hs1 Hs2]".
-  iModIntro. iFrame.
+  iIntros "Hlc HP HQ".
+  iDestruct (saved_prop_agree with "HP HQ") as "Heq".
+  iMod (lc_fupd_elim_later with "Hlc Heq") as "H3".
+  iModIntro. done.
 Qed.
 
-Lemma idle_to_two_rcv_wait γ :
-  idle_tok γ ==∗ rcv_wait_tok γ ∗ rcv_wait_tok γ.
-Proof.
-  iIntros "Hidle".
-  iMod (ghost_var_update _ γ _ with "Hidle") as "Hfull".
-  iDestruct "Hfull" as "[Hs1 Hs2]".
-  iModIntro. iFrame.
-Qed.
-
-Lemma two_snd_wait_to_idle γ v1 v2 :
-  snd_wait_tok γ v1 -∗ snd_wait_tok γ v2 ==∗ idle_tok γ.
-Proof.
-  iIntros "Hs1 Hs2".
-  iCombine "Hs1" "Hs2" as "Hfull".
-  iMod (ghost_var_update None γ _ with "Hfull") as "Hidle".
-  iModIntro. iExact "Hidle".
-Qed.
-
-Lemma two_rcv_wait_to_idle γ :
-  rcv_wait_tok γ -∗ rcv_wait_tok γ ==∗ idle_tok γ.
-Proof.
-  iIntros "Hs1 Hs2".
-  iCombine "Hs1" "Hs2" as "Hfull".
-  iMod (ghost_var_update None γ _ with "Hfull") as "Hidle".
-  iModIntro. iExact "Hidle".
-Qed.
-
-
-Definition offer_auth (γ : chan_names) (s : chan_rep.t V) : iProp Σ :=
+(** Maps physical channel states to their heap representations.
+    Each state corresponds to specific field values in the Go struct. *)
+Definition chan_phys (ch: loc) (s: chan_phys_state V) : iProp Σ :=
   match s with
-  | chan_rep.SndWait v   => snd_wait_tok γ.(offer_name) v
-  | chan_rep.RcvWait     => rcv_wait_tok γ.(offer_name)
-  | chan_rep.SndDone v   => rcv_wait_tok γ.(offer_name)
-  | chan_rep.RcvDone     =>  ∃ v, snd_wait_tok γ.(offer_name) v
-  | _  => idle_tok γ.(offer_name)
-  end.
+    | Closed [] =>
+        ∃ (slice_val: slice.t),
+        "state" ∷ ch ↦s[(channel.Channel.ty t) :: "state"] (W64 6) ∗
+        "slice" ∷ own_slice slice_val (DfracOwn 1) ([] : list V) ∗
+        "slice_cap" ∷ own_slice_cap V slice_val (DfracOwn 1) ∗
+        "buffer" ∷ ch ↦s[(channel.Channel.ty t) :: "buffer"] slice_val
+    | Closed draining =>
+        ∃ (slice_val: slice.t),
+        "state" ∷ ch ↦s[(channel.Channel.ty t) :: "state"] (W64 6) ∗
+        "slice" ∷ own_slice slice_val (DfracOwn 1) draining ∗
+        "slice_cap" ∷ own_slice_cap V slice_val (DfracOwn 1) ∗
+        "buffer" ∷ ch ↦s[(channel.Channel.ty t) :: "buffer"] slice_val
+    | Buffered buff =>
+        ∃ (slice_val: slice.t),
+        "state" ∷ ch ↦s[(channel.Channel.ty t) :: "state"] (W64 0) ∗
+        "slice" ∷ own_slice slice_val (DfracOwn 1) buff ∗
+        "slice_cap" ∷ own_slice_cap V slice_val (DfracOwn 1) ∗
+        "buffer" ∷ ch ↦s[(channel.Channel.ty t) :: "buffer"] slice_val
+    | Idle =>
+        ∃ (v:V) (slice_val: slice.t),
+        "state" ∷ ch ↦s[(channel.Channel.ty t) :: "state"] (W64 1) ∗
+        "v" ∷ ch ↦s[(channel.Channel.ty t) :: "v"] v ∗ 
+        "slice" ∷ own_slice slice_val (DfracOwn 1) ([] : list V) ∗
+        "slice_cap" ∷ own_slice_cap V slice_val (DfracOwn 1) ∗ 
+        "buffer" ∷ ch ↦s[(channel.Channel.ty t) :: "buffer"] slice_val
+    | SndWait v =>
+        ∃ (slice_val: slice.t),
+        "state" ∷ ch ↦s[(channel.Channel.ty t) :: "state"] (W64 2) ∗
+        "v" ∷ ch ↦s[(channel.Channel.ty t) :: "v"] v ∗  
+        "slice" ∷ own_slice slice_val (DfracOwn 1) ([] : list V) ∗
+        "slice_cap" ∷ own_slice_cap V slice_val (DfracOwn 1) ∗ 
+        "buffer" ∷ ch ↦s[(channel.Channel.ty t) :: "buffer"] slice_val
+    | RcvWait =>
+        ∃ (v:V) (slice_val: slice.t),
+        "state" ∷ ch ↦s[(channel.Channel.ty t) :: "state"] (W64 3) ∗
+        "v" ∷ ch ↦s[(channel.Channel.ty t) :: "v"] v ∗ 
+        "slice" ∷ own_slice slice_val (DfracOwn 1) ([] : list V) ∗
+        "slice_cap" ∷ own_slice_cap V slice_val (DfracOwn 1) ∗ 
+        "buffer" ∷ ch ↦s[(channel.Channel.ty t) :: "buffer"] slice_val
+    | SndDone v =>
+        ∃ (slice_val: slice.t),
+        "state" ∷ ch ↦s[(channel.Channel.ty t) :: "state"] (W64 4) ∗
+        "v" ∷ ch ↦s[(channel.Channel.ty t) :: "v"] v ∗  
+        "slice" ∷ own_slice slice_val (DfracOwn 1) ([] : list V) ∗
+        "slice_cap" ∷ own_slice_cap V slice_val (DfracOwn 1) ∗ 
+        "buffer" ∷ ch ↦s[(channel.Channel.ty t) :: "buffer"] slice_val
+    | RcvDone v =>
+        ∃ (slice_val: slice.t),
+        "state" ∷ ch ↦s[(channel.Channel.ty t) :: "state"] (W64 5) ∗ 
+        "v" ∷ ch ↦s[(channel.Channel.ty t) :: "v"] v ∗ 
+        "slice" ∷ own_slice slice_val (DfracOwn 1) ([] : list V) ∗
+        "slice_cap" ∷ own_slice_cap V slice_val (DfracOwn 1) ∗ 
+        "buffer" ∷ ch ↦s[(channel.Channel.ty t) :: "buffer"] slice_val
+    end.
 
-Lemma offer_snd_coherent γ (s : chan_rep.t V) v :
-  offer_auth γ s -∗ snd_wait_tok γ.(offer_name) v -∗
-  ⌜s = chan_rep.SndWait v ∨ s = chan_rep.RcvDone ⌝.
+(** Bundles together offer-related ghost state for atomic operations *)
+Definition saved_offer (γ : chan_names) (q : Qp)
+  (lock_val : option (offer_lock V))
+  (parked_prop continuation_prop : iProp Σ) : iProp Σ :=
+  ghost_var γ.(offer_lock_name) q lock_val ∗
+  saved_prop_own γ.(offer_parked_prop_name) (DfracOwn q) parked_prop ∗
+  saved_prop_own γ.(offer_continuation_name) (DfracOwn q) continuation_prop.
+
+Notation offer_bundle_full γ := (saved_offer γ 1%Qp).
+Notation offer_bundle_half γ := (saved_offer γ (1/2)%Qp).
+
+Definition offer_bundle_empty (γ : chan_names) : iProp Σ :=
+  offer_bundle_full γ None True True.
+
+Lemma offer_idle_to_send γ v parked_prop cont :
+  offer_bundle_empty γ ==∗
+  offer_bundle_half γ (Some (Snd v)) parked_prop cont ∗
+  offer_bundle_half γ (Some (Snd v)) parked_prop cont.
 Proof.
-  iIntros "Hpiece Htok".
-  destruct s; simpl.
-  - 
-     iDestruct (ghost_var_valid_2 with "[$Hpiece] [$Htok]") as "%Hinvalid".
-     destruct Hinvalid as [Hbad _]. apply  (Qp.not_add_le_r 1 (1/2)) in Hbad. contradiction.
-  - 
-     iDestruct (ghost_var_valid_2 with "[$Hpiece] [$Htok]") as "%Hinvalid".
-     destruct Hinvalid as [Hbad _]. apply  (Qp.not_add_le_r 1 (1/2)) in Hbad. contradiction.
-  - iDestruct (ghost_var_agree with "Hpiece Htok") as %Heq. inversion Heq. subst. iPureIntro. left. reflexivity.
-  - iDestruct (ghost_var_agree with "Hpiece Htok") as %Eq.  
-iPureIntro.
-exfalso. discriminate Eq. 
-  -  iDestruct (ghost_var_agree with "Hpiece Htok") as %Eq. 
-iPureIntro.
-exfalso. discriminate Eq.
-  - iPureIntro. right. done.
-  - iDestruct (ghost_var_valid_2 with "[$Hpiece] [$Htok]") as "%Hinvalid".
-    destruct Hinvalid as [Hbad _]. apply  (Qp.not_add_le_r 1 (1/2)) in Hbad. contradiction.
+  iIntros "[Hlock [Hoffer Hcont]]".
+  iMod (ghost_var_update (Some (Snd v)) with "Hlock") as "[Hlock1 Hlock2]".
+  iMod (saved_prop_update cont with "Hcont") as "[Hcont1 Hcont2]".
+  iMod (saved_prop_update parked_prop with "Hoffer") as "[Hoffer1 Hoffer2]".
+  iModIntro. iFrame.
 Qed.
 
-Lemma offer_rcv_coherent γ (s : chan_rep.t V) :
-  offer_auth γ s -∗ rcv_wait_tok γ.(offer_name) -∗
-  ⌜s = chan_rep.RcvWait ∨ ∃ v, s = chan_rep.SndDone v⌝.
+Lemma offer_send_to_idle γ v parked_prop cont :
+  offer_bundle_half γ (Some (Snd v)) parked_prop cont -∗
+   offer_bundle_half γ (Some (Snd v)) parked_prop cont ==∗
+  offer_bundle_empty γ.
 Proof.
-  iIntros "Hpiece Htok".
-  destruct s; simpl in *.
-  - iDestruct (ghost_var_valid_2 with "Hpiece Htok") as %[Hle _].
-    iPureIntro. exfalso. exact (Qp.not_add_le_l 1 (1/2)%Qp Hle).
-  - iDestruct (ghost_var_valid_2 with "Hpiece Htok") as %[Hle _]. 
-    iPureIntro. exfalso. exact (Qp.not_add_le_l 1 (1/2)%Qp Hle).
-  - iDestruct (ghost_var_agree with "Hpiece Htok") as %Eq. iPureIntro. exfalso. discriminate Eq.
-  - iPureIntro. left; reflexivity.
-  - iPureIntro. right. exists v. done.
-  - iNamed "Hpiece".
-    iDestruct (ghost_var_agree with "Hpiece Htok") as %Eq. iPureIntro. exfalso. discriminate Eq.
-  - iDestruct (ghost_var_valid_2 with "Hpiece Htok") as %[Hle _]. 
-    iPureIntro. exfalso. exact (Qp.not_add_le_l 1 (1/2)%Qp Hle).
+  iIntros "[Hlock [Hoffer Hcont]]".
+  iIntros "[Hlock2 [Hoffer2 Hcont2]]".
+  iCombine "Hlock Hlock2" as "Hlock".
+  iMod (saved_prop_update_halves True with "Hoffer Hoffer2") as "[Hoffer Hoffer2]".
+  iMod (saved_prop_update_halves True with "Hcont Hcont2") as "[Hcont Hcont2]".
+  iCombine "Hcont Hcont2" as "Hcont".
+  iCombine "Hoffer Hoffer2" as "Hoffer".
+  iMod (ghost_var_update None with "Hlock") as "Hlock".
+  iModIntro. unfold offer_bundle_empty. unfold offer_bundle_full. iFrame.
+  unfold saved_prop_own.
+  rewrite dfrac_op_own.
+  rewrite Qp.half_half.
+  iFrame.
 Qed.
 
+Lemma offer_idle_to_recv γ parked_prop cont:
+  offer_bundle_empty γ ==∗
+  offer_bundle_half γ (Some Rcv) parked_prop cont ∗
+  offer_bundle_half γ (Some Rcv) parked_prop cont.
+Proof.
+   iIntros "[Hlock [Hoffer Hcont]]".
+  iMod (ghost_var_update (Some (Rcv)) with "Hlock") as "[Hlock1 Hlock2]".
+  iMod (saved_prop_update cont with "Hcont") as "[Hcont1 Hcont2]".
+  iMod (saved_prop_update parked_prop with "Hoffer") as "[Hoffer1 Hoffer2]".
+  iModIntro. iFrame.
+Qed.
 
-(* ghost state for channel mathematical representation. *)
+Lemma offer_recv_to_idle γ parked_prop cont :
+  offer_bundle_half γ (Some Rcv) parked_prop cont -∗
+   offer_bundle_half γ (Some Rcv) parked_prop cont ==∗
+  offer_bundle_empty γ.
+Proof.
+  iIntros "[Hlock [Hoffer Hcont]]".
+  iIntros "[Hlock2 [Hoffer2 Hcont2]]".
+  iCombine "Hlock Hlock2" as "Hlock".
+  iMod (saved_prop_update_halves True with "Hoffer Hoffer2") as "[Hoffer Hoffer2]".
+  iMod (saved_prop_update_halves True with "Hcont Hcont2") as "[Hcont Hcont2]".
+  iCombine "Hcont Hcont2" as "Hcont".
+  iCombine "Hoffer Hoffer2" as "Hoffer".
+  iMod (ghost_var_update None with "Hlock") as "Hlock".
+  iModIntro. unfold offer_bundle_empty. unfold offer_bundle_full. iFrame.
+  unfold saved_prop_own.
+  rewrite dfrac_op_own.
+  rewrite Qp.half_half.
+  iFrame.
+Qed.
+
+Lemma offer_reset γ :
+  ∀ parked_prop cont state,
+   offer_bundle_full γ state parked_prop cont ==∗
+  offer_bundle_empty γ.
+Proof.
+  intros parked_prop cont state.
+  iIntros "[Hlock [Hoffer Hcont]]".
+  iMod (ghost_var_update None with "Hlock") as "Hlock".
+  iMod (saved_prop_update True with "Hcont") as "Hcont".
+  iMod (saved_prop_update True with "Hoffer") as "Hoffer".
+  iModIntro.
+  iFrame.
+Qed.
+
+Lemma offer_bundle_agree γ q1 q2
+  lock1 parked1 cont1 lock2 parked2 cont2 :
+  saved_offer γ q1 lock1 parked1 cont1 ∗
+  saved_offer γ q2 lock2 parked2 cont2 ⊢
+  ⌜lock1 = lock2⌝ ∗
+  ▷(parked1 ≡ parked2) ∗ ▷(cont1 ≡ cont2).
+Proof.
+  iIntros "[[Hl1 [Hp1 Hc1]] [Hl2 [Hp2 Hc2]]]".
+  iDestruct (ghost_var_agree with "Hl1 Hl2") as %->.
+  iDestruct (saved_prop_agree with "Hp1 Hp2") as "Hp_eq".
+  iDestruct (saved_prop_agree with "Hc1 Hc2") as "Hc_eq".
+  auto.
+Qed.
+
+Lemma offer_bundle_lc_agree γ
+  lock1 parked1 cont1 lock2 parked2 cont2 :
+  £ 1 -∗ £ 1 -∗
+  saved_offer γ (1/2) lock1 parked1 cont1 -∗
+  saved_offer γ (1/2) lock2 parked2 cont2 -∗
+  |={⊤}=> ⌜lock1 = lock2⌝ ∗
+         (parked1 ≡ parked2) ∗ (cont1 ≡ cont2) ∗
+         offer_bundle_empty γ.
+Proof.
+  iIntros "Hlc1".
+  iIntros "Hlc2".
+  iIntros "[Hl1 [Hp1 Hc1]]".
+  iIntros "[Hl2 [Hp2 Hc2]]".
+   iDestruct (ghost_var_agree with "[$Hl1] [$Hl2]") as %->.
+  iDestruct (saved_prop_agree with "[$Hp1] [$Hp2]") as "#Hp_eq".
+  iDestruct (saved_prop_agree with "[$Hc1] [$Hc2]") as "#Hc_eq".
+
+  iMod (lc_fupd_elim_later with "Hlc1 Hp_eq") as "Hp_eq1".
+  iMod (lc_fupd_elim_later with "Hlc2 Hc_eq") as "Hc_eq1".
+  unfold offer_bundle_empty. unfold offer_bundle_full.
+  iFrame.
+  iSplitR; first done.  (* ⌜lock2 = lock2⌝ is trivial *)
+
+(* Combine and update ghost variable *)
+iCombine "Hl1 Hl2" as "Hlock".
+iMod ((ghost_var_update None) with "Hlock") as "Hlock".
+
+(* Update saved propositions using halves lemmas *)
+iMod (saved_prop_update_halves True with "Hp1 Hp2") as "[Hp1 Hp2]".
+iMod (saved_prop_update_halves True with "Hc1 Hc2") as "[Hc1 Hc2]".
+
+(* Combine the updated halves to get full ownership *)
+iCombine "Hp1 Hp2" as "Hparked".
+iCombine "Hc1 Hc2" as "Hcont".
+
+(* Simplify the combined fractions *)
+rewrite dfrac_op_own Qp.half_half.
+
+iFrame.
+  auto.
+Qed.
+
+Lemma saved_offer_fractional_invalid γ q1 q2 lock1 parked1 cont1 lock2 parked2 cont2 :
+  (1 < q1 + q2)%Qp →
+  saved_offer γ q1 lock1 parked1 cont1 -∗
+  saved_offer γ q2 lock2 parked2 cont2 -∗
+  False.
+Proof.
+  iIntros (Hq) "[Hlock1 [Hp1 Hc1]] [Hlock2 [Hp2 Hc2]]".
+  iDestruct (ghost_var_valid_2 with "Hlock1 Hlock2") as "[%Hvalid _]".
+  iPureIntro.
+apply Qp.lt_nge in Hq.
+contradiction.
+Qed.
+
+Lemma saved_offer_half_full_invalid γ lock1 parked1 cont1 lock2 parked2 cont2 :
+  saved_offer γ (1/2) lock1 parked1 cont1 -∗
+  saved_offer γ 1 lock2 parked2 cont2 -∗
+  False.
+Proof.
+  iApply saved_offer_fractional_invalid.
+  compute_done. (* 1/2 + 1 = 3/2 > 1 *)
+Qed.
+
 Definition chan_rep (γ : gname) (q : Qp) (s : chan_rep.t V) : iProp Σ :=
   ghost_var γ q s.
+
 Notation chan_rep_full γ s := (chan_rep γ 1 s).
 Notation chan_rep_half γ s := (chan_rep γ (1/2)%Qp s).
 Notation chan_rep_auth γ s := (chan_rep_half γ s).
 Notation chan_rep_frag γ s := (chan_rep_half γ s).
+
 Lemma chan_rep_update γ s s' :
   chan_rep_full γ s ==∗ chan_rep_full γ s'.
 Proof.
-  iApply (ghost_var_update s' γ s). Qed.
+  iApply (ghost_var_update s' γ s). 
+Qed.
+
 Lemma chan_rep_agree γ q1 q2 s s' :
   chan_rep γ q1 s -∗ chan_rep γ q2 s' -∗ ⌜s = s'⌝.
-Proof. iIntros "H1 H2". by iApply (ghost_var_agree with "H1 H2"). Qed.
+Proof. 
+  iIntros "H1 H2". by iApply (ghost_var_agree with "H1 H2"). 
+Qed.
 
 Lemma chan_rep_combine γ s s' :
   chan_rep_half γ s -∗ chan_rep_half γ s' -∗ ⌜s = s'⌝ -∗ chan_rep_full γ s.
@@ -188,127 +363,234 @@ Proof.
   iIntros "H1 H2 %H3". iDestruct (chan_rep_agree with "H1 H2") as %->.
   iCombine "H1" "H2" as "H". done.
 Qed.
+
 Lemma chan_rep_halves_update γ s1 s2 s' :
   chan_rep_half γ s1 -∗ chan_rep_half γ s2 ==∗
      chan_rep_half γ s' ∗ chan_rep_half γ s'.
 Proof.
 Admitted.
 
-
-(* Physical state helper utility for the channel model that uses a simple blocking
-   queue for buffered channels and an offer state machine for unbuffered channels
-*)
-
-  (* Unified physical state predicate *)
-  Definition chan_phys (ch: loc) (s: chan_rep.t V) 
-       : iProp Σ :=
-    match s with
-    | chan_rep.Closed [] => 
-        ∃ (slice_val: slice.t),
-        "state" ∷ ch ↦s[(channel.Channel.ty t) :: "state"] (W64 6) ∗ 
-        "slice" ∷ own_slice slice_val (DfracOwn 1) ([] : list V) ∗
-        "slice_cap" ∷ own_slice_cap V slice_val (DfracOwn 1) ∗ 
-        "buffer" ∷ ch ↦s[(channel.Channel.ty t) :: "buffer"] slice_val
-    | chan_rep.Closed draining =>
-        ∃ (slice_val: slice.t),
-        "state" ∷ ch ↦s[(channel.Channel.ty t) :: "state"] (W64 6) ∗
-        "slice" ∷ own_slice slice_val (DfracOwn 1) draining ∗
-        "slice_cap" ∷ own_slice_cap V slice_val (DfracOwn 1) ∗ 
-        "buffer" ∷ ch ↦s[(channel.Channel.ty t) :: "buffer"] slice_val
-    | chan_rep.Buffered buff => 
-        ∃ (slice_val: slice.t),
-        "state" ∷ ch ↦s[(channel.Channel.ty t) :: "state"] (W64 0) ∗
-        "slice" ∷ own_slice slice_val (DfracOwn 1) buff ∗
-        "slice_cap" ∷ own_slice_cap V slice_val (DfracOwn 1) ∗ 
-        "buffer" ∷ ch ↦s[(channel.Channel.ty t) :: "buffer"] slice_val
-    | chan_rep.Idle => 
-      ∃ (v:V) (slice_val: slice.t),
-      "state" ∷ ch ↦s[(channel.Channel.ty t) :: "state"] (W64 1) ∗
-      "v" ∷ ch ↦s[(channel.Channel.ty t) :: "v"] v ∗ 
-        "slice" ∷ own_slice slice_val (DfracOwn 1) ([] : list V) ∗
-        "slice_cap" ∷ own_slice_cap V slice_val (DfracOwn 1) ∗ 
-        "buffer" ∷ ch ↦s[(channel.Channel.ty t) :: "buffer"] slice_val
-    | chan_rep.SndWait v => 
-      ∃ (slice_val: slice.t),
-      "state" ∷ ch ↦s[(channel.Channel.ty t) :: "state"] (W64 2) ∗
-      "v" ∷ ch ↦s[(channel.Channel.ty t) :: "v"] v ∗  
-        "slice" ∷ own_slice slice_val (DfracOwn 1) ([] : list V) ∗
-        "slice_cap" ∷ own_slice_cap V slice_val (DfracOwn 1) ∗ 
-        "buffer" ∷ ch ↦s[(channel.Channel.ty t) :: "buffer"] slice_val
-    | chan_rep.RcvWait => 
-      ∃ (v:V) (slice_val: slice.t),
-      "state" ∷ ch ↦s[(channel.Channel.ty t) :: "state"] (W64 3) ∗
-      "v" ∷ ch ↦s[(channel.Channel.ty t) :: "v"] v ∗ 
-        "slice" ∷ own_slice slice_val (DfracOwn 1) ([] : list V) ∗
-        "slice_cap" ∷ own_slice_cap V slice_val (DfracOwn 1) ∗ 
-        "buffer" ∷ ch ↦s[(channel.Channel.ty t) :: "buffer"] slice_val
-    | chan_rep.SndDone v => 
-      ∃ (slice_val: slice.t),
-      "state" ∷ ch ↦s[(channel.Channel.ty t) :: "state"] (W64 4) ∗
-      "v" ∷ ch ↦s[(channel.Channel.ty t) :: "v"] v ∗  
-        "slice" ∷ own_slice slice_val (DfracOwn 1) ([] : list V) ∗
-        "slice_cap" ∷ own_slice_cap V slice_val (DfracOwn 1) ∗ 
-        "buffer" ∷ ch ↦s[(channel.Channel.ty t) :: "buffer"] slice_val
-    | chan_rep.RcvDone => 
-      ∃ (v:V) (slice_val: slice.t),
-      "state" ∷ ch ↦s[(channel.Channel.ty t) :: "state"] (W64 5) ∗ 
-      "v" ∷ ch ↦s[(channel.Channel.ty t) :: "v"] v ∗ 
-        "slice" ∷ own_slice slice_val (DfracOwn 1) ([] : list V) ∗
-        "slice_cap" ∷ own_slice_cap V slice_val (DfracOwn 1) ∗ 
-        "buffer" ∷ ch ↦s[(channel.Channel.ty t) :: "buffer"] slice_val
-    end.
-
-(* TODO: Add select physical state *)
-
-(* Ownership *)
-
-Definition cap_rel (cap : w64) (s : chan_rep.t V) : Prop :=
+Definition chan_cap_valid (s : chan_rep.t V) (cap: Z) : Prop :=
   match s with
-  (* Once we're closed and drained, unbuffered/buffered work the same *)
-  | chan_rep.Closed []                      => True
-  | chan_rep.Buffered _ | chan_rep.Closed _ => cap ≠ W64 0 ∧ sint.Z cap > 0
-  | _                                       => cap = W64 0
+  | chan_rep.Buffered _ => (0 < cap)%Z     
+  | chan_rep.Closed [] => True              (* Empty closed channels might have been unbuffered, doesn't matter *)
+  | chan_rep.Closed _ => (0 < cap)%Z (* Draining closed channels are buffered channels *)
+  | _ => cap = 0                            (* All other states are unbuffered *)
   end.
-  
-  (* What goes inside the mutex invariant *)
-  Definition chan_inv_inner (ch: loc) (cap:w64) (γ: chan_names) : iProp Σ :=
-    ∃ (s : chan_rep.t V),
-      "phys" ∷ chan_phys ch s ∗
-      "auth" ∷ chan_rep_auth γ.(state_name) s ∗
-      "%Hcap"  ∷  
-        ⌜cap_rel cap s⌝
-      ∗  
-      (* Offer ghost state for unbuffered channels *)
-      "offer"  ∷ offer_auth γ s.
-      
-  (* Public channel interface - what clients see *)
-  Definition is_channel (ch: loc) (cap :w64) (γ: chan_names) : iProp Σ :=
-    ∃ (mu_loc: loc) (s: chan_rep.t V),
-      "#cap" ∷ ch ↦s[(channel.Channel.ty t) :: "cap"]□ cap ∗
-      "#mu" ∷ ch ↦s[(channel.Channel.ty t) :: "lock"]□ mu_loc ∗
-      "#lock" ∷ is_Mutex mu_loc (chan_inv_inner ch cap γ).
-      
-  (* Fractional ownership for protocol development *)
-  Definition own_channel (ch: loc) (s: chan_rep.t V) (cap: w64) (γ: chan_names) : iProp Σ :=
-     "Hchanrepfrag" ∷ chan_rep_frag γ.(state_name) s ∗ "%Hbuffvalid" ∷ ⌜ chan_rep.buffer_valid s cap ⌝.
 
-(* Helper lemmas *)
-  
-  (* Persistence *)
-  Global Instance is_channel_pers ch cap γ : Persistent (is_channel ch cap γ).
-  Proof.
-  Admitted.
-  
-  (* Timelessness *)
-  Global Instance own_channel_timeless ch s cap γ : Timeless (own_channel ch s cap γ).
-  Proof.
+(** ** Channel Ownership Predicate *)
+
+(** Represents ownership of a channel with its logical state *)
+Definition own_channel (ch: loc) (cap: Z) (s: chan_rep.t V) (γ: chan_names) : iProp Σ :=
+  "Hchanrepfrag" ∷ chan_rep_half γ.(state_name) s ∗
+  "%Hcapvalid" ∷ ⌜chan_cap_valid s cap⌝.
+
+Lemma own_channel_agree ch cap cap' s s' γ :
+   own_channel ch cap s γ -∗ own_channel ch cap' s' γ -∗ ⌜s = s'⌝.
+Proof. 
+  iIntros "H1 H2". iNamed "H1". iDestruct "H2" as "[Hoc %Hcap]".
+  iDestruct (ghost_var_agree with "[$Hchanrepfrag] [$Hoc]") as "%Hag".
+  unfold chan_cap_valid in *.
+  by iApply (ghost_var_agree with "Hchanrepfrag Hoc"). 
+Qed.
+
+Lemma own_channel_halves_update ch cap s s' s'' γ :
+  own_channel ch cap s γ -∗ own_channel ch cap s' γ ==∗
+  own_channel ch cap s'' γ ∗ own_channel ch cap s'' γ.
+Proof.
   Admitted.
 
-  Lemma is_channel_not_null ch γ cap :
-    is_channel ch γ cap -∗ ⌜ch ≠ null⌝.
-  Proof.
-  Admitted.
+(** Type alias for convenience: converts postcondition to predicate format *)
+Definition K (Φ : V → bool → iProp Σ) : (V * bool) → iProp Σ :=
+  λ '(v,b), Φ v b.
+
+(** Inner atomic update for receive completion (second phase of handshake) *)
+Definition rcv_au_inner ch (cap: Z) (γ: chan_names) (Φ : V → bool → iProp Σ) : iProp Σ :=
+   |={⊤,∅}=>
+    ▷∃ s, "Hocinner" ∷ own_channel ch cap s γ ∗
+     "Hcontinner" ∷
+    (match s with
+    (* Case: Sender has committed, complete the exchange *)
+    | chan_rep.SndCommit v => own_channel ch cap chan_rep.Idle γ ={∅,⊤}=∗ Φ v true
+    (* Case: Channel is closed with no messages *)
+    | chan_rep.Closed [] => own_channel ch cap s γ ={∅,⊤}=∗ Φ (default_val V) false
+    | _ => True
+    end).
+
+(** Slow path receive: may need to block and wait *)
+Definition rcv_au_slow ch (cap: Z) (γ: chan_names) (Φ : V → bool → iProp Σ) : iProp Σ :=
+   |={⊤,∅}=>
+    ▷∃ s, "Hoc" ∷ own_channel ch cap s γ ∗
+     "Hcont" ∷
+    (match s with
+    (* Case: Sender is waiting, can complete immediately *)
+    | chan_rep.SndPending v =>
+          own_channel ch cap chan_rep.RcvCommit γ ={∅,⊤}=∗ Φ v true
+    (* Case: Channel is idle, need to wait for sender *)
+    | chan_rep.Idle =>
+          own_channel ch cap (chan_rep.RcvPending) γ ={∅,⊤}=∗
+              rcv_au_inner ch cap γ Φ
+    (* Case: Channel is closed *)
+    | chan_rep.Closed [] => own_channel ch cap s γ ={∅,⊤}=∗ Φ (default_val V) false
+    (* Case: Closed but still have values to drain *)
+    | chan_rep.Closed (v::rest) => (own_channel ch cap (chan_rep.Closed rest) γ ={∅,⊤}=∗ Φ v true)
+    (* Case: Buffered channel with values in buffer *)
+    | chan_rep.Buffered (v::rest) => (own_channel ch cap (chan_rep.Buffered rest) γ ={∅,⊤}=∗ Φ v true)
+    | _ => True
+    end).
+
+(** Fast path receive: immediate completion when possible *)
+Definition rcv_au_fast ch (cap: Z) (γ: chan_names) (Φ : V → bool → iProp Σ) : iProp Σ :=
+   |={⊤,∅}=>
+    ▷∃ s, "Hoc" ∷ own_channel ch cap s γ ∗
+     "Hcont" ∷
+    (match s with
+    (* Case: Sender is waiting, can complete immediately *)
+    | chan_rep.SndPending v =>
+          own_channel ch cap chan_rep.RcvCommit γ ={∅,⊤}=∗ Φ v true
+    (* Case: Channel is closed *)
+    | chan_rep.Closed [] => own_channel ch cap s γ ={∅,⊤}=∗ Φ (default_val V) false
+    (* Case: Channel is closed but still has values to drain *)
+    | chan_rep.Closed (v::rest) => (own_channel ch cap (chan_rep.Closed rest) γ ={∅,⊤}=∗ Φ v true)
+    (* Case: Buffered channel with values *)
+    | chan_rep.Buffered (v::rest) => (own_channel ch cap (chan_rep.Buffered rest) γ ={∅,⊤}=∗ Φ v true)
+    | _ => True
+    end).
+
+(** Inner atomic update for send completion (second phase of handshake) *)
+Definition send_au_inner ch (cap: Z) (γ: chan_names) (Φ : iProp Σ) : iProp Σ :=
+   |={⊤,∅}=>
+    ▷∃ s, "Hocinner" ∷ own_channel ch cap s γ ∗
+     "Hcontinner" ∷
+    (match s with
+    (* Case: Receiver has committed, complete the exchange *)
+    | chan_rep.RcvCommit =>
+           own_channel ch cap chan_rep.Idle γ ={∅,⊤}=∗ Φ
+    (* Case: Channel is closed, operation fails *)
+    | chan_rep.Closed draining => False
+    | _ => True
+    end).
+
+(** Slow path send: may need to block and wait *)
+Definition send_au_slow ch (cap: Z) (v : V) (γ: chan_names) (Φ : iProp Σ) : iProp Σ :=
+   |={⊤,∅}=>
+    ▷∃ s, "Hoc" ∷ own_channel ch cap s γ ∗
+     "Hcont" ∷
+    (match s with
+    (* Case: Receiver is waiting, can complete immediately *)
+    | chan_rep.RcvPending =>
+        own_channel ch cap (chan_rep.SndCommit v) γ ={∅,⊤}=∗ Φ
+    (* Case: Channel is idle, need to wait for receiver *)
+    | chan_rep.Idle =>
+          own_channel ch cap (chan_rep.SndPending v) γ ={∅,⊤}=∗
+              send_au_inner ch cap γ Φ
+    (* Case: Channel is closed, client must rule this out *)
+    | chan_rep.Closed draining => False
+    (* Case: Buffered channel with space available *)
+    | chan_rep.Buffered buff => 
+        if (length buff <? cap) 
+        then (own_channel ch cap (chan_rep.SndCommit v) γ ={∅,⊤}=∗ Φ)
+        else True
+    | _ => True
+    end).
+
+(** Fast path send: immediate completion when possible *)
+Definition send_au_fast ch (cap: Z) (v : V) (γ: chan_names) (Φ : iProp Σ) : iProp Σ :=
+   |={⊤,∅}=>
+    ▷∃ s, "Hoc" ∷ own_channel ch cap s γ ∗
+     "Hcont" ∷
+    (match s with
+    (* Case: Receiver is waiting, can complete immediately *)
+    | chan_rep.RcvPending =>
+        own_channel ch cap (chan_rep.SndCommit v) γ ={∅,⊤}=∗ Φ
+    (* Case: Channel is closed, client must rule this out *)
+    | chan_rep.Closed draining => False
+    (* Case: Buffered channel with space available *)
+    | chan_rep.Buffered buff => 
+        if (length buff <? cap) 
+        then (own_channel ch cap (chan_rep.SndCommit v) γ ={∅,⊤}=∗ Φ)
+        else True
+    | _ => True
+    end).
+
+(** Maps physical states to their logical representations with ghost state.
+    This is the key invariant that connects the physical implementation
+    to the logical specifications. *)
+Definition chan_logical (ch: loc) (cap: Z) (γ : chan_names) (s : chan_phys_state V): iProp Σ :=
+  match s with
+  | Idle =>
+       ∃ (Φr: V → bool → iProp Σ),
+           "Hoffer" ∷ offer_bundle_empty γ ∗
+           "Hpred" ∷ saved_pred_own γ.(offer_parked_pred_name) (DfracOwn 1) (K Φr) ∗
+            own_channel ch cap chan_rep.Idle γ
+
+  | SndWait v =>
+       ∃ (P: iProp Σ) (Φ: iProp Σ) (Φr: V → bool → iProp Σ),
+          "Hoffer" ∷ offer_bundle_half γ (Some (Snd v)) P Φ ∗
+          "HP" ∷ P ∗
+          "Hpred" ∷ saved_pred_own γ.(offer_parked_pred_name) (DfracOwn 1) (K Φr) ∗
+          "Hau" ∷ (P -∗ send_au_slow ch cap v γ Φ) ∗
+           own_channel ch cap chan_rep.Idle γ
+
+  | RcvWait =>
+       ∃ (P: iProp Σ) (Φr: V → bool → iProp Σ),
+         "Hoffer" ∷ offer_bundle_half γ (Some Rcv) P True ∗
+         "HP" ∷ P ∗
+         "Hpred" ∷ saved_pred_own γ.(offer_parked_pred_name) (DfracOwn (1/2)) (K Φr) ∗
+         "Hau" ∷ (P -∗ rcv_au_slow ch cap γ Φr) ∗
+         own_channel ch cap chan_rep.Idle γ
+
+  | SndDone v =>
+       ∃ (P: iProp Σ) (Φr: V → bool → iProp Σ),
+       "Hpred" ∷ saved_pred_own γ.(offer_parked_pred_name) (DfracOwn (1/2)) (K Φr) ∗
+       "Hoffer" ∷ offer_bundle_half γ (Some Rcv) P True ∗
+       "Hau" ∷ rcv_au_inner ch cap γ Φr ∗
+       own_channel ch cap (chan_rep.SndCommit v) γ
+
+  | RcvDone v =>
+       ∃ (P: iProp Σ) (Φ: iProp Σ) (Φr: V → bool → iProp Σ),
+         "Hoffer" ∷ offer_bundle_half γ (Some (Snd v)) P Φ ∗
+         "Hpred" ∷ saved_pred_own γ.(offer_parked_pred_name) (DfracOwn 1) (K Φr) ∗
+         "Hau" ∷ send_au_inner ch cap γ Φ ∗
+       own_channel ch cap chan_rep.RcvCommit γ
+
+  | Closed [] =>
+          own_channel ch cap (chan_rep.Closed []) γ ∗ 
+           "Hoffer" ∷ if (cap =? 0) then offer_bundle_empty γ else True
+
+  | Closed draining =>
+          own_channel ch cap (chan_rep.Closed draining) γ
+
+  | Buffered buff =>
+          own_channel ch cap (chan_rep.Buffered buff) γ
+  end.
+
+(** The main invariant protected by the channel's mutex.
+    This connects the physical heap state with the logical state. *)
+Definition chan_inv_inner (ch: loc) (cap: Z) (γ: chan_names) : iProp Σ :=
+  ∃ (s : chan_phys_state V),
+    "phys" ∷ chan_phys ch s ∗
+    "offer" ∷ chan_logical ch cap γ s.
+
+(** The public predicate that clients use to interact with channels.
+    This is persistent and provides access to the channel's capabilities. *)
+Definition is_channel (ch: loc) (cap: Z) (γ: chan_names) : iProp Σ :=
+  ∃ (mu_loc: loc),
+    "#cap" ∷ ch ↦s[(channel.Channel.ty t) :: "cap"]□ (W64 cap) ∗
+    "#mu" ∷ ch ↦s[(channel.Channel.ty t) :: "lock"]□ mu_loc ∗
+    "#lock" ∷ is_Mutex mu_loc (chan_inv_inner ch cap γ).
+
+Global Instance is_channel_pers ch cap γ : Persistent (is_channel cap ch γ).
+Proof.
+Admitted.
+
+Global Instance own_channel_timeless ch cap s γ : Timeless (own_channel ch cap s γ).
+Proof.
+Admitted.
+
+Lemma is_channel_not_null ch cap γ:
+  is_channel ch cap γ -∗ ⌜ch ≠ null⌝.
+Proof.
+Admitted.
+
 End base.
-
-
-

--- a/new/proof/github_com/goose_lang/goose/model/channel/logatom/chan_au_recv.v
+++ b/new/proof/github_com/goose_lang/goose/model/channel/logatom/chan_au_recv.v
@@ -13,63 +13,772 @@ Context `{!IntoVal V}.
 Context `{!IntoValTyped V t}.
 Context `{!globalsGS Σ} {go_ctx : GoContext}.
 
-Definition chan_receive_atomic_update ch (cap: w64) (γ: chan_names) (Φsuccess : V → bool → iProp Σ) : iProp Σ :=
-   "#Hperschan" ∷ is_channel ch cap γ ∗
-   "Hlogatom" ∷ |={⊤,∅}=>
-    ▷∃ s,  "Hoc" ∷  own_channel ch s cap γ ∗
-    (match s with
-    (* Case: Buffered channel with at least one value. *)
-    | chan_rep.Buffered (fr :: rest) =>
-        own_channel ch (chan_rep.Buffered rest) cap γ ={∅,⊤}=∗ Φsuccess fr true
-    (* Case: Buffered channel with no values, N/A for success. *)
-    | chan_rep.Buffered [] => True
-    (* Case: Unbuffered channel with a waiting sender. *)
-    | chan_rep.SndWait v =>
-          own_channel ch chan_rep.RcvDone 0 γ ={∅,⊤}=∗ Φsuccess v true
-    (* Case: Unbuffered channel with no waiting sender. This requires a two-phase handshake. *)
-    | chan_rep.Idle =>
-          own_channel ch chan_rep.RcvWait 0 γ ={∅,⊤}=∗
-               |={⊤,∅}=> ▷∃ s', own_channel ch s' 0 γ ∗
-                 (match s' with
-                    | chan_rep.SndDone v =>
-                        own_channel ch chan_rep.Idle 0 γ ={∅,⊤}=∗ Φsuccess v true
-                  | chan_rep.Closed [] =>
-                  own_channel ch (chan_rep.Closed []) 0 γ ={∅,⊤}=∗ Φsuccess (default_val V) false
-                    (* Other states won't happen on success through this path but client shouldn't have to prove that *)
-                    | _ => True
-                 end)
-    (* Case: Channel is closed. *)
-    | chan_rep.Closed draining =>
-         (match draining with
-          | [] =>
-              (own_channel ch s cap γ ={∅,⊤}=∗ Φsuccess (default_val V) false)
-          | v :: rest =>
-              (own_channel ch (chan_rep.Closed rest) cap γ ={∅,⊤}=∗ Φsuccess v true)
-          end)
-    (* At the point when we succeed other states aren't involved *)
-    | _ => True
-    end).
+Lemma wp_TryReceive (ch: loc) (cap: Z)  (γ: chan_names) (P: iProp Σ) :
+  ∀ Φ ,
+  is_pkg_init channel ∗ is_channel ch cap γ -∗
+  (* P is here to support helping within a select statement. This is because the internal choice of
+  which case's atomic update cannot be made prematurely if an offer isn't accepted, so we need to
+  store the whole collective conjunct of atomic updates in the channel mutex invariant for the
+  channel we are making an offer on. *)
+  P ∗ (P -∗ (rcv_au_slow ch cap γ (λ v ok, Φ (#true, #v, #ok)%V))) -∗
+  (* Keep resources for attempts at this and/or other ops *)
+  (P -∗ (Φ (#false, #(default_val V), #true)%V)) -∗
+  WP ch @ (ptrT.id channel.Channel.id) @ "TryReceive" #t #true {{ Φ }}.
+Proof.
+  intros. iIntros "[#Hinit Hunb]". iIntros "[HP HPau]". iIntros "HPfail".
+  try (iModIntro (□ _)%I).
+  let x := ident:(Φ) in
+  try clear x.
+  destruct_pkg_init "Hinit".
+  try (first [ wp_func_call | wp_method_call ]; wp_call; [idtac]).
+  iNamed "Hunb".
+  wp_auto_lc 10.
+   wp_apply (wp_Mutex__Lock with "[$lock]") as "[Hlock Hchan]".
+  iNamed "Hchan".
+  (* Case analysis on channel state *)
+  destruct s.
+  { (* Buffered channel *)
+    iNamed "phys". iNamed "offer". wp_auto. unfold chan_cap_valid in Hcapvalid.
+    wp_if_destruct.
+    {
+       destruct buff as [|v rest].
+       {
+        iDestruct (own_slice_len with "slice") as "[%Hl %Hcap2]".
+        rewrite length_nil in Hl.
+        replace (sint.Z slice_val.(slice.len_f))with (0) in * by word.
+        word.
+       }
+       iApply "HPau" in "HP".
+        iAssert (own_channel ch cap (chan_rep.Buffered (v :: rest)) γ)%I
+          with "[Hchanrepfrag]" as "Hown".
+        { iFrame. iPureIntro. unfold chan_cap_valid. done. }
+        iMod (lc_fupd_elim_later with "[$] HP") as "HP".
+        unfold rcv_au_fast.
+        iApply fupd_wp.
+        iMod "HP".
+        iMod (lc_fupd_elim_later with "[$] HP") as "HP".
+        iNamed "HP".
+        iDestruct (own_channel_agree with "Hown Hoc") as %Heq.
+        subst s.
+        iMod ((own_channel_halves_update _ _ _ _ (chan_rep.Buffered rest)) with "Hown Hoc")
+          as "[Hown1 Hown2]".
+        iMod ("Hcont" with "Hown1") as "Hcont".
+        iModIntro.
+        have Hpos : 0 ≤ sint.Z (W64 0) by word.
+        have Hlookup0 : (v :: rest) !! 0%nat = Some v by done.
+        iDestruct (own_slice_elem_acc with "slice") as "[Hcell Hclose]".
+        { exact Hpos. }
+        { done. }
+        iSpecialize ("Hclose" $! v with "Hcell").  (* gives back [slice_val ↦* (v::draining)] *)
+        iDestruct (own_slice_len with "Hclose") as %(Hlen_eq & Hnonneg).
+        have Hlt : 0 ≤ sint.Z (W64 0) < sint.Z slice_val.(slice.len_f).
+        { move: Hlen_eq; simpl.  (* length (v::draining) = S (length draining) *)
+          (* sint.nat len = S _  ⇒  sint.Z len > 0 *)
+          word. }
+        wp_auto.
+        wp_apply ((wp_load_slice_elem slice_val 0
+                     ( <[sint.nat (W64 0):=v]> (v :: rest)))
+                   with "[Hclose]"). all: try word.
+        { iFrame. done. }
+        iIntros "Hsl". wp_auto.
+        iDestruct (own_slice_cap_wf with "slice_cap") as %Hwf.
+        wp_apply (wp_slice_slice_pure).
+        { iPureIntro. word. }
+        wp_apply (wp_Mutex__Unlock
+                    with "[$lock state slice_cap Hsl buffer Hown2  $Hlock]").
+        { iModIntro. unfold chan_inv_inner. iExists (Buffered rest). iFrame.
 
-Lemma wp_Receive (ch: loc) (cap: w64) (γ: chan_names) :
+          have -> : sint.nat (W64 0) = 0%nat by word.
+          (* <[0:=v]>(<[0:=v]> [v]) = [v] *)
+          simpl.
+          iDestruct (own_slice_split_all (W64 1) with "Hsl")
+            as "[Hhd Htail]"; first word. simpl.
+          iFrame.
+            iDestruct (own_slice_len with "Hhd") as %[Hlent _].
+          iDestruct (own_slice_cap_wf with "slice_cap") as %Hlen_le_cap.
+          iDestruct (own_slice_cap_slice_f (slice_val) (W64 1) (DfracOwn 1)) as "H".
+          { word. }
+          iApply "H" in "slice_cap". iFrame.
+          }
+          done.
+        }
+          {
+            iDestruct (own_slice_len with "slice") as "[%Hl %Hcap2]".
+      assert ( sint.Z slice_val.(slice.len_f) = sint.Z (W64 0)).
+      {
+        destruct (sint.Z slice_val.(slice.len_f)). all: try done.
+      }
+      assert (buff = []).
+      { destruct buff. { done. } { rewrite H in Hl. naive_solver. } }
+      subst buff. wp_auto.
+
+      wp_apply (wp_Mutex__Unlock
+                  with "[$lock state buffer slice slice_cap Hchanrepfrag $Hlock]").
+      { iModIntro. iFrame. unfold chan_inv_inner. iFrame.  iExists (Buffered []).
+        iFrame. iPureIntro. done. }
+      iApply "HPfail" in "HP".
+      done.
+      }
+  }
+  {
+    iNamed "phys". wp_auto_lc 5.
+     iNamed "offer".
+    iDestruct ((offer_idle_to_recv γ P True) with "Hoffer") as ">[offer1 offer2]".
+     iMod ((saved_prop.saved_pred_update (K (λ (v0 : V) (ok : bool), Φ (# true, # v0, # ok)%V)
+)) with "Hpred") as "[Hpred1 Hpred2]".
+     wp_apply (wp_Mutex__Unlock
+                with "[$lock state v slice slice_cap buffer  offer1 Hpred1 Hchanrepfrag HPau HP  $Hlock]").
+    { iModIntro. unfold chan_inv_inner. iExists (RcvWait). iFrame. iPureIntro. done.
+    }
+   wp_apply (wp_Mutex__Lock with "[$lock]") as "[Hlock Hchan]".
+    iNamed "Hchan".
+   iNamed "phys". iNamed "offer".
+    destruct s.
+    {
+        iNamed "phys". wp_auto_lc 5.
+        unfold chan_cap_valid in Hcapvalid. subst cap.
+    iNamed "offer".
+    unfold chan_cap_valid in Hcapvalid. done.
+      }
+      {
+        iNamed "phys". wp_auto_lc 5.
+    iNamed "offer".
+    unfold offer_bundle_empty.
+    iExFalso.
+iApply (saved_offer_half_full_invalid with "offer2 Hoffer").
+
+    }
+    {
+     iNamed "phys". wp_auto_lc 5.
+    iNamed "offer".
+    iExFalso.
+iDestruct (offer_bundle_agree with "[$offer2 $Hoffer]") as "[%Heq _]".
+discriminate Heq.
+
+    }
+    {
+    unfold chan_phys. iNamed "phys". wp_auto_lc 5.
+     iNamed "offer".
+    iDestruct ((offer_bundle_lc_agree γ (Some Rcv)  P True (Some Rcv)  P0 True
+) with " [$] [$] [$offer2] [$Hoffer]") as ">(%Heq & Hpeq & H & H1)".
+       iMod ((saved_prop.saved_pred_update_halves (K Φr0)
+) with "Hpred2 Hpred") as "[Hpred1 Hpred2]".
+      iCombine "Hpred1 Hpred2" as "Hp".
+     wp_apply (wp_Mutex__Unlock
+                with "[$lock state v slice slice_cap buffer Hchanrepfrag   Hp  H1   $Hlock]").
+    { iModIntro. unfold chan_inv_inner. iExists (Idle). iFrame.
+      iExists Φr0. iFrame. unfold  saved_prop.saved_pred_own . rewrite dfrac_op_own Qp.half_half.
+      iFrame.
+      done.
+    }
+    iRewrite -"Hpeq" in "HP".
+    iApply "HPfail" in "HP".
+    done.
+    }
+    {
+       iNamed "phys". wp_auto_lc 5.
+    iNamed "offer".
+
+    unfold rcv_au_inner.
+      iApply fupd_wp.
+     iMod "Hau".
+    iMod (lc_fupd_elim_later with "[$] Hau") as "HP".
+    iNamed "HP".
+        iAssert (own_channel ch cap (chan_rep.SndCommit v0) γ)%I
+          with "[Hchanrepfrag]" as "Hown".
+        { iFrame. iPureIntro. unfold chan_cap_valid. done. }
+    iDestruct (own_channel_agree with "[$Hocinner] [$Hown]") as "%Hseq". subst s.
+        iDestruct (own_channel_halves_update ch cap _ _
+                    (chan_rep.Idle)
+                  with "[$Hocinner] [$Hown]") as ">[Hgv1 Hgv2]".
+    iMod ("Hcontinner" with "Hgv1") as "Hcont".
+iModIntro.
+iDestruct (saved_prop.saved_pred_agree γ.(offer_parked_pred_name)
+           (DfracOwn (1/2)) (DfracOwn (1/2))
+           (K (λ (v1 : V) (ok : bool), Φ (# true, # v1, # ok)%V))
+           (K Φr0)
+           (v0, true)
+           with "[$Hpred2] [$Hpred]") as "#Hagree".
+  iCombine "Hpred2 Hpred" as "offer".
+   rewrite dfrac_op_own Qp.half_half.
+    iDestruct ((offer_bundle_lc_agree γ (Some Rcv)  P True (Some Rcv)
+                  P0 True
+) with " [$] [$] [$offer2] [$Hoffer]") as ">(%Heq & Hpeq & H & H1)".
+
+ wp_apply (wp_Mutex__Unlock
+                with "[$lock state v slice slice_cap buffer H1   Hgv2 offer   $Hlock]").
+    { iModIntro. unfold chan_inv_inner. iExists (Idle). iFrame.
+}
+unfold K.
+iRewrite -"Hagree" in "Hcont". done.
+}
+ {
+     iNamed "phys". wp_auto_lc 5.
+    iNamed "offer".
+    iExFalso.
+iDestruct (offer_bundle_agree with "[$offer2 $Hoffer]") as "[%Heq _]".
+discriminate Heq.
+
+    }
+     {
+     iNamed "phys". unfold chan_phys.
+     destruct draining.
+     {
+        iNamed "phys". wp_auto_lc 5.
+
+    iNamed "offer". unfold chan_logical. iDestruct "offer" as "[Ho Hoffer]".
+    iNamed "Hoffer". unfold chan_cap_valid in Hcapvalid. subst cap. simpl.
+    iExFalso.
+iDestruct (offer_bundle_agree with "[$offer2 $Hoffer]") as "[%Heq _]".
+discriminate Heq.
+}
+ {
+     iNamed "phys". wp_auto_lc 5.
+    iNamed "offer".
+    iExFalso.
+    unfold chan_cap_valid in *. subst cap. done.
+    }
+    }
+    }
+  { (* Idle unbuffered channel  *)
+    iNamed "phys". wp_auto_lc 2.
+    iNamed "offer". iDestruct "HP" as "HP0". iNamed "offer".
+    iApply "Hau" in "HP".
+    unfold send_au_slow.
+     iApply fupd_wp. iMod "HP".
+    iMod (lc_fupd_elim_later with "[$] HP") as "HP". iNamed "HP".
+    iDestruct "Hoc" as "[H1 H2]".
+    iDestruct (chan_rep_agree with "[$H1] [$Hchanrepfrag]") as "%Hseq". subst s.
+        iAssert (own_channel ch cap (chan_rep.Idle) γ)%I
+          with "[Hchanrepfrag]" as "Hown".
+    { iFrame. iPureIntro. done. }
+        iAssert (own_channel ch cap (chan_rep.Idle) γ)%I
+          with "[H1]" as "Hown1".
+    { iFrame. iPureIntro. done. }
+    iDestruct (own_channel_halves_update ch cap _ _  (chan_rep.SndPending v)
+              with "[$Hown] [$Hown1]") as ">[Hgv1 Hgv2]".
+    iMod ("Hcont" with "Hgv2") as "Hcont1". iModIntro.
+    iApply "HPau" in "HP0".
+     iApply fupd_wp.
+    iMod (lc_fupd_elim_later with "[$] HP0") as "HP0".
+    unfold rcv_au_fast.
+    iMod "HP0".
+    iMod (lc_fupd_elim_later with "[$] HP0") as "HP".
+    iNamed "HP".
+    iDestruct (own_channel_agree with "[$Hgv1] [$Hoc]") as "%Hseq". subst s.
+    iDestruct (own_channel_halves_update _ _ _ _ (chan_rep.RcvCommit)
+              with "[$Hgv1] [$Hoc]") as ">[Hgv1 Hgv2]".
+    iMod ("Hcont" with "Hgv2") as "Hcont". iModIntro.
+    wp_apply (wp_Mutex__Unlock
+                with "[$lock state v slice slice_cap buffer Hgv1 H2 Hpred Hoffer Hcont1 $Hlock]").
+    { iModIntro. unfold chan_inv_inner.  iExists (RcvDone v). iFrame. iNamed "Hgv1". iFrame.
+      }
+      done.
+    }
+     {
+        iNamed "phys". wp_auto_lc 2.
+
+     wp_apply (wp_Mutex__Unlock
+                with "[$lock state v slice slice_cap buffer offer  $Hlock]").
+    { iModIntro. unfold chan_inv_inner. iExists RcvWait. iFrame. }
+    iApply "HPfail" in "HP". done.
+  }
+   {
+        iNamed "phys". wp_auto_lc 2.
+
+     wp_apply (wp_Mutex__Unlock
+                with "[$lock state v slice slice_cap buffer offer  $Hlock]").
+    { iModIntro. unfold chan_inv_inner. iExists (SndDone v). iFrame. }
+    iApply "HPfail" in "HP". done.
+  }
+   {
+        iNamed "phys". wp_auto_lc 2.
+
+     wp_apply (wp_Mutex__Unlock
+                with "[$lock state v slice slice_cap buffer offer  $Hlock]").
+    { iModIntro. unfold chan_inv_inner. iExists (RcvDone v). iFrame. }
+    iApply "HPfail" in "HP". done.
+  }
+
+
+  {   iNamed "phys".
+   destruct draining.
+   { iNamed "offer". iNamed "phys".
+      wp_auto_lc 2.
+    iApply "HPau" in "HP".
+     iApply fupd_wp.
+    iMod (lc_fupd_elim_later with "[$] HP") as "HP".
+    unfold rcv_au_fast.
+    iMod "HP".
+    iMod (lc_fupd_elim_later with "[$] HP") as "HP".
+    iNamed "HP". unfold chan_logical. iDestruct "offer" as "[offer H]".
+    iDestruct (own_channel_agree with "[$offer] [$Hoc]") as "%Hseq". subst s.
+
+    iMod ("Hcont" with "Hoc") as "Hcont". iModIntro.
+    wp_if_destruct.
+    {
+        iDestruct (own_slice_len with "slice") as "[%H1 %H2]".
+        simpl in H1.
+        word.
+    } wp_auto.
+
+    wp_apply (wp_Mutex__Unlock
+                with "[$lock state  slice slice_cap buffer offer H $Hlock]").
+    { iModIntro. unfold chan_inv_inner.  iExists (Closed []). iFrame.
+      }
+      done.
+  }
+  {
+     iNamed "phys". iNamed "offer". wp_auto. unfold chan_cap_valid in Hcapvalid.
+    wp_if_destruct.
+    {
+
+       iApply "HPau" in "HP".
+        iAssert (own_channel ch cap (chan_rep.Closed (v :: draining)) γ)%I
+          with "[Hchanrepfrag]" as "Hown".
+        { iFrame. iPureIntro. done. }
+        iMod (lc_fupd_elim_later with "[$] HP") as "HP".
+        unfold rcv_au_fast.
+        iApply fupd_wp.
+        iMod "HP".
+        iMod (lc_fupd_elim_later with "[$] HP") as "HP".
+        iNamed "HP".
+        iDestruct (own_channel_agree with "Hown Hoc") as %Heq.
+        subst s.
+        iMod ((own_channel_halves_update _ _ _ _ (chan_rep.Closed draining)) with "Hown Hoc")
+          as "[Hown1 Hown2]".
+        iMod ("Hcont" with "Hown1") as "Hcont".
+        iModIntro.
+        have Hpos : 0 ≤ sint.Z (W64 0) by word.
+        have Hlookup0 : (v :: draining) !! 0%nat = Some v by done.
+        iDestruct (own_slice_elem_acc with "slice") as "[Hcell Hclose]".
+        { exact Hpos. }
+        { done. }
+        iSpecialize ("Hclose" $! v with "Hcell").  (* gives back [slice_val ↦* (v::draining)] *)
+        iDestruct (own_slice_len with "Hclose") as %(Hlen_eq & Hnonneg).
+        have Hlt : 0 ≤ sint.Z (W64 0) < sint.Z slice_val.(slice.len_f).
+        { move: Hlen_eq; simpl.  (* length (v::draining) = S (length draining) *)
+          (* sint.nat len = S _  ⇒  sint.Z len > 0 *)
+          word. }
+        wp_auto.
+        wp_apply ((wp_load_slice_elem slice_val 0
+                     ( <[sint.nat (W64 0):=v]> (v :: draining)))
+                   with "[Hclose]"). all: try word.
+        { iFrame. done. }
+        iIntros "Hsl". wp_auto.
+        iDestruct (own_slice_cap_wf with "slice_cap") as %Hwf.
+        wp_apply (wp_slice_slice_pure).
+        { iPureIntro. word. }
+        wp_apply (wp_Mutex__Unlock
+                    with "[$lock state slice_cap Hsl buffer Hown2  $Hlock]").
+        { iModIntro. unfold chan_inv_inner. iExists (Closed draining). iFrame.
+
+          have -> : sint.nat (W64 0) = 0%nat by word.
+          (* <[0:=v]>(<[0:=v]> [v]) = [v] *)
+          simpl.
+          iDestruct (own_slice_split_all (W64 1) with "Hsl")
+            as "[Hhd Htail]"; first word. simpl.
+          iFrame.
+            iDestruct (own_slice_len with "Hhd") as %[Hlent _].
+          iDestruct (own_slice_cap_wf with "slice_cap") as %Hlen_le_cap.
+          iDestruct (own_slice_cap_slice_f (slice_val) (W64 1) (DfracOwn 1)) as "H".
+          { word. }
+          iApply "H" in "slice_cap". iFrame.
+            destruct draining.
+          {
+            iFrame. destruct cap. { done.  } { done. } done.
+            }
+            {
+              iFrame.
+            }
+
+          }
+          { done.
+
+          }
+
+          }
+          {
+                iDestruct (own_slice_len with "slice") as "[%Hl %Hcap2]".
+      assert ( sint.Z slice_val.(slice.len_f) = sint.Z (W64 0)).
+      {
+        destruct (sint.Z slice_val.(slice.len_f)). all: try done.
+      }
+      replace (sint.nat slice_val.(slice.len_f)) with 0%nat in *.
+      { done.  }
+      word.
+
+      }
+
+  }
+}
+Qed.
+
+Lemma wp_Receive (ch: loc) (cap: Z) (γ: chan_names) :
   ∀ Φ,
   is_pkg_init channel ∗ is_channel ch cap γ -∗
-  ▷(chan_receive_atomic_update ch cap γ (λ v ok, Φ (#v, #ok)%V)) -∗
+  (rcv_au_slow ch cap γ (λ v ok, Φ (#v, #ok)%V)) -∗
   WP ch @ (ptrT.id channel.Channel.id) @ "Receive" #t #() {{ Φ }}.
 Proof.
-Admitted.
+    intros. iIntros "[#Hinit #Hic]". iIntros "Hau".
+  try (iModIntro (□ _)%I).
+  iDestruct (is_channel_not_null with "[$Hic]") as "%Hnn".
+    destruct_pkg_init "Hinit".
+  try (first [ wp_func_call | wp_method_call ]; wp_call; [idtac]).
+  wp_auto.
 
-Lemma wp_TryReceive (ch: loc) (cap: w64) (γ: chan_names) (P: iProp Σ) :
-  ∀ Φ (b: bool),
+  wp_if_destruct; first done.
+  wp_for. iNamed "Hau".
+  wp_apply ((wp_TryReceive ch cap γ    (rcv_au_slow ch cap γ (λ (v : V) (ok : bool), Φ (v ::= # ok)%V) ∗ c_ptr ↦ ch ∗
+           ok_ptr ↦ into_val_typed_bool.(default_val bool) ∗ v_ptr ↦ IntoValTyped0.(default_val V) ∗
+           success_ptr ↦ into_val_typed_bool.(default_val bool))%I
+)
+  with "[][Hau c ok v success]").
+  { iFrame "#". }
+  { iFrame.
+    iIntros "(Hau & c & ok & v & succ)".
+    unfold rcv_au_slow. iMod "Hau".
+    iModIntro. iModIntro. iNamed "Hau". iFrame.
+    destruct s. all: try done.
+    {
+      destruct buff;first done.
+      iIntros "H". iMod ("Hcont" with "H") as "H".
+      iModIntro. wp_auto. wp_for_post.
+      iFrame.
+    }
+    {
+      iIntros "H". iMod ("Hcont" with "H") as "H".
+      iModIntro. unfold rcv_au_inner.  iMod "H". iModIntro. iModIntro.
+      iNamed "H".
+      iFrame.
+      destruct s. all: try done.
+      {
+        iIntros "Hcontineer".
+       iMod ("Hcontinner" with "Hcontineer") as "H". iModIntro. wp_auto.
+       wp_for_post. done.
+      }
+      {
+        destruct draining. all: try done.
+         iIntros "Hcontineer".
+       iMod ("Hcontinner" with "Hcontineer") as "H". iModIntro. wp_auto.
+       wp_for_post. done.
+
+      }
+      }
+      {
+         iIntros "Hcontineer".
+       iMod ("Hcont" with "Hcontineer") as "H". iModIntro. wp_auto.
+       wp_for_post. done.
+
+      }
+       {
+        destruct draining. all: try done.
+        {
+         iIntros "Hcontineer".
+       iMod ("Hcont" with "Hcontineer") as "H". iModIntro. wp_auto.
+       wp_for_post. done.
+
+      }
+      {
+         iIntros "Hcontineer".
+       iMod ("Hcont" with "Hcontineer") as "H". iModIntro. wp_auto.
+       wp_for_post. done.
+
+      }
+      }}
+  iIntros "Hau". iDestruct "Hau" as "(Hau & c & ok & v & succ)". wp_auto.
+ wp_for_post.
+      iFrame.
+      Qed.
+
+Lemma wp_TryReceive_nb (ch: loc) (cap: Z)  (γ: chan_names) (P: iProp Σ) :
+  ∀ Φ ,
   is_pkg_init channel ∗ is_channel ch cap γ -∗
   (* P is here to support helping within a select statement. This is because the internal choice of 
   which case's atomic update cannot be made prematurely if an offer isn't accepted, so we need to 
   store the whole collective conjunct of atomic updates in the channel mutex invariant for the 
   channel we are making an offer on. *)
-  P ∗ (P -∗ ▷(chan_receive_atomic_update ch cap γ (λ v ok, Φ (#true, #v, #ok)%V))) -∗
+  P ∗ (P -∗ (rcv_au_fast ch cap γ (λ v ok, Φ (#true, #v, #ok)%V))) -∗
   (* Keep resources for attempts at this and/or other ops *)
   (P -∗ (Φ (#false, #(default_val V), #true)%V)) -∗ 
-  WP ch @ (ptrT.id channel.Channel.id) @ "TryReceive" #t #b {{ Φ }}.
+  WP ch @ (ptrT.id channel.Channel.id) @ "TryReceive" #t #false {{ Φ }}.
 Proof.
-Admitted.
+  intros. iIntros "[#Hinit Hunb]". iIntros "[HP HPau]". iIntros "HPfail".
+  try (iModIntro (□ _)%I).
+  let x := ident:(Φ) in
+  try clear x.
+  destruct_pkg_init "Hinit".
+  try (first [ wp_func_call | wp_method_call ]; wp_call; [idtac]).
+  iNamed "Hunb".
+  wp_auto_lc 10.
+   wp_apply (wp_Mutex__Lock with "[$lock]") as "[Hlock Hchan]".
+  iNamed "Hchan".
 
+  (* Case analysis on channel state *)
+  destruct s.
+
+  { (* Buffered channel *)
+    iNamed "phys". iNamed "offer". wp_auto. unfold chan_cap_valid in Hcapvalid.
+    wp_if_destruct.
+    {
+       destruct buff as [|v rest].
+       {
+        iDestruct (own_slice_len with "slice") as "[%Hl %Hcap2]".
+        rewrite length_nil in Hl.
+        replace (sint.Z slice_val.(slice.len_f))with (0) in * by word.
+        word.
+       }
+       iApply "HPau" in "HP".
+        iAssert (own_channel ch cap (chan_rep.Buffered (v :: rest)) γ)%I
+          with "[Hchanrepfrag]" as "Hown".
+        { iFrame. iPureIntro. unfold chan_cap_valid. done. }
+        iMod (lc_fupd_elim_later with "[$] HP") as "HP".
+        unfold rcv_au_fast.
+        iApply fupd_wp.
+        iMod "HP".
+        iMod (lc_fupd_elim_later with "[$] HP") as "HP".
+        iNamed "HP".
+        iDestruct (own_channel_agree with "Hown Hoc") as %Heq.
+        subst s.
+        iMod ((own_channel_halves_update _ _ _ _ (chan_rep.Buffered rest)) with "Hown Hoc")
+          as "[Hown1 Hown2]".
+        iMod ("Hcont" with "Hown1") as "Hcont".
+        iModIntro.
+        have Hpos : 0 ≤ sint.Z (W64 0) by word.
+        have Hlookup0 : (v :: rest) !! 0%nat = Some v by done.
+        iDestruct (own_slice_elem_acc with "slice") as "[Hcell Hclose]".
+        { exact Hpos. }
+        { done. }
+        iSpecialize ("Hclose" $! v with "Hcell").  (* gives back [slice_val ↦* (v::draining)] *)
+        iDestruct (own_slice_len with "Hclose") as %(Hlen_eq & Hnonneg).
+        have Hlt : 0 ≤ sint.Z (W64 0) < sint.Z slice_val.(slice.len_f).
+        { move: Hlen_eq; simpl.  (* length (v::draining) = S (length draining) *)
+          (* sint.nat len = S _  ⇒  sint.Z len > 0 *)
+          word. }
+        wp_auto.
+        wp_apply ((wp_load_slice_elem slice_val 0
+                     ( <[sint.nat (W64 0):=v]> (v :: rest)))
+                   with "[Hclose]"). all: try word.
+        { iFrame. done. }
+        iIntros "Hsl". wp_auto.
+        iDestruct (own_slice_cap_wf with "slice_cap") as %Hwf.
+        wp_apply (wp_slice_slice_pure).
+        { iPureIntro. word. }
+        wp_apply (wp_Mutex__Unlock
+                    with "[$lock state slice_cap Hsl buffer Hown2  $Hlock]").
+        { iModIntro. unfold chan_inv_inner. iExists (Buffered rest). iFrame.
+
+          have -> : sint.nat (W64 0) = 0%nat by word.
+          (* <[0:=v]>(<[0:=v]> [v]) = [v] *)
+          simpl.
+          iDestruct (own_slice_split_all (W64 1) with "Hsl")
+            as "[Hhd Htail]"; first word. simpl.
+          iFrame.
+            iDestruct (own_slice_len with "Hhd") as %[Hlent _].
+          iDestruct (own_slice_cap_wf with "slice_cap") as %Hlen_le_cap.
+          iDestruct (own_slice_cap_slice_f (slice_val) (W64 1) (DfracOwn 1)) as "H".
+          { word. }
+          iApply "H" in "slice_cap". iFrame.
+          }
+          done.
+        }
+          {
+            iDestruct (own_slice_len with "slice") as "[%Hl %Hcap2]".
+      assert ( sint.Z slice_val.(slice.len_f) = sint.Z (W64 0)).
+      {
+        destruct (sint.Z slice_val.(slice.len_f)). all: try done.
+      }
+      assert (buff = []).
+      { destruct buff. { done. } { rewrite H in Hl. naive_solver. } }
+      subst buff. wp_auto.
+      wp_apply (wp_Mutex__Unlock
+                  with "[$lock state buffer slice slice_cap Hchanrepfrag $Hlock]").
+      { iModIntro. iFrame. unfold chan_inv_inner. iFrame.  iExists (Buffered []).
+        iFrame. iPureIntro. done. }
+      iApply "HPfail" in "HP".
+      done.
+      }
+  }
+    {
+        iNamed "phys". wp_auto_lc 2.
+
+     wp_apply (wp_Mutex__Unlock
+                with "[$lock state v slice slice_cap buffer offer  $Hlock]").
+    { iModIntro. unfold chan_inv_inner. iExists Idle. iFrame. }
+    iApply "HPfail" in "HP". done.
+  }
+  { (* Idle unbuffered channel  *)
+    iNamed "phys". wp_auto_lc 2.
+    iNamed "offer". iDestruct "HP" as "HP0". iNamed "offer".
+    iApply "Hau" in "HP".
+    unfold send_au_slow.
+     iApply fupd_wp. iMod "HP".
+    iMod (lc_fupd_elim_later with "[$] HP") as "HP". iNamed "HP".
+    iDestruct "Hoc" as "[H1 H2]".
+    iDestruct (chan_rep_agree with "[$H1] [$Hchanrepfrag]") as "%Hseq". subst s.
+        iAssert (own_channel ch cap (chan_rep.Idle) γ)%I
+          with "[Hchanrepfrag]" as "Hown".
+    { iFrame. iPureIntro. done. }
+        iAssert (own_channel ch cap (chan_rep.Idle) γ)%I
+          with "[H1]" as "Hown1".
+    { iFrame. iPureIntro. done. }
+    iDestruct (own_channel_halves_update ch cap _ _  (chan_rep.SndPending v)
+              with "[$Hown] [$Hown1]") as ">[Hgv1 Hgv2]".
+    iMod ("Hcont" with "Hgv2") as "Hcont1". iModIntro.
+    iApply "HPau" in "HP0".
+     iApply fupd_wp.
+    iMod (lc_fupd_elim_later with "[$] HP0") as "HP0".
+    unfold rcv_au_fast.
+    iMod "HP0".
+    iMod (lc_fupd_elim_later with "[$] HP0") as "HP".
+    iNamed "HP".
+    iDestruct (own_channel_agree with "[$Hgv1] [$Hoc]") as "%Hseq". subst s.
+    iDestruct (own_channel_halves_update _ _ _ _ (chan_rep.RcvCommit)
+              with "[$Hgv1] [$Hoc]") as ">[Hgv1 Hgv2]".
+    iMod ("Hcont" with "Hgv2") as "Hcont". iModIntro.
+
+    wp_apply (wp_Mutex__Unlock
+                with "[$lock state v slice slice_cap buffer Hgv1 H2 Hpred Hoffer Hcont1 $Hlock]").
+    { iModIntro. unfold chan_inv_inner.  iExists (RcvDone v). iFrame. iNamed "Hgv1". iFrame.
+      }
+      done.
+    }
+     {
+        iNamed "phys". wp_auto_lc 2.
+
+     wp_apply (wp_Mutex__Unlock
+                with "[$lock state v slice slice_cap buffer offer  $Hlock]").
+    { iModIntro. unfold chan_inv_inner. iExists RcvWait. iFrame. }
+    iApply "HPfail" in "HP". done.
+  }
+   {
+        iNamed "phys". wp_auto_lc 2.
+
+     wp_apply (wp_Mutex__Unlock
+                with "[$lock state v slice slice_cap buffer offer  $Hlock]").
+    { iModIntro. unfold chan_inv_inner. iExists (SndDone v). iFrame. }
+    iApply "HPfail" in "HP". done.
+  }
+   {
+        iNamed "phys". wp_auto_lc 2.
+
+     wp_apply (wp_Mutex__Unlock
+                with "[$lock state v slice slice_cap buffer offer  $Hlock]").
+    { iModIntro. unfold chan_inv_inner. iExists (RcvDone v). iFrame. }
+    iApply "HPfail" in "HP". done.
+  }
+
+  {   iNamed "phys".
+   destruct draining.
+   { iNamed "offer". iNamed "phys".
+      wp_auto_lc 2.
+    iApply "HPau" in "HP".
+     iApply fupd_wp.
+    iMod (lc_fupd_elim_later with "[$] HP") as "HP".
+    unfold rcv_au_fast.
+    iMod "HP".
+    iMod (lc_fupd_elim_later with "[$] HP") as "HP".
+    iNamed "HP".
+     unfold chan_logical. iDestruct "offer" as "[offer H]".
+    iDestruct (own_channel_agree with "[$offer] [$Hoc]") as "%Hseq". subst s.
+
+
+    iMod ("Hcont" with "Hoc") as "Hcont". iModIntro.
+    wp_if_destruct.
+    {
+        iDestruct (own_slice_len with "slice") as "[%H1 %H2]".
+        simpl in H1.
+        word.
+    } wp_auto.
+
+    wp_apply (wp_Mutex__Unlock
+                with "[$lock state  slice slice_cap buffer H offer $Hlock]").
+    { iModIntro. unfold chan_inv_inner.  iExists (Closed []). iFrame.
+      }
+      done.
+  }
+  {
+     iNamed "phys". iNamed "offer". wp_auto. unfold chan_cap_valid in Hcapvalid.
+    wp_if_destruct.
+    {
+
+       iApply "HPau" in "HP".
+        iAssert (own_channel ch cap (chan_rep.Closed (v :: draining)) γ)%I
+          with "[Hchanrepfrag]" as "Hown".
+        { iFrame. iPureIntro. done. }
+        iMod (lc_fupd_elim_later with "[$] HP") as "HP".
+        unfold rcv_au_fast.
+        iApply fupd_wp.
+        iMod "HP".
+        iMod (lc_fupd_elim_later with "[$] HP") as "HP".
+        iNamed "HP".
+        iDestruct (own_channel_agree with "Hown Hoc") as %Heq.
+        subst s.
+        iMod ((own_channel_halves_update _ _ _ _ (chan_rep.Closed draining)) with "Hown Hoc")
+          as "[Hown1 Hown2]".
+        iMod ("Hcont" with "Hown1") as "Hcont".
+        iModIntro.
+        have Hpos : 0 ≤ sint.Z (W64 0) by word.
+        have Hlookup0 : (v :: draining) !! 0%nat = Some v by done.
+        iDestruct (own_slice_elem_acc with "slice") as "[Hcell Hclose]".
+        { exact Hpos. }
+        { done. }
+        iSpecialize ("Hclose" $! v with "Hcell").  (* gives back [slice_val ↦* (v::draining)] *)
+        iDestruct (own_slice_len with "Hclose") as %(Hlen_eq & Hnonneg).
+        have Hlt : 0 ≤ sint.Z (W64 0) < sint.Z slice_val.(slice.len_f).
+        { move: Hlen_eq; simpl.  (* length (v::draining) = S (length draining) *)
+          (* sint.nat len = S _  ⇒  sint.Z len > 0 *)
+          word. }
+        wp_auto.
+        wp_apply ((wp_load_slice_elem slice_val 0
+                     ( <[sint.nat (W64 0):=v]> (v :: draining)))
+                   with "[Hclose]"). all: try word.
+        { iFrame. done. }
+        iIntros "Hsl". wp_auto.
+        iDestruct (own_slice_cap_wf with "slice_cap") as %Hwf.
+        wp_apply (wp_slice_slice_pure).
+        { iPureIntro. word. }
+        wp_apply (wp_Mutex__Unlock
+                    with "[$lock state slice_cap Hsl buffer Hown2  $Hlock]").
+        { iModIntro. unfold chan_inv_inner. iExists (Closed draining). iFrame.
+
+          have -> : sint.nat (W64 0) = 0%nat by word.
+          (* <[0:=v]>(<[0:=v]> [v]) = [v] *)
+          simpl.
+          iDestruct (own_slice_split_all (W64 1) with "Hsl")
+            as "[Hhd Htail]"; first word. simpl.
+          iFrame.
+            iDestruct (own_slice_len with "Hhd") as %[Hlent _].
+          iDestruct (own_slice_cap_wf with "slice_cap") as %Hlen_le_cap.
+          iDestruct (own_slice_cap_slice_f (slice_val) (W64 1) (DfracOwn 1)) as "H".
+          { word. }
+          iApply "H" in "slice_cap". iFrame.
+            destruct draining.
+          {
+            destruct cap. all: try done.
+            iFrame.
+            }
+            {
+              iFrame.
+            }
+
+          }
+          { done.
+
+          }
+
+          }
+          {
+                iDestruct (own_slice_len with "slice") as "[%Hl %Hcap2]".
+      assert ( sint.Z slice_val.(slice.len_f) = sint.Z (W64 0)).
+      {
+        destruct (sint.Z slice_val.(slice.len_f)). all: try done.
+      }
+      replace (sint.nat slice_val.(slice.len_f)) with 0%nat in *.
+      { done.  }
+      word.
+      }
+  }
+}
+Qed.
 End atomic_specs.

--- a/new/proof/github_com/goose_lang/goose/model/channel/logatom/chan_au_send.v
+++ b/new/proof/github_com/goose_lang/goose/model/channel/logatom/chan_au_send.v
@@ -13,60 +13,38 @@ Context `{!IntoVal V}.
 Context `{!IntoValTyped V t}.
 Context `{!globalsGS Σ} {go_ctx : GoContext}.
 
-(* Used for a standalone send as well as a send case in a blocking select statement. 
-   This tracks the possible success paths for both unbuffered and buffered channels.
-*)
-Definition chan_send_atomic_update ch (cap: w64) (v : V) (γ: chan_names) (Φ : iProp Σ) : iProp Σ :=
-  "#Hperschan" ∷ is_channel ch cap γ ∗
-  "Hlogatom" ∷ |={⊤,∅}=>
-    ▷∃ s,  "Hoc" ∷ own_channel ch s cap γ ∗
-     "Hcont" ∷
-    (match s with
-    (* Case: Buffered channel with available capacity, enqueue the value. *)
-    | chan_rep.Buffered buff =>
-      if decide (length buff < uint.Z cap) then
-        (* Space available: enqueue the value *)
-        own_channel ch (chan_rep.Buffered (buff ++ [v])) cap γ ={∅,⊤}=∗ Φ
-      else
-        (* Buffer full: not applicable for blocking send when it succeeds *)
-        True
-    (* Case: Unbuffered channel with waiting receiver, complete the exchange. *)
-    | chan_rep.RcvWait =>
-          own_channel ch (chan_rep.SndDone v) 0 γ ={∅,⊤}=∗ Φ
-    (* Case: Unbuffered idle channel. This requires a two-phase handshake. *)
-    | chan_rep.Idle =>
-          (* Register as a waiting sender *)
-          own_channel ch (chan_rep.SndWait v) 0 γ ={∅,⊤}=∗
-               |={⊤,∅}=> ▷∃ s', own_channel ch s' 0 γ ∗
-                 (match s' with
-                    (* If we succeed through this path, the receiver completed the offer *)
-                    | chan_rep.RcvDone =>
-                        own_channel ch chan_rep.Idle 0 γ ={∅,⊤}=∗ Φ
-                  | chan_rep.Closed _ => False
-                    | _ => True
-                 end)
-    | chan_rep.SndWait _ | chan_rep.RcvDone | chan_rep.SndDone _ =>  True
-    | chan_rep.Closed _ => False
-    end).
-
-Lemma wp_TrySend (ch: loc) (cap: w64) (v: V) (γ: chan_names) (P: iProp Σ):
+Lemma wp_TrySend (ch: loc) (cap: Z) (v: V) (γ: chan_names) (P: iProp Σ):
   ∀ Φ (b: bool),
   is_pkg_init channel ∗ is_channel ch cap γ -∗
   (* P is here to support helping within a select statement. This is because the internal choice of 
   which case's atomic update cannot be made prematurely if an offer isn't accepted, so we need to 
   store the whole collective conjunct of atomic updates in the channel mutex invariant for the 
   channel we are making an offer on. *)
-  P ∗ (P -∗ (▷(chan_send_atomic_update ch cap v γ (Φ (#true))))) -∗ 
+  P ∗ (P -∗ ((send_au_fast ch cap v γ (Φ (#true))))) -∗ 
   (* Keep resources for attempts at this and/or other ops *)
   (P -∗ (Φ (#false))) -∗ 
-  WP ch @ (ptrT.id channel.Channel.id) @ "TrySend" #t #v #b {{ Φ }}.
+  WP ch @ (ptrT.id channel.Channel.id) @ "TrySend" #t #v #true {{ Φ }}.
 Proof.
 Admitted.
 
-Lemma wp_Send (ch: loc) (cap: w64) (v: V) (γ: chan_names):
+Lemma wp_TrySend_nb (ch: loc) (cap: Z) (v: V) (γ: chan_names) (P: iProp Σ):
   ∀ Φ,
   is_pkg_init channel ∗ is_channel ch cap γ -∗
-  ▷(chan_send_atomic_update ch cap v γ (Φ #())) -∗
+  (* P is here to support helping within a select statement. This is because the internal choice of 
+  which case's atomic update cannot be made prematurely if an offer isn't accepted, so we need to 
+  store the whole collective conjunct of atomic updates in the channel mutex invariant for the 
+  channel we are making an offer on. *)
+  P ∗ (P -∗ ((send_au_slow ch cap v γ (Φ (#true))))) -∗ 
+  (* Keep resources for attempts at this and/or other ops *)
+  (P -∗ (Φ (#false))) -∗ 
+  WP ch @ (ptrT.id channel.Channel.id) @ "TrySend" #t #v #false {{ Φ }}.
+Proof.
+Admitted.
+
+Lemma wp_Send (ch: loc) (cap: Z) (v: V) (γ: chan_names):
+  ∀ Φ,
+  is_pkg_init channel ∗ is_channel ch cap γ -∗
+  (send_au_slow ch cap v γ (Φ #())) -∗
   WP ch @ (ptrT.id channel.Channel.id) @ "Send" #t #v {{ Φ }}.
 Proof.
 Admitted.


### PR DESCRIPTION
Completed verification of channel receive operations (Receive, TryReceive blocking/non-blocking)

The big changes here are to support helping for unbuffered ops. A notable change is that there is now a separate inductive type for the mathematical representation and the model implementation. While these look nearly identical, the mathematical representation doesn't enter the "pending" state until the offer will be accepted, whereas the model implementation goes from idle to offer and back to idle when an offer is rescinded. 

The saved prop/pred approach allows operations to register their AUs/continuations in the mutex invariant, enabling other operations to help complete them. This is essential for select where multiple channel operations need to coordinate without premature commitment.