### PR TITLE
Add more automation to wp_if_destruct

### DIFF
--- a/new/golang/theory/auto.v
+++ b/new/golang/theory/auto.v
@@ -308,6 +308,10 @@ Ltac wp_if_destruct :=
       | context[bool_decide ?b] =>
           destruct (bool_decide_reflect b); subst;
           wp_pures;
-          cleanup_bool_decide
+          cleanup_bool_decide;
+          try wp_auto
+      | context[@to_val _ bool _ ?b] =>
+          is_var b; destruct b;
+          try wp_auto
       end
   end.

--- a/new/golang/theory/auto.v
+++ b/new/golang/theory/auto.v
@@ -207,6 +207,15 @@ Tactic Notation "wp_auto_lc" int(x) :=
   let f := ltac2:(x |- wp_auto_lc (Option.get (Ltac1.to_int x))) in
   f x.
 
+Lemma true_neq_false `{ffi: ffi_syntax} :
+  #true ≠ #false.
+Proof. intros ?%(inj to_val); congruence. Qed.
+Lemma false_neq_true `{ffi: ffi_syntax} :
+  #false ≠ #true.
+Proof. intros ?%(inj to_val); congruence. Qed.
+
+Hint Resolve true_neq_false false_neq_true : core.
+
 Lemma if_decide_bool_eq_true `{!ffi_syntax} {A} `{!Decision P} (x y: A) :
   (if decide (#(bool_decide P) = #true) then x
   else y) = (if bool_decide P then x else y).
@@ -214,7 +223,6 @@ Proof.
   destruct (bool_decide_reflect P).
   - rewrite decide_True //.
   - rewrite decide_False //.
-    inv 1.
 Qed.
 
 Lemma if_decide_bool_eq_false `{!ffi_syntax} {A} `{!Decision P} (x y: A) :
@@ -223,7 +231,6 @@ Lemma if_decide_bool_eq_false `{!ffi_syntax} {A} `{!Decision P} (x y: A) :
 Proof.
   destruct (bool_decide_reflect P).
   - rewrite decide_False //.
-    inv 1.
   - rewrite decide_True //.
 Qed.
 
@@ -241,16 +248,31 @@ Proof.
   rewrite decide_True //.
 Qed.
 
-(* This patterns comes up in the postcondition from [wp_for] if the condition is
+(* This pattern comes up in the postcondition from [wp_for] if the condition is
 the constant [#true] (for infinite loops using [break] for example) *)
 Lemma if_decide_true_eq `{!ffi_syntax} {A} (x y: A) :
   (if decide (#true = #true) then x else y) = x.
-Proof.
-  rewrite decide_True //.
-Qed.
+Proof. rewrite decide_True //. Qed.
+
+(* TODO: is there a systematic way to avoid seeing these? *)
+Lemma if_decide_true_eq_false `{!ffi_syntax} {A} (x y: A) :
+  (if decide (#true = #false) then x else y) = y.
+Proof. rewrite decide_False //. Qed.
+Lemma if_decide_false_eq_true `{!ffi_syntax} {A} (x y: A) :
+  (if decide (#false = #true) then x else y) = y.
+Proof. rewrite decide_False //. Qed.
+
+Lemma if_decide_true_neq_false `{!ffi_syntax} {A} (x y: A) :
+  (if decide (#true ≠ #false) then x else y) = x.
+Proof. rewrite decide_True //. Qed.
+Lemma if_decide_false_neq_true `{!ffi_syntax} {A} (x y: A) :
+  (if decide (#false ≠ #true) then x else y) = x.
+Proof. rewrite decide_True //. Qed.
 
 Ltac cleanup_bool_decide :=
-  rewrite ?if_decide_bool_eq_true ?if_decide_bool_eq_false ?if_decide_true_eq.
+  rewrite ?if_decide_bool_eq_true ?if_decide_bool_eq_false
+    ?if_decide_true_eq ?if_decide_true_eq_false ?if_decide_false_eq_true
+    ?if_decide_true_neq_false ?if_decide_false_neq_true.
 
 #[local]
 Ltac wp_for_cleanup :=

--- a/new/golang/theory/slice.v
+++ b/new/golang/theory/slice.v
@@ -420,7 +420,6 @@ Proof.
     simpl. iSplit; auto. iSplit; auto.
     iApply own_slice_cap_none; reflexivity.
   }
-  wp_pures.
   wp_bind (AllocN _ _).
   rewrite [in #cap]to_val_unseal.
   iApply (wp_allocN_seq with "[//]").
@@ -445,7 +444,7 @@ Proof.
     iApply (big_sepL_impl with "[$]").
     iModIntro. iIntros.
     rewrite /pointsto_vals typed_pointsto_unseal /typed_pointsto_def /=.
-    rewrite default_val_eq_zero_val.
+    rewrite !default_val_eq_zero_val.
     erewrite has_go_type_len.
     2:{ apply zero_val_has_go_type. }
     iApply (big_sepL_impl with "[$]").
@@ -459,6 +458,7 @@ Proof.
     rewrite /own_slice_cap_def /=.
     iSplitR; first iPureIntro.
     { word. }
+    rewrite !default_val_eq_zero_val.
     erewrite has_go_type_len.
     2:{ apply zero_val_has_go_type. }
     iExists (replicate (sint.nat cap - sint.nat len)%nat (default_val V)).
@@ -953,7 +953,6 @@ Proof.
   iDestruct (own_slice_len with "Hsl") as %Hlen.
   wp_if_destruct.
   - (* Case: execute loop body *)
-    wp_auto.
     pose proof (list_lookup_lt vs (sint.nat j) ltac:(word)) as [w Hlookup].
     iDestruct (own_slice_elem_acc j with "[$]") as "[Helem Hown]"; [word|done|].
     wp_pure.
@@ -1178,8 +1177,8 @@ Proof.
     )%I with "[Hs1 Hs2 i]" as "IH".
   { iFrame. word. }
   wp_for "IH".
-  wp_if_destruct; try wp_auto.
-  - wp_if_destruct; try wp_auto.
+  wp_if_destruct.
+  - wp_if_destruct.
     {
       list_elem vs' (sint.Z i) as y.
       wp_pure; [ word | ].
@@ -1206,8 +1205,6 @@ Proof.
       rewrite -app_assoc /=.
       rewrite -> length_take_le by word.
       repeat (f_equal; try word). }
-    rewrite decide_False.
-    2: { inv 1. }
     rewrite decide_True //.
     wp_auto.
     assert (i = slice.len_f s2) by word; subst i.
@@ -1217,9 +1214,7 @@ Proof.
     rewrite -> !take_ge by word.
     iExactEq "Hs1".
     repeat (f_equal; try word).
-  - rewrite decide_False.
-    2: { inv 1. }
-    rewrite decide_True //.
+  - rewrite decide_True //.
     wp_auto.
     assert (i = slice.len_f s) by word; subst i.
     iApply "HΦ".
@@ -1295,7 +1290,7 @@ Proof.
   iDestruct (own_slice_wf with "Hs") as %Hwf1.
   iDestruct (own_slice_wf with "Hs2") as %Hwf2.
   wp_apply wp_sum_assume_no_overflow_signed as "%Hoverflow".
-  wp_if_destruct; try wp_auto.
+  wp_if_destruct.
   - wp_pure.
     { word. }
     match goal with

--- a/new/proof/bytes.v
+++ b/new/proof/bytes.v
@@ -43,7 +43,6 @@ Proof.
     iDestruct (own_slice_len with "Hsl_b") as %[Hb_len ?].
     apply nil_length_inv in Hb_len. subst.
     iFrame "∗#". }
-  wp_auto.
   wp_apply (wp_slice_append with "[$Hsl_b]") as "* (?&?&?)".
   { iFrame "#". }
   iApply "HΦ". iFrame.

--- a/new/proof/github_com/goose_lang/goose/testdata/examples/unittest.v
+++ b/new/proof/github_com/goose_lang/goose/testdata/examples/unittest.v
@@ -201,11 +201,11 @@ Lemma wp_testSwitchMultiple (x: w64) :
   }}}.
 Proof.
   wp_start. wp_auto.
-  wp_if_destruct; try wp_auto.
+  wp_if_destruct.
   { by iApply "HΦ". }
-  wp_if_destruct; try wp_auto.
+  wp_if_destruct.
   { by iApply "HΦ". }
-  wp_if_destruct; try wp_auto.
+  wp_if_destruct.
   { by iApply "HΦ". }
   iApply "HΦ".
   word.
@@ -309,15 +309,14 @@ Proof.
   { word. }
   wp_for "IH".
   wp_if_destruct.
-  - wp_auto.
-    wp_pure; first word.
+  - wp_pure; first word.
     list_elem xs (sint.nat i) as x_i.
     wp_apply (wp_load_slice_elem with "[$Hs]") as "Hs"; first word.
     { eauto. }
     wp_for_post.
     iFrame.
     word.
-  - wp_auto. iApply "HΦ". iFrame.
+  - iApply "HΦ". iFrame.
 Qed.
 
 End proof.

--- a/new/proof/github_com/goose_lang/std.v
+++ b/new/proof/github_com/goose_lang/std.v
@@ -56,7 +56,7 @@ Proof.
   wp_auto.
   iDestruct (own_slice_len with "Hs1") as "%".
   iDestruct (own_slice_len with "Hs2") as "%".
-  wp_if_destruct; try wp_auto.
+  wp_if_destruct.
   {
     assert (length xs1 = length xs2) by word.
     iAssert (∃ (i: w64),
@@ -69,7 +69,7 @@ Proof.
       split; [ word | intros; word ].
     }
     wp_for "IH".
-    wp_if_destruct; try wp_auto.
+    wp_if_destruct.
     - list_elem xs1 (sint.Z i) as x1_i.
       wp_pure; [ word | ].
       wp_apply (wp_load_slice_elem with "[$Hs1]") as "Hs1"; [ word | eauto | ].
@@ -107,7 +107,7 @@ Lemma wp_BytesClone (b:slice.t) (xs:list u8) (dq:dfrac) :
   {{{ b', RET #b'; own_slice b' (DfracOwn 1) xs ∗ own_slice_cap w8 b' (DfracOwn 1) }}}.
 Proof.
   wp_start as "Hb". wp_auto.
-  wp_if_destruct; try wp_auto.
+  wp_if_destruct.
   - iApply "HΦ". 
     + iSplitL.
       * iDestruct (own_slice_len with "Hb") as "[%Hb_len %]".
@@ -151,9 +151,10 @@ Lemma wp_SignedSumAssumeNoOverflow (x y : u64) :
 Proof.
   wp_start as "_"; wp_auto.
   unfold math.MaxInt, math.MinInt.
-  repeat (wp_if_destruct
+  repeat (
             (* BUG: this unshelve avoids trivial shelved goals of type w64 and
-            val *)
+            val (coming from wp_auto) *)
+      unshelve wp_if_destruct
           || unshelve wp_auto
           || (wp_apply wp_Assume; iIntros "%")
           || congruence).

--- a/new/proof/github_com/goose_lang/std/std_core.v
+++ b/new/proof/github_com/goose_lang/std/std_core.v
@@ -63,7 +63,7 @@ Proof.
   wp_if_destruct.
   { rewrite -> bool_decide_eq_true_2 by word.
     iApply "HΦ"; auto. }
-  wp_auto. wp_if_destruct; try wp_auto.
+  wp_if_destruct.
   { rewrite -> bool_decide_eq_true_2 by word.
     iApply "HΦ"; auto. }
   iSpecialize ("HΦ" with "[$]").

--- a/new/proof/github_com/mit_pdos/go_journal/alloc.v
+++ b/new/proof/github_com/mit_pdos/go_journal/alloc.v
@@ -143,9 +143,7 @@ Proof.
   wp_start as "_".
   wp_auto.
   wp_if_destruct; last by word.
-  wp_auto.
   wp_if_destruct; last by word.
-  wp_auto.
   wp_apply (wp_slice_make2 (V:=u8)).
   { word. }
   iIntros (bitmap_s) "[Hs Hscap]". simpl.
@@ -177,15 +175,13 @@ Proof.
   iNamed "Hl".
   wp_auto.
   wp_if_destruct.
-  - wp_auto.
-    iApply "HΦ".
+  - iApply "HΦ".
     iSplit.
     + iPureIntro.
       word.
     + iExists _, _, _.
       iFrame "∗%".
-  - wp_auto.
-    iApply "HΦ".
+  - iApply "HΦ".
     iDestruct (own_slice_len with "Hbits") as %Hsz_len.
     rewrite word.unsigned_mul in n.
     rewrite -> wrap_small in n by word.
@@ -230,8 +226,7 @@ Proof.
   destruct (bits_lookup_byte max bits num) as [b Hlookup]; [ done | word | ].
   wp_apply (wp_load_slice_elem with "[$Hbits]") as "Hbits"; [ word | eauto | ].
   wp_if_destruct.
-  - wp_auto.
-    wp_pure; first by word.
+  - wp_pure; first by word.
     wp_apply (wp_load_slice_elem with "[$Hbits]") as "Hbits"; [ word | eauto | ].
     wp_pure; first by word.
     wp_apply (wp_store_slice_elem with "[$Hbits]") as "Hbits"; [ word | ].
@@ -239,14 +234,12 @@ Proof.
     wp_apply (wp_Mutex__Unlock with "[$His_lock $Hlocked $next $bitmap $Hbits]").
     { rewrite length_insert. word. }
     iApply "HΦ". word.
-  - wp_auto.
-    wp_apply (wp_incNext max with "[$next $bitmap $Hbits]"); first done.
+  - wp_apply (wp_incNext max with "[$next $bitmap $Hbits]"); first done.
     { word. }
     iIntros (next'') "[%Hnext'' Hlinv]".
     wp_auto.
     wp_if_destruct.
-    + wp_auto.
-      wp_for_post.
+    + wp_for_post.
       wp_apply (wp_Mutex__Unlock with "[$His_lock $Hlocked $Hlinv]").
       iApply "HΦ". done.
     + wp_for_post.
@@ -304,7 +297,6 @@ Proof.
   wp_start as "H".
   wp_auto.
   wp_if_destruct; first word.
-  wp_auto.
   wp_apply (wp_freeBit with "[$H]"); eauto.
   by iApply "HΦ".
 Qed.
@@ -329,14 +321,11 @@ Proof.
   iNamed "Hloop".
   wp_auto.
   wp_if_destruct.
-  - wp_auto.
-    wp_for_post.
+  - wp_for_post.
     iFrame.
     pose proof (and_1_u8 x). word.
   - (* XXX why doesn't the automation work for this? *)
-    replace (# true) with (into_val_bool.(to_val_def) true) by ( rewrite to_val_unseal; auto ).
-    replace (# false) with (into_val_bool.(to_val_def) false) by ( rewrite to_val_unseal; auto ).
-    simpl.
+    rewrite decide_True //.
     wp_auto.
     iApply "HΦ". word.
 Qed.
@@ -373,8 +362,7 @@ Proof.
   iDestruct (own_slice_len with "Hbits") as %Hsz.
   wp_auto.
   wp_if_destruct.
-  - wp_auto.
-    wp_pure; first word.
+  - wp_pure; first word.
     edestruct (lookup_lt_is_Some_2 bits (sint.nat i)); first word.
     wp_apply (wp_load_slice_elem with "[$Hbits]") as "Hbits"; [ word | eauto | ].
     wp_apply wp_popCnt. iIntros (n Hn).
@@ -382,10 +370,8 @@ Proof.
     wp_for_post.
     iFrame.
     word.
-  - (* XXX: decide (#false = #true) does not evaluate *)
-    replace (# true) with (into_val_bool.(to_val_def) true) by ( rewrite to_val_unseal; auto ).
-    replace (# false) with (into_val_bool.(to_val_def) false) by ( rewrite to_val_unseal; auto ).
-    simpl.
+  - (* XXX: decide (#false = #false) does not evaluate *)
+    rewrite decide_True //.
     wp_auto.
     wp_apply (wp_Mutex__Unlock with "[$His_lock $Hlocked $next $bitmap $Hbits]").
     { word. }

--- a/new/proof/github_com/mit_pdos/go_journal/buf_proof/buf_proof.v
+++ b/new/proof/github_com/mit_pdos/go_journal/buf_proof/buf_proof.v
@@ -781,18 +781,15 @@ Proof.
   wp_auto.
   rewrite !mask_bit_ok //.
   wp_if_destruct.
-  - wp_auto.
-    iExactEq "HΦ"; do 3 f_equal.
+  - iExactEq "HΦ"; do 3 f_equal.
     rewrite install_one_bit_id //.
     { lia. }
     destruct (default false _), (default false _); auto.
     + apply masks_different in e; eauto; contradiction.
     + apply symmetry, masks_different in e; eauto; contradiction.
-  - wp_auto.
-    rewrite !mask_bit_ok //.
+  - rewrite !mask_bit_ok //.
     wp_if_destruct.
-    + wp_auto.
-      destruct (default false (byte_to_bits src !! uint.nat bit)) eqn:?.
+    + destruct (default false (byte_to_bits src !! uint.nat bit)) eqn:?.
       { apply masks_different in e; auto; contradiction. }
       iExactEq "HΦ"; do 3 f_equal.
       rewrite /install_one_bit.
@@ -800,8 +797,7 @@ Proof.
       apply (inj byte_to_bits).
       rewrite bits_to_byte_to_bits; [|len].
       bit_cases bit; byte_cases dst; vm_refl.
-    + wp_auto.
-      destruct (default false (byte_to_bits src !! uint.nat bit)) eqn:?; last contradiction.
+    + destruct (default false (byte_to_bits src !! uint.nat bit)) eqn:?; last contradiction.
       destruct (default false (byte_to_bits dst !! uint.nat bit)) eqn:?; first contradiction.
       iExactEq "HΦ"; do 3 f_equal.
       rewrite /install_one_bit.

--- a/new/proof/github_com/mit_pdos/go_journal/lockmap.v
+++ b/new/proof/github_com/mit_pdos/go_journal/lockmap.v
@@ -228,8 +228,7 @@ Proof.
 
   wp_auto.
   wp_if_destruct.
-  - wp_auto.
-    wp_apply (wp_Cond__Signal with "[$Hcond]").
+  - wp_apply (wp_Cond__Signal with "[$Hcond]").
 
     iMod (ghost_map_update false with "Hghctx Haddrlocked") as "[Hghctx Haddrlocked]".
     iDestruct (big_sepM2_insert_2 _ _ _ addr with "[held cond waiters Haddrlocked Hp] Haddrs") as "Haddrs".
@@ -241,8 +240,7 @@ Proof.
     wp_apply (wp_Mutex__Unlock with "[$Hlock $Hlocked $Hmptr $Hghctx $Haddrs $Hcovered]").
     iApply "HΦ". done.
 
-  - wp_auto.
-    wp_apply (wp_map_delete with "Hmptr") as "Hmptr".
+  - wp_apply (wp_map_delete with "Hmptr") as "Hmptr".
 
     iMod (ghost_map_delete with "Hghctx Haddrlocked") as "Hghctx".
     iDestruct (big_sepS_delete with "Hcovered") as "[Hcaddr Hcovered]"; eauto.
@@ -417,7 +415,7 @@ Proof.
   }
 
   wp_for "Hloop".
-  wp_if_destruct; wp_auto.
+  wp_if_destruct.
   - rewrite rangeSet_first.
     2: { unseal_nshard. word. }
     iDestruct (big_sepS_insert with "Hpp") as "[Hp Hpp]".

--- a/new/proof/github_com/mit_pdos/go_journal/util.v
+++ b/new/proof/github_com/mit_pdos/go_journal/util.v
@@ -31,7 +31,7 @@ Theorem wp_Min_l (n m: u64) :
 Proof.
   wp_start as "%Hmin".
   wp_auto.
-  wp_if_destruct; wp_auto.
+  wp_if_destruct.
   - iApply "HΦ". done.
   - replace m with n by word.
     iApply "HΦ". done.
@@ -45,7 +45,7 @@ Theorem wp_Min_r (n m: u64) :
 Proof.
   wp_start as "%Hmin".
   wp_auto.
-  wp_if_destruct; wp_auto.
+  wp_if_destruct.
   - replace n with m by word.
     iApply "HΦ". done.
   - iApply "HΦ". done.
@@ -63,7 +63,7 @@ Proof.
   (* Annoying that [iNamed "Hpkg"] doesn't work directly.. *)
   iDestruct (is_pkg_init_access with "[$]") as "Hpkg". simpl. iNamed "Hpkg".
   wp_auto.
-  wp_if_destruct; try wp_auto.
+  wp_if_destruct.
   - wp_apply wp_Printf.
     iApply "HΦ". done.
   - iApply "HΦ". done.

--- a/new/proof/github_com/mit_pdos/gokv/lockservice.v
+++ b/new/proof/github_com/mit_pdos/gokv/lockservice.v
@@ -111,8 +111,8 @@ Proof.
     iMod ("Hclo" with "[Hk]").
     { iExists true. iFrame. }
     iModIntro. iIntros "Hck". wp_auto. rewrite bool_decide_true // decide_False //.
-    2:{ naive_solver. } rewrite decide_True //.
-    wp_auto. iApply "HΦ". iFrame.
+    rewrite decide_True //; wp_auto.
+    iApply "HΦ". iFrame.
 Qed.
 
 Lemma wp_LockClerk__Unlock ck key γ R :

--- a/new/proof/github_com/sanjit_bhat/pav/hashchain.v
+++ b/new/proof/github_com/sanjit_bhat/pav/hashchain.v
@@ -426,7 +426,6 @@ Proof.
   iDestruct (own_slice_len with "Hsl_proof") as %?.
   wp_if_destruct.
   2: {
-    wp_auto.
     iApply "HΦ".
     (* TODO(goose): could "nil ownership" be automated? *)
     iDestruct (own_slice_nil (DfracOwn 1)) as "?".
@@ -441,7 +440,6 @@ Proof.
       iIntros (?) "@".
       iDestruct (wish_Verify_impl_mod_len with "[//]") as %?.
       word. }
-  wp_auto.
   iPersist "extLen".
 
   remember (word.divu _ _) as extLen.

--- a/new/proof/github_com/sanjit_bhat/pav/merkle_proof/code.v
+++ b/new/proof/github_com/sanjit_bhat/pav/merkle_proof/code.v
@@ -194,7 +194,6 @@ Proof.
 
   (* in golang, extract byte. *)
   wp_if_destruct; [|word].
-  wp_auto.
   wp_pure; [ word | ].
   wp_apply (wp_load_slice_elem with "[$Hsl_bs]") as "Hsl_bs".
   { word. }
@@ -602,7 +601,7 @@ Admitted. (*
   wp_start as "@". wp_auto.
   iDestruct (own_slice_len with "Hsl_sibs") as %[].
 
-  wp_if_destruct; wp_auto.
+  wp_if_destruct.
   { iApply "HΦ".
     destruct sibs_enc. 2: { simpl in *. word. }
     instantiate (1:=[]).
@@ -737,7 +736,7 @@ Proof.
 Admitted. (*
   wp_start as "@". wp_auto.
   iDestruct (own_slice_len with "Hsl_label") as %[].
-  wp_if_destruct; wp_auto.
+  wp_if_destruct.
   2: { iApply "HΦ". intro_wish. word. }
   wp_apply (MerkleProof.wp_dec with "[$Hsl_proof]") as "* Hpost".
   destruct err; wp_auto.
@@ -746,14 +745,14 @@ Admitted. (*
   iNamed "Hown_obj_dec".
   iDestruct (own_slice_len with "Hsl_Siblings") as %[Hlen_sl_sibs ?].
   wp_auto.
-  wp_if_destruct; wp_auto.
+  wp_if_destruct.
   2: { iApply "HΦ". intro_wish.
     iDestruct (MerkleProof.wish_det with "Hwish_dec Henc_proof") as %[-> ->].
     iClear "Hwish_dec". simpl in *.
     apply join_same_len_length in Hlen_sibs.
     rewrite -join_length_reverse in Hlen_sibs.
     word. }
-  wp_if_destruct; wp_auto.
+  wp_if_destruct.
   { iApply "HΦ". intro_wish.
     iDestruct (MerkleProof.wish_det with "Hwish_dec Henc_proof") as %[-> ->].
     iClear "Hwish_dec". simpl in *.
@@ -784,7 +783,7 @@ Admitted. (*
     iPureIntro; repeat split; try done; word. }
 
   iDestruct (own_slice_len with "Hsl_LeafLabel") as %[].
-  wp_if_destruct; wp_auto.
+  wp_if_destruct.
   2: { iApply "HΦ". intro_wish.
     destruct oleaf as [[]|].
     2: { iDestruct (MerkleProof.wish_det with "Hwish_dec Henc_proof") as %[[=] _]. }
@@ -794,7 +793,7 @@ Admitted. (*
   iPersist "Hsl_LeafLabel Hsl_LeafVal".
   wp_apply bytes.wp_Equal as "_".
   { iFrame "#". }
-  wp_if_destruct; wp_auto.
+  wp_if_destruct.
   { iApply "HΦ". intro_wish.
     destruct oleaf as [[]|].
     2: { iDestruct (MerkleProof.wish_det with "Hwish_dec Henc_proof") as %[[=] _]. }

--- a/new/proof/go_etcd_io/etcd/client/v3/leasing.v
+++ b/new/proof/go_etcd_io/etcd/client/v3/leasing.v
@@ -211,7 +211,7 @@ Proof.
   wp_apply "HErr"; first iFrame "#". iIntros (?) "_". wp_pures.
   destruct bool_decide.
   2:{
-    rewrite decide_False //; last naive_solver.
+    rewrite decide_False //.
     rewrite decide_True //. wp_auto. iApply "HΦ". eauto.
   }
   rewrite decide_True //. wp_auto.
@@ -229,7 +229,6 @@ Proof.
       iNamedAccu. }
     { (* not nil *)
       rewrite decide_False //. iNamed "Hsession".
-      wp_auto.
       wp_apply "HDone". wp_auto.
       wp_apply wp_Session__Done.
       { iFrame "#". }
@@ -583,7 +582,7 @@ Proof.
   wp_apply (wp_map_get with "[$entries_own]") as "entries_own".
   wp_auto. wp_if_destruct.
   { (* li is nil *)
-    wp_auto. iCombineNamed "*_own" as "Hown".
+    iCombineNamed "*_own" as "Hown".
     iDestruct ("Hclose" with "[Hown]") as "Hown".
     { iNamed "Hown". iFrame "∗#%". iExists true. iFrame "∗#%". }
     wp_apply (wp_RWMutex__Unlock with "[$Hlocked $Hown]") as "Hmu".

--- a/new/proof/go_etcd_io/etcd/server/v3/etcdserver.v
+++ b/new/proof/go_etcd_io/etcd/server/v3/etcdserver.v
@@ -148,7 +148,7 @@ Proof.
     (* FIXME: declare then access init predicate of errors. *)
     admit.
   }
-  wp_auto. wp_apply (wp_Generator__Next with "[]"). { iFrame "#". }
+  wp_apply (wp_Generator__Next with "[]"). { iFrame "#". }
   iIntros "%i Hid". wp_auto. wp_alloc hdr_ptr as "hdr". wp_auto.
   iNamed "Hsimple". rewrite HAuthenticate. wp_auto.
   iDestruct ("Hclose" with "[$]") as "Hsrv".
@@ -180,7 +180,7 @@ Proof.
   iDestruct "Hmarshal" as "(req_ptr & req & %data & data_sl & %Hmarshal)".
   wp_auto. wp_if_destruct.
   { wp_bind. (* FIXME: access errors init predicate *) admit. }
-  wp_auto. rewrite HID. wp_auto. wp_bind.
+  rewrite HID. wp_auto. wp_bind.
   wp_apply (wp_wand with "[req]").
   {
     instantiate (1:=(λ v, "->" ∷ ⌜ v = #hdr.(etcdserverpb.RequestHeader.ID') ⌝ ∗

--- a/new/proof/sync_proof/once.v
+++ b/new/proof/sync_proof/once.v
@@ -163,7 +163,6 @@ Proof.
     iApply "HQ_inv".
     done.
   - wp_if_destruct; [ | exfalso; word ].
-    wp_auto.
     wp_apply wp_Once__doSlow.
     { iFrame "#". }
     iIntros "HQ".

--- a/new/proof/time.v
+++ b/new/proof/time.v
@@ -13,7 +13,7 @@ Lemma wp_Time__sec (t : loc) (tv : time.Time.t) :
     t @ (ptrT.id time.Time.id) @ "sec" #()
   {{{ (x : w64), RET #x; t ↦ tv }}}.
 Proof.
-  wp_start. wp_auto. wp_if_destruct; wp_auto; by iApply "HΦ".
+  wp_start. wp_auto. wp_if_destruct; by iApply "HΦ".
 Qed.
 
 #[local]

--- a/src/program_proof/tutorial/kvservice/proof.v
+++ b/src/program_proof/tutorial/kvservice/proof.v
@@ -197,7 +197,7 @@ Proof.
   iUnfold put.own in "Hargs". iNamed "Hargs". rewrite Hown_struct. wp_pures.
   wp_auto.
   wp_apply (wp_MapGet with "HlastRepliesM") as (??) "[%HlastReply HlastRepliesM]".
-  wp_if_destruct; wp_auto.
+  wp_if_destruct.
   { (* case: this is a duplicate request *)
     wp_apply (wp_Mutex__Unlock with "[-HΦ Hspec]").
     {
@@ -237,7 +237,7 @@ Proof.
   iUnfold conditionalPut.own in "Hargs". iNamed "Hargs". rewrite Hown_struct.
   wp_auto.
   wp_apply (wp_MapGet with "HlastRepliesM") as (??) "[%HlastReply HlastRepliesM]".
-  wp_if_destruct; wp_auto.
+  wp_if_destruct.
   { (* case: this is a duplicate request *)
     wp_apply (wp_Mutex__Unlock with "[-HΦ Hspec]").
     {
@@ -251,7 +251,7 @@ Proof.
   }
   wp_apply (wp_ref_to) as (ret2_ptr) "Hret"; first val_ty.
   wp_apply (wp_MapGet with "HkvsM") as (??) "[Hlookup HkvsM]".
-  wp_if_destruct; wp_auto.
+  wp_if_destruct.
   { (* case: the old value matches the expected value *)
     wp_apply (wp_MapInsert with "HkvsM") as "HkvsM"; first done.
     (* FIXME: delete typed_map.map_insert *)
@@ -299,7 +299,7 @@ Proof.
   iUnfold get.own in "Hargs". iNamed "Hargs". rewrite Hown_struct.
   wp_auto.
   wp_apply (wp_MapGet with "HlastRepliesM") as (??) "[%HlastReply HlastRepliesM]".
-  wp_if_destruct; wp_auto.
+  wp_if_destruct.
   { (* case: this is a duplicate request *)
     wp_apply (wp_Mutex__Unlock with "[-HΦ Hspec]").
     {


### PR DESCRIPTION
The reason for so many affected proofs is just adding `wp_auto` to the end.