### PR TITLE
Add done/mpmc/join and proofs.

### DIFF
--- a/new/proof/github_com/goose_lang/goose/model/channel/protocol/join/auth_set.v
+++ b/new/proof/github_com/goose_lang/goose/model/channel/protocol/join/auth_set.v
@@ -1,0 +1,108 @@
+(* Auth set from Prof. Tej Chajed's CS 839 curriculum 
+https://github.com/tchajed/sys-verif-fa25-proofs/blob/main/src/sys_verif/program_proof/demos/barrier_proof.v 
+*)
+From iris.algebra Require Import auth gset.
+From iris.proofmode Require Import proofmode.
+From iris.base_logic.lib Require Export own.
+
+Set Default Proof Using "Type".
+Set Default Goal Selector "!".
+
+Class auth_setG Σ (A: Type) `{Countable A} := AuthSetG {
+    auth_set_inG :: inG Σ (authUR (gset_disjUR A));
+}.
+Global Hint Mode auth_setG - ! - - : typeclass_instances.
+
+Definition auth_setΣ A `{Countable A} : gFunctors :=
+  #[ GFunctor (authRF (gset_disjUR A)) ].
+
+#[global] Instance subG_auth_setG Σ A `{Countable A} :
+  subG (auth_setΣ A) Σ → auth_setG Σ A.
+Proof. solve_inG. Qed.
+
+(*| auth_set is a thin wrapper around the resource algebra `authUR (gset_disjUR A)`. |*)
+Local Definition auth_set_auth_def `{auth_setG Σ A}
+    (γ : gname) (s: gset A) : iProp Σ :=
+  own γ (● GSet s).
+Local Definition auth_set_auth_aux : seal (@auth_set_auth_def). Proof. by eexists. Qed.
+Definition auth_set_auth := auth_set_auth_aux.(unseal).
+Local Definition auth_set_auth_unseal :
+  @auth_set_auth = @auth_set_auth_def := auth_set_auth_aux.(seal_eq).
+Global Arguments auth_set_auth {Σ A _ _ _} γ s.
+
+#[local] Notation "○ a" := (auth_frag a) (at level 20).
+
+Local Definition auth_set_frag_def `{auth_setG Σ A}
+    (γ : gname) (a: A) : iProp Σ :=
+  own γ (○ GSet {[a]}).
+Local Definition auth_set_frag_aux : seal (@auth_set_frag_def). Proof. by eexists. Qed.
+Definition auth_set_frag := auth_set_frag_aux.(unseal).
+Local Definition auth_set_frag_unseal :
+  @auth_set_frag = @auth_set_frag_def := auth_set_frag_aux.(seal_eq).
+Global Arguments auth_set_frag {Σ A _ _ _} γ a.
+
+Local Ltac unseal := rewrite ?auth_set_auth_unseal ?auth_set_frag_unseal /auth_set_auth_def /auth_set_frag_def.
+
+Section lemmas.
+  Context `{auth_setG Σ A}.
+
+  Implicit Types (s: gset A) (a: A).
+
+  #[global] Instance auth_set_auth_timeless γ s :
+    Timeless (auth_set_auth γ s).
+  Proof. unseal. apply _. Qed.
+  #[global] Instance auth_set_frag_timeless γ a :
+    Timeless (auth_set_frag γ a).
+  Proof. unseal. apply _. Qed.
+
+(*| The definition of auth_set is designed to make these ghost updates true. This as the API for this construction, in that the user of the library will not use the definitions above, only these lemmas. However, we have to carefully choose the definitions to make all of these rules true. |*)
+
+(*| We create an auth_set variable with an empty set and thus no fragments. |*)
+  Lemma auth_set_init :
+    ⊢ |==> ∃ γ, auth_set_auth γ (∅: gset A).
+  Proof.
+    unseal.
+    iApply (own_alloc (● GSet (∅: gset A))).
+    apply auth_auth_valid. done.
+  Qed.
+
+(*| We can add to the set and produce a new fragment that controls the new element. `a ∉ s` is required since there can only be one `auth_set_frag γ a` for a given value of `a`. |*)
+  Lemma auth_set_alloc a γ s :
+    a ∉ s →
+    auth_set_auth γ s ==∗
+    auth_set_auth γ ({[a]} ∪ s) ∗ auth_set_frag γ a.
+  Proof.
+    unseal.
+    iIntros (Hnotin) "Hauth".
+    rewrite -own_op.
+    iApply (own_update with "Hauth").
+    apply auth_update_alloc.
+    apply gset_disj_alloc_empty_local_update.
+    set_solver.
+  Qed.
+
+(*| Because a fragment expresses ownership of a part of the authoritative set, we have this rule which says that fragments agree with the authoritative predicate: |*)
+  Lemma auth_set_elem γ s a :
+    auth_set_auth γ s -∗ auth_set_frag γ a -∗ ⌜a ∈ s⌝.
+  Proof.
+    unseal. iIntros "Hauth Hfrag".
+    iDestruct (own_valid_2 with "Hauth Hfrag") as %Hin.
+    iPureIntro.
+    apply auth_both_valid_discrete in Hin as [Hin _].
+    apply gset_disj_included in Hin.
+    apply singleton_subseteq_l in Hin.
+    auto.
+  Qed.
+
+(*| If we control an element via `auth_set_frag γ a`, it's also possible to delete that element from the authoritative set (as long as we also give up ownership of the fragment). |*)
+  Lemma auth_set_dealloc γ s a :
+    auth_set_auth γ s ∗ auth_set_frag γ a ==∗
+    auth_set_auth γ (s ∖ {[a]}).
+  Proof.
+    unseal. iIntros "[Hauth Hfrag]".
+    iApply (own_update_2 with "Hauth Hfrag").
+    apply auth_update_dealloc.
+    apply gset_disj_dealloc_local_update.
+  Qed.
+
+End lemmas.

--- a/new/proof/github_com/goose_lang/goose/model/channel/protocol/join/join.v
+++ b/new/proof/github_com/goose_lang/goose/model/channel/protocol/join/join.v
@@ -1,0 +1,518 @@
+Require Import New.proof.proof_prelude.
+From New.proof.github_com.goose_lang.goose.model.channel Require Export chan_au_send chan_au_recv chan_au_base chan_init auth_set.
+From iris.base_logic Require Import ghost_map.
+From iris.base_logic.lib Require Import saved_prop.
+From iris.algebra Require Import excl.
+
+Section proof.
+  Context `{hG: heapGS Σ} `{!ffi_semantics _ _}.
+  Context {go_ctx: GoContext}.
+End proof.
+
+Module join.
+
+Record join_names :=
+  {
+    chan_name: chan_names;
+    join_prop_name: gname;
+    worker_names_name: gname;
+    join_counter_name: gname;
+  }.
+
+Class joinG Σ := JoinG {
+    join_saved_propG :: savedPropG Σ;
+    join_auth_setG :: auth_setG Σ gname;
+    join_counterG :: ghost_varG Σ nat;
+  }.
+
+Definition joinΣ: gFunctors :=
+  #[ savedPropΣ; auth_setΣ gname; ghost_varΣ nat].
+
+#[global] Instance subG_joinG Σ : subG joinΣ Σ → joinG Σ.
+Proof. solve_inG. Qed.
+
+Section proof.
+Context `{hG: heapGS Σ, !ffi_semantics _ _}.
+Context `{!chanGhostStateG Σ V}.
+Context `{!IntoVal V}.
+Context `{!IntoValTyped V t}.
+Context `{!globalsGS Σ} {go_ctx : GoContext}.
+Context `{!joinG Σ}.
+
+Definition join (γ: join_names) (count:nat) (Q: iProp Σ): iProp Σ :=
+  ghost_var γ.(join_counter_name) (1/2) count ∗
+  ∃ Q', saved_prop_own γ.(join_prop_name) (DfracOwn (1/2)) Q' ∗ (Q' -∗ Q).
+
+Definition worker (γ: join_names) (P: iProp Σ): iProp Σ :=
+  ∃ γS, auth_set_frag γ.(worker_names_name) γS ∗
+        saved_prop_own γS DfracDiscarded P.
+
+Definition own_join (γ : join_names) (ch : loc) (cap: nat) : iProp Σ :=
+  ∃ (workerQ: iProp Σ) (sendNames: gset gname) s count,
+    "Hch" ∷ own_channel ch cap s γ.(chan_name) ∗
+    "joinQ" ∷ saved_prop_own γ.(join_prop_name) (DfracOwn (1/2)) workerQ ∗
+    "%HnumWaiting" ∷ ⌜size sendNames = count⌝ ∗
+    "Hjoincount" ∷ ghost_var γ.(join_counter_name) (1/2) count ∗
+    "HsendNames_auth" ∷ auth_set_auth γ.(worker_names_name) sendNames ∗
+    "HworkerQ_wand" ∷ ((([∗ set] γS ∈ sendNames,
+                          ∃ P, saved_prop_own γS DfracDiscarded P ∗ ▷ P) -∗
+                        ▷ workerQ) ∨ (ghost_var γ.(join_counter_name) (1/2) count)) ∗
+    match s with
+    | chan_rep.Buffered msgs =>
+        [∗ list] _ ∈ msgs, ∃ P, worker γ P ∗ P
+    | chan_rep.SndPending v =>
+        ∃ P, worker γ P ∗ P
+    | chan_rep.SndCommit v =>
+        ∃ P, worker γ P ∗ P
+    | chan_rep.Idle | chan_rep.RcvPending | chan_rep.RcvCommit => True
+    | _ => False
+    end.
+
+Definition is_join (γ : join_names) (ch : loc) (cap : nat) : iProp Σ :=
+  is_channel ch cap γ.(chan_name) ∗
+  inv nroot ("Hbar" ∷ own_join γ ch cap)%I.
+
+#[global] Instance is_join_persistent ch γ cap : Persistent (is_join γ ch cap) := _.
+
+#[global] Instance worker_proper : Proper ((=) ==> (≡) ==> (≡)) worker.
+Proof.
+  intros γ _ <- Q1 Q2 Heq.
+  rewrite /worker.
+  setoid_rewrite Heq; done.
+Qed.
+
+Lemma join_mono γ Q Q' n :
+  (Q -∗ Q') -∗ (join γ n Q -∗ join γ n Q').
+Proof.
+  iIntros "Hwand Hrecv".
+  unfold join.
+  iDestruct "Hrecv" as "[HJoin Hrecv]".
+  iDestruct "Hrecv" as (Q'') "[Hsaved Hwand2]".
+  iFrame "Hsaved HJoin".
+  iIntros "H". iApply "Hwand". iApply "Hwand2". iFrame.
+Qed.
+
+Lemma own_join_alloc_unbuff (ch : loc) (γch : chan_names):
+  is_channel ch 0 γch -∗
+  own_channel ch 0 chan_rep.Idle γch ={⊤}=∗
+  ∃ γ, own_join γ ch 0 ∗ join γ 0 emp.
+Proof.
+  iIntros "Hchan_info Hchan_own".
+  iMod (saved_prop_alloc emp (DfracOwn 1)) as (γjoin_prop) "Hjoin_prop".
+  { done. }
+  iMod (auth_set_init (A:=gname)) as (γworker_names) "Hworker_names".
+  iMod (ghost_var_alloc 0) as (γjoin_counter) "Hjoin_counter".
+  set (γ := {|
+    chan_name := γch;
+    join_prop_name := γjoin_prop;
+    worker_names_name := γworker_names;
+    join_counter_name := γjoin_counter;
+  |}).
+  iModIntro. iExists γ. simpl. iFrame.
+  iDestruct "Hjoin_prop" as "[Hjoin_prop_half1 Hjoin_prop_half2]".
+  iFrame.
+  iDestruct "Hjoin_counter" as "[Hjoin_counter_half1 Hjoin_counter_half2]".
+  iSplitR "Hjoin_counter_half1".
+  {
+    iFrame.
+    iSplitL ""; first set_solver.
+    iSplitR "".
+    {
+      iLeft. rewrite big_sepS_empty. done.
+    }
+    { done. }
+  }
+  iFrame. done.
+Qed.
+
+Lemma own_join_alloc_buff (ch : loc) (γch : chan_names):
+  is_channel ch 0 γch -∗
+  own_channel ch 0 (chan_rep.Buffered []) γch ={⊤}=∗
+  ∃ γ, own_join γ ch 0 ∗ join γ 0 emp.
+Proof.
+  iIntros "Hchan_info Hchan_own".
+  iMod (saved_prop_alloc emp (DfracOwn 1)) as (γjoin_prop) "Hjoin_prop".
+  { done. }
+  iMod (auth_set_init (A:=gname)) as (γworker_names) "Hworker_names".
+  iMod (ghost_var_alloc 0) as (γjoin_counter) "Hjoin_counter".
+  set (γ := {|
+    chan_name := γch;
+    join_prop_name := γjoin_prop;
+    worker_names_name := γworker_names;
+    join_counter_name := γjoin_counter;
+  |}).
+  iModIntro. iExists γ. simpl. iFrame.
+  iDestruct "Hjoin_prop" as "[Hjoin_prop_half1 Hjoin_prop_half2]".
+  iFrame.
+  iDestruct "Hjoin_counter" as "[Hjoin_counter_half1 Hjoin_counter_half2]".
+  iSplitR "Hjoin_counter_half1".
+  {
+    iFrame.
+    iSplitL ""; first set_solver.
+    iSplitR "".
+    {
+      iLeft. rewrite big_sepS_empty. done.
+    }
+    { done. }
+  }
+  iFrame. done.
+Qed.
+
+Lemma join_alloc_worker γ ch cap Q P count :
+  £ 1 -∗
+  is_join γ ch cap -∗
+  join γ count Q ={⊤}=∗
+  join γ (S count) (Q ∗ P) ∗ worker γ P.
+Proof.
+  iIntros "Hlc (#Hisjoin & Hjoininv) Hjoin".
+  iInv "Hjoininv" as "Hinv_open" "Hinv_close".
+  iMod (lc_fupd_elim_later with "Hlc Hinv_open") as "Hinv_open".
+  iNamed "Hinv_open".
+  iNamed "Hbar".
+  unfold join.
+  iDestruct "Hjoin" as "[Hcount Hrest]".
+  iNamed "Hrest".
+  iDestruct "Hrest" as "[Hsp HQimp]".
+  iDestruct (saved_prop_agree with "joinQ Hsp") as "#HQeq".
+  iMod (saved_prop_update_halves (Q ∗ P) with "joinQ Hsp") as "[joinQ worker_prop]".
+  iDestruct (ghost_var_agree with "Hjoincount Hcount") as %Hcount_eq.
+  assert (count = count0) as -> by done.
+  iMod (ghost_var_update_halves (S count0) with "Hjoincount Hcount") as "[Hjoincount Hjoincount2]".
+  iMod (saved_prop_alloc_cofinite sendNames P DfracDiscarded) as (γS) "[%Hfresh #HworkerS]".
+  { done. }
+  iMod (auth_set_alloc γS with "HsendNames_auth") as "[HsendNames_auth HγS_frag]".
+  { set_solver. }
+  iDestruct "HworkerQ_wand" as "[HworkerQ_wand|H2]".
+  {
+    iMod ("Hinv_close" with "[Hch Hbar HworkerQ_wand HQimp joinQ Hjoincount HsendNames_auth]").
+    {
+      iModIntro. iFrame. iFrame "#".
+      iSplitL "".
+      {
+        iPureIntro.
+        rewrite size_union.
+        { rewrite size_singleton. rewrite HnumWaiting. done. }
+        { set_solver. }
+      }
+      {
+        iLeft.
+        iIntros "Hset".
+        rewrite big_sepS_union.
+        {
+          iDestruct "Hset" as "[Hsing Hset]".
+          iApply "HworkerQ_wand" in "Hset".
+          iRewrite "HQeq" in "Hset".
+          rewrite big_sepS_singleton.
+          iNamed "Hsing".
+          iDestruct "Hsing" as "[Hsingsp Hx]".
+          iDestruct (saved_prop_agree with "Hsingsp HworkerS") as "Hagree".
+          iNext.
+          iRewrite "Hagree" in "Hx".
+          iFrame.
+          iApply "HQimp" in "Hset".
+          done.
+        }
+        { set_solver. }
+      }
+    }
+    {
+      iModIntro. iFrame "#". iFrame.
+      iIntros "H". done.
+    }
+  }
+  {
+    iCombine "H2 Hjoincount" as "H2".
+    iDestruct (ghost_var_valid_2 with "Hjoincount2 H2") as "[%Hvalid _]".
+    done.
+  }
+Qed.
+
+Lemma wp_worker_send γ ch cap P :
+  {{{ £ 1 ∗ £ 1 ∗ £ 1 ∗ £ 1 ∗
+      is_pkg_init channel ∗
+      is_join γ ch cap ∗
+      worker γ P ∗
+      P }}}
+    ch @ (ptrT.id channel.Channel.id) @ "Send" #t #(default_val V)
+  {{{ RET #(); True }}}.
+Proof.
+  iIntros (Φ) "(Hlc1 & Hlc2 & Hlc3 & Hlc4 & #Hinit & #Hjoin & HWorker & HP) HΦ".
+  rewrite /worker /is_join.
+  iNamed "HWorker".
+  iDestruct "HWorker" as "[Hfrag Hprop]".
+  iDestruct "Hjoin" as "[#Hch #Hinv]".
+  iApply (wp_Send ch cap (default_val V) γ.(chan_name) with "[$Hinit $Hch]").
+  iInv "Hinv" as "Hinv_open" "Hinv_close".
+  iMod (lc_fupd_elim_later with "Hlc1 Hinv_open") as "Hinv_open".
+  iDestruct "Hch" as "Hch1".
+  iNamed "Hinv_open".
+  iApply fupd_mask_intro; [solve_ndisj|iIntros "Hmask"].
+  unfold own_join.
+  iNamed "Hbar".
+  iExists s. iFrame "Hch".
+  iNamed "Hbar".
+  destruct s; try done.
+  - destruct (length buff <? cap)%Z.
+    + iNext. iIntros "Hoc".
+      iMod "Hmask".
+      iMod ("Hinv_close" with "[Hoc joinQ Hjoincount HsendNames_auth HworkerQ_wand Hbar HP Hprop Hfrag]") as "_".
+      {
+        iNext. iFrame.
+        iSplitL ""; first done.
+        rewrite big_sepL_app.
+        iFrame. simpl. done.
+      }
+      iModIntro. iApply "HΦ". done.
+    + iModIntro. done.
+  - iNext. iIntros "Hoc".
+    iMod "Hmask".
+    iMod ("Hinv_close" with "[Hoc joinQ Hjoincount HsendNames_auth HworkerQ_wand Hbar HP Hprop Hfrag]") as "_".
+    {
+      iNext. iFrame.
+      iSplitL ""; first done.
+      iFrame.
+    }
+    {
+      iModIntro.
+      unfold send_au_inner.
+      iInv "Hinv" as "Hinv_open2" "Hinv_close2".
+      iMod (lc_fupd_elim_later with "Hlc2 Hinv_open2") as "Hinv_open2".
+      iNamed "Hinv_open2".
+      iApply fupd_mask_intro; [solve_ndisj|iIntros "Hmask2"].
+      iNamed "Hbar".
+      iNext. iExists s. iFrame "Hch".
+      destruct s; try done.
+      - iIntros "Hoc". iMod "Hmask2".
+        iMod ("Hinv_close2" with "[Hoc joinQ Hjoincount HsendNames_auth HworkerQ_wand Hbar]") as "_".
+        {
+          iNext. iFrame.
+          iSplitL ""; first done.
+          iFrame.
+        }
+        iModIntro. iApply "HΦ". done.
+    }
+  - iNext. iIntros "Hoc". iMod "Hmask".
+    iMod ("Hinv_close" with "[Hoc joinQ Hjoincount HsendNames_auth HworkerQ_wand Hbar HP Hfrag Hprop]") as "_".
+    {
+      iNext. iFrame.
+      iSplitL ""; first done.
+      iFrame.
+    }
+    iModIntro. iApply "HΦ". done.
+Qed.
+
+Lemma wp_join_receive γ ch cap n Q :
+  {{{ £ 1 ∗ £ 1 ∗ £ 1 ∗ £ 1 ∗
+      is_pkg_init channel ∗
+      is_join γ ch cap ∗
+      join γ (S n) Q }}}
+    ch @ (ptrT.id channel.Channel.id) @ "Receive" #t #()
+  {{{ v, RET (v, #true); join γ n Q }}}.
+Proof.
+  iIntros (Φ) "(Hlc1 & Hlc2 & Hlc3 & Hlc4 & #Hinit & #Hjoin & HJoin & HJoinQ) HΦ".
+  iNamed "HJoinQ".
+  iDestruct "HJoinQ" as "[HspQ HQimp]".
+  rewrite /join /is_join.
+  iDestruct "Hjoin" as "[#Hch #Hinv]".
+  iApply (wp_Receive ch cap γ.(chan_name) with "[$Hinit $Hch]").
+  iInv "Hinv" as "Hinv_open" "Hinv_close".
+  iMod (lc_fupd_elim_later with "Hlc1 Hinv_open") as "Hinv_open".
+  iNamed "Hinv".
+  iDestruct "Hch" as "Hch1".
+  iNamed "Hinv_open".
+  iNamed "Hbar".
+  iNamed "Hbar".
+  iApply fupd_mask_intro; [solve_ndisj|iIntros "Hmask"].
+  iNext.
+  iFrame.
+  destruct s; try done.
+  - destruct buff as [|v_rcv msgs'] eqn:Hmsgs; simpl; try easy.
+    iDestruct "Hbar" as "[Hworker_P HPs]".
+    iNamed "Hworker_P".
+    iDestruct "Hworker_P" as "[Hworker_P HP]".
+    iIntros "Hoc".
+    iMod "Hmask".
+    iDestruct (ghost_var_agree with "Hjoincount HJoin") as %Hcount_eq.
+    assert (count = S n) as -> by done.
+    iMod (ghost_var_update_halves n with "Hjoincount HJoin") as "[Hjoincount HJoin_new]".
+    unfold worker.
+    iDestruct "Hworker_P" as (γS) "[Hfrag Hprop]".
+    iDestruct (auth_set_elem with "HsendNames_auth Hfrag") as %HγS_in_names.
+    iMod ((auth_set_dealloc γ.(worker_names_name) sendNames γS) with "[$HsendNames_auth $Hfrag]") as "HsendNames_auth".
+    iDestruct "HworkerQ_wand" as "[HworkerQ_wand|H2]".
+    {
+      iMod ("Hinv_close" with "[Hoc joinQ Hjoincount HsendNames_auth HworkerQ_wand HPs HP Hprop]") as "_".
+      {
+        iNext. unfold own_join. iExists workerQ. iExists (sendNames ∖ {[γS]}). iFrame.
+        iFrame "%".
+        iSplitL "".
+        {
+          iPureIntro.
+          rewrite size_difference.
+          { rewrite HnumWaiting. rewrite size_singleton. lia. }
+          set_solver.
+        }
+        iFrame.
+        iLeft. iFrame.
+        iIntros "H". iApply "HworkerQ_wand".
+        iApply (big_sepS_delete _ _ γS).
+        { auto. }
+        iFrame.
+      }
+      iApply "HΦ".
+      iModIntro. iFrame.
+    }
+    {
+      iCombine "H2 Hjoincount" as "H2".
+      iDestruct (ghost_var_valid_2 with "HJoin_new H2") as "[%Hvalid _]".
+      done.
+    }
+  - iMod "Hmask".
+    iIntros "Hoc".
+    iMod ("Hinv_close" with "[Hoc joinQ Hjoincount HsendNames_auth HworkerQ_wand]") as "_".
+    {
+      iNext. iFrame. done.
+    }
+    iModIntro.
+    iInv "Hinv" as "Hinv_open" "Hinv_close".
+    iMod (lc_fupd_elim_later with "Hlc2 Hinv_open") as "Hinv_open".
+    iApply fupd_mask_intro; [solve_ndisj|iIntros "Hmask2"].
+    iDestruct "Hbar" as "_".
+    iNamed "Hinv_open".
+    iNamed "Hbar".
+    iNext. iFrame.
+    destruct s; try done.
+    + iIntros "Hoc".
+      iMod "Hmask2".
+      iDestruct (ghost_var_agree with "Hjoincount HJoin") as %Hcount_eq.
+      assert (count0 = S n) as -> by done.
+      iMod (ghost_var_update_halves n with "Hjoincount HJoin") as "[Hjoincount HJoin_new]".
+      unfold worker. iNamed "Hbar".
+      iDestruct "Hbar" as "[Hy HP]".
+      iDestruct "Hy" as (γS0) "[Hfrag Hprop]".
+      iDestruct (auth_set_elem with "HsendNames_auth Hfrag") as %HγS_in_names.
+      iMod ((auth_set_dealloc γ.(worker_names_name) sendNames0 γS0) with "[$HsendNames_auth $Hfrag]") as "HsendNames_auth".
+      iDestruct "HworkerQ_wand" as "[HworkerQ_wand|H2]".
+      {
+        iMod ("Hinv_close" with "[Hoc joinQ Hjoincount HsendNames_auth HworkerQ_wand HP Hprop]") as "_".
+        {
+          iNext. unfold own_join. iExists workerQ0. iExists (sendNames0 ∖ {[γS0]}). iFrame.
+          iFrame "%".
+          iSplitL "".
+          {
+            iPureIntro.
+            rewrite size_difference.
+            { rewrite HnumWaiting0. rewrite size_singleton. lia. }
+            set_solver.
+          }
+          iSplitL "HworkerQ_wand HP Hprop".
+          {
+            iLeft.
+            iIntros "H". iApply "HworkerQ_wand".
+            iApply (big_sepS_delete _ _ γS0).
+            { done. }
+            iFrame.
+          }
+          done.
+        }
+        iModIntro. iApply "HΦ". iFrame.
+      }
+      {
+        iCombine "H2 Hjoincount" as "H2".
+        iDestruct (ghost_var_valid_2 with "HJoin_new H2") as "[%Hvalid _]".
+        done.
+      }
+  - iNamed "Hbar".
+    iDestruct "Hbar" as "[Hworker_P HPs]".
+    iNamed "Hworker_P".
+    iDestruct "Hworker_P" as "[Hworker_P HP]".
+    iIntros "Hoc".
+    iMod "Hmask".
+    iDestruct (ghost_var_agree with "Hjoincount HJoin") as %Hcount_eq.
+    assert (count = S n) as -> by done.
+    iMod (ghost_var_update_halves n with "Hjoincount HJoin") as "[Hjoincount HJoin_new]".
+    unfold worker.
+    iDestruct (auth_set_elem with "HsendNames_auth Hworker_P") as %HγS_in_names.
+    iMod ((auth_set_dealloc γ.(worker_names_name) sendNames γS) with "[$HsendNames_auth $Hworker_P]") as "HsendNames_auth".
+    iDestruct "HworkerQ_wand" as "[HworkerQ_wand|H2]".
+    {
+      iMod ("Hinv_close" with "[Hoc joinQ Hjoincount HsendNames_auth HworkerQ_wand HP HPs]") as "_".
+      {
+        iNext. unfold own_join. iExists workerQ. iExists (sendNames ∖ {[γS]}). iFrame.
+        iFrame "%".
+        iSplitL "".
+        {
+          iPureIntro.
+          rewrite size_difference.
+          { rewrite HnumWaiting. rewrite size_singleton. lia. }
+          set_solver.
+        }
+        iFrame.
+        iSplitR "".
+        {
+          iLeft.
+          iIntros "H". iApply "HworkerQ_wand".
+          iApply (big_sepS_delete _ _ γS).
+          { auto. }
+          iFrame.
+          done.
+        }
+        { done. }
+      }
+      iApply "HΦ".
+      iModIntro. iFrame.
+    }
+    iCombine "H2 Hjoincount" as "H2".
+    iDestruct (ghost_var_valid_2 with "HJoin_new H2") as "[%Hvalid _]".
+    done.
+Qed.
+
+Lemma join_finish γ ch cap Q :
+  £ 1 -∗
+  is_join γ ch cap -∗
+  join γ 0 Q ={⊤}=∗
+  ▷ Q.
+Proof.
+  iIntros "Hlc (#Hjoinch & #Hjoininv) Hjoin".
+  rewrite /is_join /join.
+  iDestruct "Hjoin" as "[Hcount Hrest]".
+  iDestruct "Hrest" as (Q') "[Hsp HQimp]".
+  iInv "Hjoininv" as "Hinv_open" "Hinv_close".
+  iNamed "Hinv_open".
+  iMod (lc_fupd_elim_later with "Hlc Hinv_open") as "Hinv_open".
+  iNamed "Hinv_open".
+  iNamed "Hbar".
+  iDestruct (ghost_var_agree with "Hjoincount Hcount") as %Hcount_eq.
+  assert (count = 0) as -> by done.
+  replace sendNames with (∅: gset gname).
+  {
+    iDestruct (saved_prop_agree with "joinQ Hsp") as "#HQeq".
+    rewrite big_sepS_empty.
+    iDestruct "HworkerQ_wand" as "[HworkerQ_wand|H2]".
+    {
+      iMod ("Hinv_close" with "[joinQ Hch Hjoincount HsendNames_auth Hcount Hbar]").
+      {
+        iNext.
+        iFrame. iPureIntro. set_solver.
+      }
+      iModIntro. iApply "HQimp".
+      iAssert (emp)%I as "Hemp"; iFrame.
+      iDestruct ("HworkerQ_wand" with "Hemp") as "Hnew".
+      iNext.
+      iRewrite "HQeq" in "Hnew". iFrame.
+    }
+    {
+      iCombine "H2 Hjoincount" as "H2".
+      iDestruct (ghost_var_valid_2 with "Hcount H2") as "[%Hvalid _]".
+      done.
+    }
+  }
+  {
+    rewrite size_empty_iff in HnumWaiting. set_solver.
+  }
+Qed.
+
+End proof.
+End join.
+
+#[global] Typeclasses Opaque join.is_join join.join join.worker.

--- a/new/proof/github_com/goose_lang/goose/model/channel/protocol/mpmc/contrib.v
+++ b/new/proof/github_com/goose_lang/goose/model/channel/protocol/mpmc/contrib.v
@@ -1,0 +1,206 @@
+(*
+   This file is part of Actris (https://gitlab.mpi-sws.org/iris/actris).
+
+   Copyright (c) Actris developers and contributors.
+   Distributed under the terms of the BSD 3-Clause License; see
+   https://gitlab.mpi-sws.org/iris/actris/-/blob/master/LICENSE
+   for the full license text.
+*)
+
+(** This file defines the "authoritative contribution ghost theory" for tracking
+contributions made by clients towards a shared concurrent effort. Compared to
+the paper, the construction is defined over a user-given carrier camera [A],
+instead of multisets.
+
+This ghost theory construction exposes two connectives:
+
+- [server γ n v]: keeps track of the number of active clients [n] and the total
+  amount of resources hold by all clients [x : A].
+- [client γ x]: keeps track of the resources [x : A] hold by a single client.
+
+The intended use case is to allocate a [client] for each thread that contributes
+to a channel endpoint, where the resources [x] are owned by the thread, that is
+later used in the protocol.
+
+To model this ghost theory construction, we use the camera
+[auth (option (csum (positive * A) (excl unit)))]. *)
+From iris.base_logic Require Export base_logic lib.iprop lib.own.
+From iris.proofmode Require Export proofmode.
+From iris.algebra Require Import excl auth csum gmultiset numbers.
+From iris.algebra Require Export local_updates.
+
+Class contributionG Σ (A : ucmra) `{!CmraDiscrete A} := {
+  contribution_inG :: inG Σ
+    (authR (optionUR (csumR (prodR positiveR A) (exclR unitO))))
+}.
+
+Definition server `{contributionG Σ A} (γ : gname) (n : nat) (x : A) : iProp Σ :=
+  (if decide (n = O)
+   then x ≡ ε ∗ own γ (● (Some (Cinr (Excl ())))) ∗ own γ (◯ (Some (Cinr (Excl ()))))
+   else own γ (● (Some (Cinl (Pos.of_nat n, x)))))%I.
+Global Typeclasses Opaque server.
+Global Instance: Params (@server) 6 := {}.
+
+Definition client `{contributionG Σ A} (γ : gname) (x : A) : iProp Σ :=
+  own γ (◯ (Some (Cinl (1%positive, x)))).
+Global Typeclasses Opaque client.
+Global Instance: Params (@client) 5 := {}.
+
+Section contribution.
+  Context `{contributionG Σ A}.
+  Implicit Types x y : A.
+
+  Global Instance server_ne γ n : NonExpansive (server γ n).
+  Proof. solve_proper. Qed.
+  Global Instance server_proper γ n : Proper ((≡) ==> (≡)) (server γ n).
+  Proof. apply (ne_proper _). Qed.
+  Global Instance client_ne γ : NonExpansive (client γ).
+  Proof. solve_proper. Qed.
+  Global Instance client_proper γ : Proper ((≡) ==> (≡)) (client γ).
+  Proof. apply (ne_proper _). Qed.
+
+  Lemma contribution_init : ⊢ |==> ∃ γ, server γ 0 ε.
+  Proof.
+    iMod (own_alloc (● (Some (Cinr (Excl ()))) ⋅ ◯ (Some (Cinr (Excl ())))))
+      as (γ) "[Hγ Hγ']"; first by apply auth_both_valid_2.
+    iExists γ. rewrite /server. by case_decide; auto with iFrame.
+  Qed.
+
+  Lemma server_0_empty γ x : server γ 0 x -∗ x ≡ ε.
+  Proof. rewrite /server. case_decide=> //. iIntros "[? _] //". Qed.
+
+  Lemma server_1_agree γ x y : server γ 1 x -∗ client γ y -∗ ⌜ x ≡ y ⌝.
+  Proof.
+    rewrite /server /client. case_decide=> //. iIntros "Hs Hc".
+    iCombine "Hs Hc"
+      gives %[[[_ ?]%(inj Cinl)|Hincl]%Some_included _]%auth_both_valid_discrete; first done.
+    move: Hincl. rewrite Cinl_included prod_included /= pos_included=> -[? _].
+    by destruct (Pos.lt_irrefl 1).
+  Qed.
+
+  Lemma server_valid γ n x : server γ n x -∗ ✓ x.
+  Proof.
+    rewrite /server. case_decide.
+    - iDestruct 1 as (->) "_". iPureIntro. apply ucmra_unit_valid.
+    - iIntros "Hs". iDestruct (own_valid with "Hs") as %Hv.
+      move: Hv. by rewrite auth_auth_valid=> -[??].
+  Qed.
+
+  Lemma client_valid γ x : client γ x -∗ ✓ x.
+  Proof.
+    rewrite /client. iIntros "Hs". iDestruct (own_valid with "Hs") as %Hv.
+    move: Hv. by rewrite auth_frag_valid=> -[??].
+  Qed.
+
+  Lemma server_agree γ n x y : server γ n x -∗ client γ y -∗ ⌜ n ≠ 0 ∧ y ≼ x ⌝.
+  Proof.
+    rewrite /server /client. iIntros "Hs Hc". case_decide; subst.
+    - iDestruct "Hs" as "(_ & _ & Hc')".
+      by iCombine "Hc Hc'" gives %?%auth_frag_op_valid_1.
+    - iCombine "Hs Hc"
+        gives %[[[??]%(inj Cinl)|Hincl]%Some_included _]%auth_both_valid_discrete.
+      { setoid_subst. by destruct n. }
+      move: Hincl. rewrite Cinl_included prod_included /= pos_included=> -[??].
+      by destruct n.
+  Qed.
+
+  Lemma alloc_client γ n x :
+    server γ n x ==∗ server γ (S n) x ∗ client γ ε.
+  Proof.
+    rewrite /server /client.
+    destruct (decide (n = 0)) as [->|?]; case_decide; try done.
+    - iDestruct 1 as (Hx) "[Hs Hc]"; setoid_subst.
+      iMod (own_update_2 with "Hs Hc") as "[$ $]"; last done.
+      apply auth_update, option_local_update.
+      eapply transitivity with (Cinl (Pos.of_nat 1, ε), Cinl (1%positive, ε)).
+      { apply exclusive_local_update. split; [done|]. apply ucmra_unit_valid. }
+      by apply csum_local_update_l, prod_local_update_2.
+    - iIntros "Hs". iMod (own_update with "Hs") as "[$ $]"; last done.
+      eapply auth_update_alloc, transitivity
+        with (Some (Cinl (Pos.of_nat (S n), x)), Some (Cinl (1%positive, ε))).
+      { rewrite Nat2Pos.inj_succ // -Pos.add_1_l -{2}(left_id ε op x).
+        rewrite -(right_id _ _ (Some (Cinl (1%positive, _)))).
+        rewrite pair_op Cinl_op Some_op. apply op_local_update_discrete.
+        intros [??]; split=> //=. by rewrite left_id. }
+      by apply option_local_update, csum_local_update_l, prod_local_update_2.
+  Qed.
+
+  Lemma dealloc_client γ n x :
+    server γ n x -∗ client γ ε ==∗ server γ (pred n) x.
+  Proof.
+    iIntros "Hs Hc". iDestruct (server_valid with "Hs") as %Hv.
+    destruct (decide (n = 1)) as [->|]; simpl.
+    - iDestruct (server_1_agree with "Hs Hc") as %->.
+      rewrite /server /client; repeat case_decide=> //.
+      iMod (own_update_2 with "Hs Hc") as "[$ $]"; last done.
+      by apply auth_update, option_local_update, (replace_local_update _ _).
+    - iDestruct (server_agree with "Hs Hc") as %[? [z ->]].
+      rewrite /server /client. destruct n as [|[|n]]; case_decide=>//=.
+      iApply (own_update_2 with "Hs Hc"). apply auth_update_dealloc.
+      rewrite -(right_id _ _ (Some (Cinl (1%positive, _)))).
+      rewrite Nat2Pos.inj_succ // -Pos.add_1_l.
+      rewrite pair_op Cinl_op Some_op left_id. apply (cancel_local_update _ _ _).
+  Qed.
+
+  Lemma update_client γ n x y x' y' :
+    (x,y) ~l~> (x',y') →
+    server γ n x -∗ client γ y ==∗ server γ n x' ∗ client γ y'.
+  Proof.
+    iIntros (?) "Hs Hc". destruct (decide (n = 1)) as [->|]; simpl.
+    - iDestruct (server_1_agree with "Hs Hc") as %?; setoid_subst.
+      rewrite /server /client. case_decide=> //=.
+      iMod (own_update_2 with "Hs Hc") as "[$ $]"; last done.
+      by apply auth_update, option_local_update,
+        csum_local_update_l, prod_local_update_2.
+    - iDestruct (server_agree with "Hs Hc") as %[??].
+      rewrite /server /client. case_decide=> //=.
+      iMod (own_update_2 with "Hs Hc") as "[$ $]"; last done.
+      by apply auth_update, option_local_update,
+        csum_local_update_l, prod_local_update_2.
+  Qed.
+
+  (** Derived *)
+  Lemma contribution_init_pow n :
+    ⊢ |==> ∃ γ, server γ n ε ∗ [∗] replicate n (client γ ε).
+  Proof.
+    iMod (contribution_init) as (γ) "Hs". iExists γ.
+    iInduction n as [|n] "IH"; simpl; first by iFrame.
+    iMod ("IH" with "Hs") as "[Hs $]". by iApply alloc_client.
+  Qed.
+
+  Lemma server_client_op_false γ  x y1 y2 :
+  server γ 1 x -∗ client γ y1 -∗ client γ y2 -∗ False.
+Proof.
+  rewrite /server /client. case_decide=> //.
+  iIntros "Hs Hc1 Hc2".
+  iCombine "Hc1 Hc2" as "Hcs".
+  iCombine "Hs Hcs" gives %Hvalid.
+  exfalso.
+  move: Hvalid.
+  rewrite auth_both_valid_discrete.
+  intros [Hincl Hvalid].
+  rewrite Some_op in Hincl.
+  apply Some_included in Hincl as [Heq|Hincl].
+  - (* Equality *)
+    (* Heq : Cinl (1, y1) ⋅ Cinl (1, y2) ≡ Cinl (1, x) *)
+
+    apply (inj Cinl) in Heq.
+    simpl in Heq.
+    destruct Heq as [Hpos _].
+    simpl in Hpos.
+(* Now Hpos : 1%positive ⋅ 1%positive ≡ Pos.of_nat 1 *)
+(* But Pos.of_nat 1 = 1%positive *)
+replace (Pos.of_nat 1) with (1%positive) in Hpos by reflexivity.
+(* So 1 ⋅ 1 ≡ 1, but ⋅ on positive is + *)
+(* So 1 + 1 = 2 ≠ 1 *)
+done.
+  - (* Inclusion *)
+
+    move: Hincl.
+    rewrite Cinl_included prod_included /= pos_included.
+    intros [Hpos _].
+replace (Pos.of_nat 1) with (1%positive) in Hpos by reflexivity.
+done.
+Qed.
+
+End contribution.

--- a/new/proof/github_com/goose_lang/goose/model/channel/protocol/mpmc/mpmc.v
+++ b/new/proof/github_com/goose_lang/goose/model/channel/protocol/mpmc/mpmc.v
@@ -1,0 +1,962 @@
+Require Import New.proof.proof_prelude.
+From New.proof.github_com.goose_lang.goose.model.channel Require Export chan_au_send chan_au_recv chan_au_base chan_init contrib.
+From iris.algebra Require Import gmultiset big_op.
+From iris.algebra Require Export csum.
+From stdpp Require Export sets gmultiset countable.
+From Perennial.algebra Require Import ghost_var.
+
+(** * Multiple Producer Multiple Consumer (MPMC) Channel Verification
+
+    Key insight: Each producer/consumer tracks their OWN history using multisets.
+
+    - Producer i has sent: sent_i (a multiset)
+    - Consumer j has received: recv_j (a multiset)
+    - Invariant: ⊎ sent_i = ⊎ recv_j ⊎ inflight
+
+    Uses contribution theory with gmultisetR V.
+    Requires Countable V because gmultiset V = gmap V positive.
+*)
+
+Section mpmc.
+Context `{hG: heapGS Σ, !ffi_semantics _ _}.
+Context `{!chanGhostStateG Σ V}.
+Context `{!IntoVal V}.
+Context `{!IntoValTyped V t}.
+Context `{!globalsGS Σ} {go_ctx : GoContext}.
+Context `{!Countable V}.
+Context `{!contributionG Σ (gmultisetR V)}.
+Context `{!ghost_varG Σ bool}.
+
+Record mpmc_names := {
+  chan_name : chan_names;
+  mpmc_sent_name : gname;
+  mpmc_recv_name : gname;
+  mpmc_closed_name : gname
+}.
+
+Lemma delete_client γ n (X Y Z: gmultiset V) :
+  n > 0 ->
+  Z ⊆ Y →
+  server γ n X -∗ client γ Y ==∗ server γ n (X ∖ Z) ∗ client γ (Y ∖ Z).
+Proof.
+  iIntros (Hgt HsubY) "Hs Hc".
+  unfold server, client.
+  destruct (decide (n = 0)); try lia.
+  assert (Hupd : (X, Y) ~l~> ((X ∖ Z), (Y ∖ Z))).
+  {
+    apply gmultiset_local_update_dealloc.
+    done.
+  }
+  Local Notation B := (exclR unitO).
+  iMod (own_update_2 with "Hs Hc") as "[$ $]"; last done.
+  by apply auth_update, option_local_update,
+        csum_local_update_l, prod_local_update_2.
+Qed.
+
+Lemma delete_client_for_good γ n (X Y Z: gmultiset V) :
+  n > 0 ->
+  server γ n X -∗ client γ Y ==∗ server γ n (X ∖ Y) ∗ client γ (∅: gmultiset V) ∗ ⌜Y ⊆ X⌝.
+Proof.
+  iIntros (Hgt) "Hs Hc".
+  iDestruct ((server_agree γ n X Y) with "Hs Hc") as %H.
+  destruct H as [H1 H2].
+  assert (Y ⊆ X).
+  {
+    apply gmultiset_included.
+    exact H2.
+  }
+  iFrame "%".
+  replace (∅) with (Y ∖ Y).
+  {
+    iApply ((delete_client _ _ X Y Y) with "Hs Hc"); first done.
+    done.
+  }
+  {
+    apply gmultiset_difference_diag.
+  }
+Qed.
+
+Lemma bulk_cancel_and_dealloc γ n (X Y: gmultiset V) :
+  n > 0 ->
+  server γ n X -∗ client γ Y ==∗ server γ (pred n) (X ∖ Y) ∗ ⌜Y ⊆ X⌝.
+Proof.
+  iIntros (Hgt) "Hs Hc".
+  iDestruct (delete_client_for_good with "Hs Hc") as ">(H1 & H2 & %H3)"; try done.
+  iFrame "%".
+  iApply (dealloc_client with "H1 H2").
+Qed.
+
+Lemma bulk_dealloc_all γ (X : gmultiset V) (ys : list (gmultiset V)) :
+  let Z_total := fold_right (λ acc y, acc ⊎ y) ∅ ys in
+  server γ (length ys) X -∗ ([∗ list] y_i ∈ ys, client γ y_i) ==∗ server γ 0 (∅: (gmultiset V)) ∗ ⌜X = Z_total⌝.
+Proof.
+  intros.
+  iIntros "Hs Hcs".
+  destruct ys.
+  {
+    simpl. simpl in Z_total. subst Z_total. unfold server. simpl.
+    iDestruct "Hs" as "(%H1 & H2 & H3)".
+    iModIntro. iFrame. iPureIntro. done.
+  }
+  iInduction ys as [|g' ys'] "IH" forall (X).
+  - simpl. iDestruct "Hcs" as "[Hc _]".
+    simpl in Z_total. subst Z_total. replace (g ⊎ ∅) with g by multiset_solver.
+    iDestruct ((server_1_agree γ X g) with "[$Hs] [$Hc]") as %H.
+    iSplitR "".
+    {
+      iDestruct ((bulk_cancel_and_dealloc γ 1 X g) with "Hs Hc") as ">Hnew"; try lia.
+      replace g with X by multiset_solver. simpl. replace ∅ with (X ∖ X) by multiset_solver.
+      iModIntro. iDestruct "Hnew" as "[H1 %H2]". iFrame.
+    }
+    iModIntro. iPureIntro. multiset_solver.
+  - iDestruct (big_sepL_cons with "Hcs") as "[Hc Hcs]".
+    iDestruct (big_sepL_cons with "Hcs") as "[Hc' Hcs]".
+    iAssert ([∗ list] y ∈ (g :: ys'), client γ y)%I with "[Hc Hcs]" as "Hcs".
+    { iFrame. }
+    iDestruct ((bulk_cancel_and_dealloc γ (length (g :: g' :: ys')) X g') with "Hs Hc'") as ">Hnew".
+    {
+      rewrite length_cons. lia.
+    }
+    replace (Init.Nat.pred (length (g :: g' :: ys'))) with (length (g :: ys')) by done.
+    iSpecialize ("IH" $! (X ∖ g')).
+    iDestruct "Hnew" as "[Hnew %Hss]".
+    iApply "IH" in "Hnew".
+    iMod ("Hnew" with "Hcs") as "[Hr %HX]".
+    iFrame.
+    iModIntro. subst Z_total.
+    iPureIntro.
+    simpl.
+    simpl in HX.
+    replace X with ((X ∖ g') ⊎ g').
+    { rewrite HX. multiset_solver. }
+    simpl.
+    symmetry.
+    rewrite gmultiset_disj_union_comm.
+    apply gmultiset_disj_union_difference.
+    done.
+Qed.
+
+Lemma bulk_alloc_clients γ (ys : list (gmultiset V)) :
+  let X := fold_right (λ acc y, acc ⊎ y) ∅ ys in
+  server γ 0 (∅: gmultiset V) ==∗ server γ (length ys) X ∗ ([∗ list] y_i ∈ ys, client γ y_i).
+Proof.
+  intros X.
+  iIntros "Hs".
+  iInduction ys as [|y ys'] "IH".
+  { simpl. iModIntro. iFrame. }
+  {
+    simpl. simpl in X.
+    iMod ("IH" with "Hs") as "[Hs Hcs']".
+    iMod (alloc_client with "Hs") as "[Hs Hc]".
+    iMod ((update_client γ _ (foldr (λ acc y0 : gmultiset V, acc ⊎ y0) ∅ ys') ε X y) with "Hs Hc") as "[Hs Hc]".
+    {
+      subst X.
+      rewrite comm.
+      apply gmultiset_local_update.
+      multiset_solver.
+    }
+    iModIntro. iFrame.
+  }
+Qed.
+
+Lemma auth_map_agree γ (X : gmultiset V) (ys : list (gmultiset V)) :
+  let Z_total := fold_right (λ acc y, acc ⊎ y) ∅ ys in
+  server γ (length ys) X -∗ ([∗ list] y_i ∈ ys, client γ y_i) ==∗
+    ⌜X = Z_total⌝ ∗ server γ (length ys) X ∗ ([∗ list] y_i ∈ ys, client γ y_i).
+Proof.
+  intros Z_total.
+  iIntros "Hs Hcs".
+  iMod (bulk_dealloc_all with "Hs Hcs") as "[Hnew %HX]".
+  iFrame "%".
+  iMod (bulk_alloc_clients γ ys with "Hnew") as "[Hs Hcs]".
+  iFrame. subst X. iFrame.
+  iModIntro. done.
+Qed.
+
+Definition is_closed (γ:mpmc_names) : iProp Σ :=
+  ghost_var γ.(mpmc_closed_name) DfracDiscarded true.
+
+Global Instance is_closed_persistent γ : Persistent (is_closed γ) := _.
+
+Definition mpmc_producer (γ:mpmc_names) (sent:gmultiset V) : iProp Σ :=
+  client γ.(mpmc_sent_name) sent.
+
+Definition mpmc_consumer (γ:mpmc_names) (received:gmultiset V) : iProp Σ :=
+  client γ.(mpmc_recv_name) received.
+
+Definition inflight_mset (s : chan_rep.t V) : gmultiset V :=
+  match s with
+  | chan_rep.Buffered buff => list_to_set_disj buff
+  | chan_rep.SndPending v | chan_rep.SndCommit v => {[+ v +]}
+  | chan_rep.Closed draining => list_to_set_disj draining
+  | _ => ∅
+  end.
+
+Definition is_mpmc (γ:mpmc_names) (ch:loc) (n_prod n_cons:nat)
+                   (P: V → iProp Σ) (R: gmultiset V → iProp Σ) : iProp Σ :=
+  ∃ (cap:Z),
+    is_channel ch cap γ.(chan_name) ∗
+    inv nroot (
+      ∃ s sent recv,
+        "Hch" ∷ own_channel ch cap s γ.(chan_name) ∗
+        "HsentI" ∷ server γ.(mpmc_sent_name) n_prod sent ∗
+        "HrecvI" ∷ server γ.(mpmc_recv_name) n_cons recv ∗
+        "%Hrel" ∷ ⌜sent = recv ⊎ inflight_mset s⌝ ∗
+        "%Hncons" ∷ ⌜n_cons > 0⌝ ∗
+        "%Hnprod" ∷ ⌜n_prod > 0⌝ ∗
+        "Hclosed" ∷ (match s with
+                     | chan_rep.Closed [] => ghost_var γ.(mpmc_closed_name) DfracDiscarded true
+                     | _ => ghost_var γ.(mpmc_closed_name) (DfracOwn 1) false
+                     end) ∗
+        (match s with
+        | chan_rep.Buffered buff => "Hbuff" ∷ [∗ list] v ∈ buff, P v
+        | chan_rep.SndPending v => "HPv" ∷ P v
+        | chan_rep.SndCommit v => "HPv" ∷ P v
+        | chan_rep.Closed [] =>
+            "%Hsent_recv" ∷ ⌜sent = recv⌝ ∗
+            "Hprods" ∷ (∃ prods : list (gmultiset V), ⌜length prods = n_prod⌝ ∗
+                        [∗ list] s_i ∈ prods, mpmc_producer γ s_i) ∗
+            "HR_or_clients" ∷ (R sent ∨ (∃ conss : list (gmultiset V), ⌜length conss = n_cons⌝ ∗
+                                          [∗ list] r_i ∈ conss, mpmc_consumer γ r_i))
+        | chan_rep.Closed draining =>
+            "Hdraining" ∷ ([∗ list] v ∈ draining, P v) ∗
+            "Hprods" ∷ (∃ prods : list (gmultiset V), ⌜length prods = n_prod⌝ ∗
+                        [∗ list] s_i ∈ prods, mpmc_producer γ s_i) ∗
+            "HR" ∷ R sent
+        | _ => True
+        end)
+    )%I.
+
+Lemma gmultiset_disj_union_local_update (X Y Z : gmultiset V) :
+  (X, Y) ~l~> (X ⊎ Z, Y ⊎ Z).
+Proof.
+  apply gmultiset_local_update_alloc.
+Qed.
+
+Lemma start_mpmc ch (P : V → iProp Σ) (R : gmultiset V → iProp Σ) γ (n_prod n_cons : nat) cap s:
+  match s with
+  | chan_rep.Buffered [] => True
+  | chan_rep.Idle => True
+  | _ => False
+  end ->
+  n_prod > 0 ->
+  n_cons > 0 ->
+  is_channel ch cap γ -∗
+  (own_channel ch cap s γ) ={⊤}=∗
+  (∃ γmpmc, is_mpmc γmpmc ch n_prod n_cons P R ∗
+            ([∗ list] _ ∈ seq 0 n_prod, mpmc_producer γmpmc ∅) ∗
+            ([∗ list] _ ∈ seq 0 n_cons, mpmc_consumer γmpmc ∅)).
+Proof.
+  intros Hs Hprod Hcons.
+  iIntros "#Hch Hoc".
+  iMod (ghost_var_alloc false) as (γclosed) "Hclosed".
+  iMod (contribution_init_pow n_prod (A := gmultisetR V)) as (γsent) "[HsentAuth HsentFrags]".
+  iMod (contribution_init_pow n_cons (A := gmultisetR V)) as (γrecv) "[HrecvAuth HrecvFrags]".
+  set (γmpmc := {| chan_name := γ;
+                   mpmc_sent_name := γsent;
+                   mpmc_recv_name := γrecv;
+                   mpmc_closed_name := γclosed |}).
+  destruct s; try done.
+  {
+    destruct buff; try done.
+    iMod (inv_alloc nroot _ (
+      ∃ s sent recv,
+        "Hch" ∷ own_channel ch cap s γ ∗
+        "HsentI" ∷ server γsent n_prod sent ∗
+        "HrecvI" ∷ server γrecv n_cons recv ∗
+        "%Hrel" ∷ ⌜sent = recv ⊎ inflight_mset s⌝ ∗
+        "%Hncons" ∷ ⌜n_cons > 0⌝ ∗
+        "%Hnprod" ∷ ⌜n_prod > 0⌝ ∗
+        "Hclosed" ∷ (match s with
+                     | chan_rep.Closed [] => ghost_var γclosed DfracDiscarded true
+                     | _ => ghost_var γclosed (DfracOwn 1) false
+                     end) ∗
+        (match s with
+        | chan_rep.Buffered buff => "Hbuff" ∷ [∗ list] v ∈ buff, P v
+        | chan_rep.SndPending v => "HPv" ∷ P v
+        | chan_rep.SndCommit v => "HPv" ∷ P v
+        | chan_rep.Closed [] =>
+            "%Hsent_recv" ∷ ⌜sent = recv⌝ ∗
+            "Hprods" ∷ (∃ prods : list (gmultiset V), ⌜length prods = n_prod⌝ ∗
+                        [∗ list] s_i ∈ prods, mpmc_producer γmpmc s_i) ∗
+            "HR_or_clients" ∷ (R sent ∨ (∃ conss : list (gmultiset V), ⌜length conss = n_cons⌝ ∗
+                                          [∗ list] r_i ∈ conss, mpmc_consumer γmpmc r_i))
+        | chan_rep.Closed draining =>
+            "Hdraining" ∷ ([∗ list] v ∈ draining, P v) ∗
+            "Hprods" ∷ (∃ prods : list (gmultiset V), ⌜length prods = n_prod⌝ ∗
+                        [∗ list] s_i ∈ prods, mpmc_producer γmpmc s_i) ∗
+            "HR" ∷ R sent
+        | _ => True
+        end)
+    ) with "[Hoc HsentAuth HrecvAuth Hclosed]") as "#Hinv".
+    {
+      iNext.
+      iFrame.
+      iSplitL ""; first done.
+      iFrame.
+      simpl. done.
+    }
+    iModIntro. iExists γmpmc.
+    unfold is_mpmc. iFrame. iSplitL "". { iExists cap. iFrame "#". }
+    iSplitL "HsentFrags".
+    - unfold mpmc_producer.
+      assert (∅ = (ε : gmultiset V)) as Heq by reflexivity.
+      rewrite -Heq.
+      iApply big_sepL_replicate.
+      rewrite length_seq. done.
+    - unfold mpmc_consumer.
+      assert (∅ = (ε : gmultiset V)) as Heq by reflexivity.
+      rewrite -Heq.
+      iApply big_sepL_replicate.
+      rewrite length_seq. done.
+  }
+  {
+    iMod (inv_alloc nroot _ (
+      ∃ s sent recv,
+        "Hch" ∷ own_channel ch cap s γ ∗
+        "HsentI" ∷ server γsent n_prod sent ∗
+        "HrecvI" ∷ server γrecv n_cons recv ∗
+        "%Hrel" ∷ ⌜sent = recv ⊎ inflight_mset s⌝ ∗
+        "%Hncons" ∷ ⌜n_cons > 0⌝ ∗
+        "%Hnprod" ∷ ⌜n_prod > 0⌝ ∗
+        "Hclosed" ∷ (match s with
+                     | chan_rep.Closed [] => ghost_var γclosed DfracDiscarded true
+                     | _ => ghost_var γclosed (DfracOwn 1) false
+                     end) ∗
+        (match s with
+        | chan_rep.Buffered buff => "Hbuff" ∷ [∗ list] v ∈ buff, P v
+        | chan_rep.SndPending v => "HPv" ∷ P v
+        | chan_rep.SndCommit v => "HPv" ∷ P v
+        | chan_rep.Closed [] =>
+            "%Hsent_recv" ∷ ⌜sent = recv⌝ ∗
+            "Hprods" ∷ (∃ prods : list (gmultiset V), ⌜length prods = n_prod⌝ ∗
+                        [∗ list] s_i ∈ prods, mpmc_producer γmpmc s_i) ∗
+            "HR_or_clients" ∷ (R sent ∨ (∃ conss : list (gmultiset V), ⌜length conss = n_cons⌝ ∗
+                                          [∗ list] r_i ∈ conss, mpmc_consumer γmpmc r_i))
+        | chan_rep.Closed draining =>
+            "Hdraining" ∷ ([∗ list] v ∈ draining, P v) ∗
+            "Hprods" ∷ (∃ prods : list (gmultiset V), ⌜length prods = n_prod⌝ ∗
+                        [∗ list] s_i ∈ prods, mpmc_producer γmpmc s_i) ∗
+            "HR" ∷ R sent
+        | _ => True
+        end)
+    ) with "[Hoc HsentAuth HrecvAuth Hclosed]") as "#Hinv".
+    {
+      iNext.
+      iFrame.
+      iSplitL ""; first done.
+      iFrame.
+      iPureIntro. done.
+    }
+    iModIntro. iExists γmpmc.
+    unfold is_mpmc. iFrame. iSplitL "". { iExists cap. iFrame "#". }
+    iSplitL "HsentFrags".
+    - unfold mpmc_producer.
+      assert (∅ = (ε : gmultiset V)) as Heq by reflexivity.
+      rewrite -Heq.
+      iApply big_sepL_replicate.
+      rewrite length_seq. done.
+    - unfold mpmc_consumer.
+      assert (∅ = (ε : gmultiset V)) as Heq by reflexivity.
+      rewrite -Heq.
+      iApply big_sepL_replicate.
+      rewrite length_seq. done.
+  }
+Qed.
+
+Lemma wp_mpmc_send γ ch (n_prod n_cons:nat) (P : V → iProp Σ) (R : gmultiset V → iProp Σ)
+                   (sent : gmultiset V) (v : V) :
+  {{{ £ 1 ∗ £ 1 ∗ £ 1 ∗ £ 1 ∗ is_pkg_init channel ∗ is_mpmc γ ch n_prod n_cons P R ∗
+      mpmc_producer γ sent ∗
+      P v }}}
+    ch @ (ptrT.id channel.Channel.id) @ "Send" #t #v
+  {{{ RET #(); mpmc_producer γ (sent ⊎ {[+ v +]}) }}}.
+Proof.
+  iIntros (Φ) "(Hlc1 & Hlc2 & Hlc3 & Hlc4 & #Hinit & #Hmpmc & Hprod & HP) Hcont".
+  unfold is_mpmc. iNamed "Hmpmc". iDestruct "Hmpmc" as "[#Hchan Hinv]".
+  iApply (wp_Send ch cap v γ.(chan_name) with "[$Hchan $Hinit]").
+  iMod (lc_fupd_elim_later with "Hlc1 Hcont") as "Hcont".
+  iInv "Hinv" as "Hinv_open" "Hinv_close".
+  iMod (lc_fupd_elim_later with "Hlc2 Hinv_open") as "Hinv_open".
+  iNamed "Hinv_open".
+  iDestruct (server_agree with "HsentI Hprod") as %[Hn_pos Hsub].
+  iApply fupd_mask_intro; [solve_ndisj|iIntros "Hmask"].
+  iNext. iFrame "Hch".
+  destruct s; try done.
+  {
+    destruct (length buff <? cap)%Z eqn:Hlen; [|done].
+    iIntros "Hoc".
+    unfold mpmc_producer.
+    iMod (update_client γ.(mpmc_sent_name) n_prod sent0 sent
+                       (sent0 ⊎ {[+ v +]}) (sent ⊎ {[+ v +]})
+           with "HsentI Hprod") as "[HsentI Hprod]".
+    { apply gmultiset_disj_union_local_update. }
+    iMod "Hmask".
+    iNamed "Hinv_open".
+    iMod ("Hinv_close" with "[Hoc HsentI HrecvI Hclosed HP Hbuff]") as "_".
+    {
+      iNext. iExists (chan_rep.Buffered (buff ++ [v])), (sent0 ⊎ {[+ v +]}), recv.
+      iFrame "Hoc HsentI HrecvI Hclosed".
+      iSplitR.
+      {
+        iPureIntro. rewrite Hrel. unfold inflight_mset.
+        rewrite list_to_set_disj_app /=.
+        rewrite gmultiset_disj_union_right_id gmultiset_disj_union_assoc.
+        reflexivity.
+      }
+      simpl. iFrame "Hbuff HP".
+      iFrame. simpl.
+      iPureIntro.
+      done.
+    }
+    iModIntro. by iApply "Hcont".
+  }
+  {
+    iIntros "Hoc".
+    unfold mpmc_producer.
+    iMod (update_client γ.(mpmc_sent_name) n_prod sent0 sent
+                       (sent0 ⊎ {[+ v +]}) (sent ⊎ {[+ v +]})
+           with "HsentI Hprod") as "[HsentI Hprod]".
+    { apply gmultiset_disj_union_local_update. }
+    iMod "Hmask".
+    iNamed "Hoc".
+    iAssert (own_channel ch cap (chan_rep.SndPending v) γ.(chan_name))%I
+      with "[Hchanrepfrag]" as "Hoc".
+    { iFrame. iPureIntro. unfold chan_cap_valid. done. }
+    iMod ("Hinv_close" with "[Hoc HsentI HrecvI Hclosed HP]") as "_".
+    {
+      iNext. iExists (chan_rep.SndPending v), (sent0 ⊎ {[+ v +]}), recv.
+      iFrame "Hoc HsentI HrecvI Hclosed".
+      iSplitR.
+      { iPureIntro. rewrite Hrel. unfold inflight_mset. set_solver. }
+      simpl. iFrame "HP".
+      iPureIntro. done.
+    }
+    iModIntro. unfold send_au_inner.
+    iInv "Hinv" as "Hinv_open2" "Hinv_close2".
+    iMod (lc_fupd_elim_later with "Hlc3 Hinv_open2") as "Hinv_open2".
+    iNamed "Hinv_open2".
+    destruct s; try (iFrame;done).
+    {
+      iApply fupd_mask_intro; [solve_ndisj | iIntros "Hmask1"].
+      iNext.
+      iNamed "Hinv_open2".
+      iFrame.
+    }
+    {
+      iApply fupd_mask_intro; [solve_ndisj | iIntros "Hmask1"].
+      iNext.
+      iNamed "Hinv_open2".
+      iFrame.
+    }
+    {
+      iApply fupd_mask_intro; [solve_ndisj | iIntros "Hmask1"].
+      iNext.
+      iNamed "Hinv_open2".
+      iFrame.
+    }
+    {
+      iApply fupd_mask_intro; [solve_ndisj | iIntros "Hmask1"].
+      iNext.
+      iNamed "Hinv_open2".
+      iFrame.
+    }
+    {
+      iApply fupd_mask_intro; [solve_ndisj | iIntros "Hmask1"].
+      iNext.
+      iNamed "Hinv_open2".
+      iFrame.
+    }
+    {
+      iApply fupd_mask_intro; [solve_ndisj | iIntros "Hmask1"].
+      iNext.
+      iNamed "Hinv_open2".
+      iFrame.
+      iIntros "Hoc".
+      iMod "Hmask1".
+      iMod ("Hinv_close2" with "[HsentI HrecvI Hoc Hclosed]") as "_".
+      {
+        iNext. iExists chan_rep.Idle, sent1, recv0.
+        iFrame "Hoc HsentI HrecvI Hclosed".
+        iPureIntro. rewrite Hrel0. simpl. done.
+      }
+      iModIntro. by iApply "Hcont".
+    }
+    {
+      destruct draining.
+      - iNamed "Hinv_open2".
+        unfold mpmc_producer.
+        iNamed "Hprods".
+        iDestruct "Hprods" as "[%H1 Hprods]".
+        subst n_prod.
+        iExists (chan_rep.Closed []).
+        iFrame "Hch".
+        iMod (bulk_dealloc_all with "HsentI Hprods") as "[Hserver0 _]".
+        iFrame.
+        destruct prods as [|p ps]; first (simpl in *;lia).
+        iDestruct (server_agree with "Hserver0 Hprod") as %[Hcontra _].
+        done.
+      - iNamed "Hinv_open2".
+        unfold mpmc_producer.
+        iNamed "Hprods".
+        iDestruct "Hprods" as "[%H1 Hprods]".
+        subst n_prod.
+        iMod (bulk_dealloc_all with "HsentI Hprods") as "[Hserver0 _]".
+        iFrame.
+        destruct prods as [|p ps]; first (simpl in *;lia).
+        iDestruct (server_agree with "Hserver0 Hprod") as %[Hcontra _].
+        done.
+    }
+  }
+  {
+    iMod "Hmask".
+    iNamed "Hinv_open". iIntros "Hoc".
+    iMod (update_client γ.(mpmc_sent_name) n_prod sent0 sent
+                       (sent0 ⊎ {[+ v +]}) (sent ⊎ {[+ v +]})
+           with "HsentI Hprod") as "[HsentI Hprod]".
+    { apply gmultiset_disj_union_local_update. }
+    iMod ("Hinv_close" with "[Hoc HsentI HrecvI Hclosed HP]") as "_".
+    {
+      iNext. iFrame. iFrame "HP". iFrame. iPureIntro. subst sent0.
+      unfold inflight_mset. simpl. set_solver.
+    }
+    {
+      iModIntro. iApply "Hcont". iFrame.
+    }
+  }
+  {
+    destruct draining.
+    - iNamed "Hinv_open".
+      unfold mpmc_producer.
+      iNamed "Hprods".
+      iDestruct "Hprods" as "[%H1 Hprods]".
+      subst n_prod.
+      iMod (bulk_dealloc_all with "HsentI Hprods") as "[Hserver0 _]".
+      iFrame.
+      destruct prods as [|p ps]; first (simpl in *;lia).
+      iDestruct (server_agree with "Hserver0 Hprod") as %[Hcontra _].
+      done.
+    - iNamed "Hinv_open".
+      unfold mpmc_producer.
+      iNamed "Hprods".
+      iDestruct "Hprods" as "[%H1 Hprods]".
+      subst n_prod.
+      iMod (bulk_dealloc_all with "HsentI Hprods") as "[Hserver0 _]".
+      iFrame.
+      destruct prods as [|p ps]; first (simpl in *;lia).
+      iDestruct (server_agree with "Hserver0 Hprod") as %[Hcontra _].
+      done.
+  }
+Qed.
+
+Lemma wp_mpmc_receive γ ch (n_prod n_cons:nat) (P : V → iProp Σ) (R : gmultiset V → iProp Σ)
+                      (received : gmultiset V) :
+  {{{ £ 1 ∗ £ 1 ∗ £ 1 ∗ £ 1 ∗ is_pkg_init channel ∗ is_mpmc γ ch n_prod n_cons P R ∗
+      mpmc_consumer γ received }}}
+    ch @ (ptrT.id channel.Channel.id) @ "Receive" #t #()
+  {{{ (v:V) (ok:bool), RET (#v, #ok);
+      if ok
+      then P v ∗ mpmc_consumer γ (received ⊎ {[+ v +]})
+      else is_closed γ ∗ mpmc_consumer γ received }}}.
+Proof.
+  iIntros (Φ) "(Hlc1 & Hlc2 & Hlc3 & Hlc4 & #Hinit & #Hmpmc & Hcons) Hcont".
+  unfold is_mpmc. iNamed "Hmpmc".
+  iDestruct "Hmpmc" as "[Hchan Hinv]".
+  iApply (wp_Receive ch cap γ.(chan_name) with "[$Hinit $Hchan]").
+  iInv "Hinv" as "Hinv_open" "Hinv_close".
+  iMod (lc_fupd_elim_later with "Hlc1 Hinv_open") as "Hinv_open".
+  iNamed "Hinv_open".
+  iDestruct (server_agree with "HrecvI Hcons") as %[Hn_pos Hsub].
+  unfold rcv_au_slow.
+  iExists s. iFrame "Hch".
+  iApply fupd_mask_intro; [solve_ndisj|iIntros "Hmask"].
+  iNext. iFrame.
+  destruct s; try done.
+  {
+    destruct buff as [|v rest].
+    { done. }
+    {
+      iIntros "Hoc".
+      unfold mpmc_consumer.
+      iMod (update_client γ.(mpmc_recv_name) n_cons recv received (recv ⊎ {[+ v +]})
+                                (received ⊎ {[+ v +]})
+             with "HrecvI Hcons") as "[HrecvI_new Hcons_new]".
+      { apply gmultiset_disj_union_local_update. }
+      iDestruct (big_sepL_cons with "Hinv_open") as "[HPv Hrest]".
+      iMod "Hmask".
+      iMod ("Hinv_close" with "[Hoc HsentI HrecvI_new Hrest Hclosed]") as "_".
+      {
+        iNext.
+        iFrame.
+        iFrame "%".
+        iFrame.
+        iPureIntro.
+        rewrite Hrel. simpl. unfold inflight_mset.
+        rewrite -gmultiset_disj_union_assoc.
+        reflexivity.
+      }
+      iModIntro. iApply "Hcont". iFrame.
+    }
+  }
+  {
+    iIntros "Hoc".
+    iMod "Hmask".
+    iMod ("Hinv_close" with "[Hoc HsentI HrecvI Hclosed]") as "_".
+    {
+      iNext.
+      iFrame. iFrame "%". iFrame.
+    }
+    iModIntro. unfold rcv_au_inner.
+    iInv "Hinv" as "Hinv_open2" "Hinv_close2".
+    iMod (lc_fupd_elim_later with "Hlc2 Hinv_open2") as "Hinv_open2".
+    iNamed "Hinv_open2".
+    iDestruct (server_agree with "HrecvI Hcons") as %[_ Hsub2].
+    unfold rcv_au_slow.
+    iExists s. iFrame "Hch".
+    iApply fupd_mask_intro; [solve_ndisj|iIntros "Hmask1"].
+    iNext.
+    destruct s; try done.
+    {
+      iMod (update_client γ.(mpmc_recv_name) n_cons recv0 received (recv0 ⊎ {[+ v +]})
+                                (received ⊎ {[+ v +]})
+             with "HrecvI Hcons") as "[HrecvI_new Hcons_new]".
+      { apply gmultiset_disj_union_local_update. }
+      iIntros "Hoc".
+      iMod "Hmask1".
+      iMod ("Hinv_close2" with "[HsentI HrecvI_new Hoc Hclosed]") as "_".
+      {
+        iNext.
+        iFrame. iFrame "Hclosed". iPureIntro.
+        rewrite Hrel0. simpl. rewrite gmultiset_disj_union_right_id. done.
+      }
+      iModIntro. iApply "Hcont". iFrame.
+    }
+    {
+      destruct draining as [|v rest]; last done.
+      iIntros "Hoc".
+      iMod "Hmask1".
+      simpl.
+      iDestruct "Hinv_open2" as "[%Hprod2 HR]".
+      iNamed "HR".
+      iDestruct "HR_or_clients" as "[HR_final | Hconss]".
+      - iDestruct "Hclosed" as "#Hclosed".
+        iMod ("Hinv_close2" with "[Hoc HsentI HrecvI Hprods HR_final]") as "_".
+        {
+          iNext. iExists (chan_rep.Closed []), sent0, recv0.
+          iFrame "#". iFrame. iFrame "%".
+        }
+        iModIntro.
+        iApply "Hcont".
+        iFrame "Hcons".
+        unfold is_closed.
+        iFrame.
+        iFrame "Hclosed".
+      - unfold mpmc_consumer.
+        iNamed "Hconss".
+        iDestruct "Hconss" as "[%H1 Hcons1]".
+        subst n_cons.
+        iMod (bulk_dealloc_all with "HrecvI Hcons1") as "[Hserver0 _]".
+        iFrame.
+        destruct conss as [|p ps]; first (simpl in *;lia).
+        iDestruct (server_agree with "Hserver0 Hcons") as %[Hcontra _].
+        done.
+    }
+  }
+  {
+    iIntros "Hcont1".
+    iMod "Hmask".
+    iMod (update_client γ.(mpmc_recv_name) n_cons recv received (recv ⊎ {[+ v +]})
+                                (received ⊎ {[+ v +]})
+             with "HrecvI Hcons") as "[HrecvI_new Hcons_new]".
+    { apply gmultiset_disj_union_local_update. }
+    iMod ("Hinv_close" with "[HsentI HrecvI_new Hcont1 Hclosed]") as "_".
+    {
+      iNext.
+      iFrame. iFrame "Hclosed". iPureIntro.
+      unfold inflight_mset in *. rewrite gmultiset_disj_union_right_id. done.
+    }
+    iModIntro. iApply "Hcont". iFrame.
+  }
+  {
+    destruct draining as [|v rest].
+    {
+      iIntros "Hoc".
+      iMod "Hmask".
+      simpl.
+      iDestruct "Hinv_open" as "[%Hprod2 HR]".
+      iNamed "HR".
+      iDestruct "HR_or_clients" as "[HR_final | Hconss]".
+      - iDestruct "Hclosed" as "#Hclosed".
+        iMod ("Hinv_close" with "[Hoc HsentI HrecvI Hprods HR_final]") as "_".
+        {
+          iNext.
+          iFrame.
+          iFrame "#". iFrame. iFrame "%".
+        }
+        iModIntro.
+        iApply "Hcont".
+        iFrame "Hcons".
+        unfold is_closed.
+        iFrame.
+        iFrame "Hclosed".
+      - unfold mpmc_consumer.
+        iNamed "Hconss".
+        iDestruct "Hconss" as "[%H1 Hcons1]".
+        subst n_cons.
+        iMod (bulk_dealloc_all with "HrecvI Hcons1") as "[Hserver0 _]".
+        iFrame.
+        destruct conss as [|p ps]; first (simpl in *;lia).
+        iDestruct (server_agree with "Hserver0 Hcons") as %[Hcontra _].
+        done.
+    }
+    {
+      iIntros "Hoc".
+      iMod (update_client _ _ recv received (recv ⊎ {[+ v +]}) (received ⊎ {[+ v +]})
+             with "HrecvI Hcons") as "[HrecvI_new Hcons_new]".
+      { apply gmultiset_disj_union_local_update. }
+      iMod "Hmask".
+      iDestruct "Hinv_open" as "(Hrest & Hmp & HR)".
+      {
+        iDestruct (big_sepL_cons with "Hrest") as "[HPv Hrest2]".
+        destruct rest.
+        {
+          iMod (ghost_var_update true with "Hclosed") as "Hclosed".
+          iMod (ghost_var_persist with "Hclosed") as "#Hclosed'".
+          iMod ("Hinv_close" with "[HsentI HrecvI_new Hoc HR Hmp]") as "_".
+          {
+            iNext.
+            iFrame. iFrame "#". iFrame "HR".
+            iFrame "Hmp". iPureIntro.
+            split.
+            {
+              rewrite Hrel. unfold inflight_mset.
+              rewrite list_to_set_disj_cons list_to_set_disj_nil.
+              rewrite gmultiset_disj_union_right_id -gmultiset_disj_union_assoc.
+              set_solver.
+            }
+            set_solver.
+          }
+          iModIntro. iApply "Hcont". iFrame.
+        }
+        {
+          iMod ("Hinv_close" with "[HsentI HrecvI_new Hoc Hrest2 HR Hmp Hclosed]") as "_".
+          {
+            iNext.
+            iFrame. iFrame "HR".
+            iFrame.
+            iFrame "%".
+            iFrame "#".
+            iPureIntro.
+            rewrite Hrel. unfold inflight_mset.
+            rewrite !list_to_set_disj_cons -!gmultiset_disj_union_assoc.
+            reflexivity.
+          }
+          iModIntro. iApply "Hcont". iFrame.
+        }
+      }
+    }
+  }
+Qed.
+
+Lemma wp_mpmc_close γ ch (n_prod n_cons:nat) P R (producers : list (gmultiset V)):
+  length producers = n_prod →
+  {{{ £ 1 ∗ £ 1 ∗ £ 1 ∗ £ 1 ∗ is_pkg_init channel ∗ is_mpmc γ ch n_prod n_cons P R ∗
+      ([∗ list] s_i ∈ producers, mpmc_producer γ s_i) ∗
+      R (foldr (⊎) ∅ producers) }}}
+    ch @ (ptrT.id channel.Channel.id) @ "Close" #t #()
+  {{{ RET #(); True }}}.
+Proof.
+  intros.
+  iIntros "(Hlc1 & Hlc2 & Hlc3 & Hlc4 & #Hinit & #Hmpmc & Hprods & HR) Hcont".
+  unfold is_mpmc. iNamed "Hmpmc".
+  iDestruct "Hmpmc" as "[Hchan Hinv]".
+  iApply (wp_Close ch cap γ.(chan_name) with "[$Hinit $Hchan]").
+  iMod (lc_fupd_elim_later with "Hlc1 Hcont") as "Hcont".
+  iInv "Hinv" as "Hinv_open" "Hinv_close".
+  iMod (lc_fupd_elim_later with "Hlc2 Hinv_open") as "Hinv_open".
+  iNamed "Hinv_open".
+  destruct s; try done.
+  - iExists (chan_rep.Buffered buff). iFrame "Hch".
+    iApply fupd_mask_intro; [solve_ndisj|]. iIntros "Hmask". iNext.
+    iIntros "Hoc".
+    iMod "Hmask".
+    iFrame.
+    destruct buff as [|v rest].
+    + iMod (ghost_var_update true with "Hclosed") as "Hclosed".
+      iMod (ghost_var_persist with "Hclosed") as "#Hclosed'".
+      assert (inflight_mset (chan_rep.Buffered []) = ∅) as Hempty.
+      { simpl. reflexivity. }
+      rewrite Hempty in Hrel.
+      rewrite right_id in Hrel.
+      unfold mpmc_producer.
+      subst n_prod.
+      iMod (auth_map_agree γ.(mpmc_sent_name) sent producers with "[$HsentI] [$Hprods]") as "(%Hsent_eq & HsentI & Hprods)".
+      replace (foldr (λ acc y : gmultiset V, acc ⊎ y) ∅ producers) with sent by done.
+      iMod ("Hinv_close" with "[Hoc HsentI HrecvI Hinv_open Hprods HR]") as "_".
+      {
+        iNext.
+        iFrame. iFrame "#".
+        simpl.
+        iFrame "%".
+        rewrite right_id.
+        iSplitL ""; first done.
+        unfold inflight_mset in Hrel.
+        simpl in Hrel.
+        iFrame.
+        done.
+      }
+      iModIntro.
+      iApply "Hcont". done.
+    + iFrame.
+      unfold mpmc_producer.
+      subst n_prod.
+      iMod (auth_map_agree γ.(mpmc_sent_name) sent producers with "[$HsentI] [$Hprods]") as "(%Hsent_eq & HsentI & Hprods)".
+      replace (foldr (λ acc y : gmultiset V, acc ⊎ y) ∅ producers) with sent by done.
+      iMod ("Hinv_close" with "[Hoc HsentI HrecvI Hinv_open Hprods Hclosed HR]") as "_".
+      {
+        iModIntro. iFrame.
+        iFrame "%#". iFrame.
+        done.
+      }
+      iModIntro.
+      iApply "Hcont". done.
+  - iApply fupd_mask_intro; [solve_ndisj|]. iIntros "Hmask". iNext.
+    iFrame. iIntros "Hoc".
+    iMod (ghost_var_update true with "Hclosed") as "Hclosed".
+    iMod (ghost_var_persist with "Hclosed") as "#Hclosed'".
+    iMod "Hmask".
+    unfold mpmc_producer.
+    subst n_prod.
+    iMod (auth_map_agree γ.(mpmc_sent_name) sent producers with "[$HsentI] [$Hprods]") as "(%Hsent_eq & HsentI & Hprods)".
+    replace (foldr (λ acc y : gmultiset V, acc ⊎ y) ∅ producers) with sent by done.
+    iMod ("Hinv_close" with "[Hoc HsentI HrecvI Hclosed' Hprods HR]") as "_".
+    {
+      iNext.
+      iExists (chan_rep.Closed []), sent, recv.
+      iFrame "Hoc HsentI HrecvI".
+      iSplitR; first by iPureIntro; rewrite Hrel; simpl.
+      iFrame "Hclosed'".
+      simpl. iFrame.
+      iPureIntro.
+      unfold inflight_mset in Hrel.
+      simpl in Hrel.
+      subst sent.
+      multiset_solver.
+    }
+    iModIntro. iApply "Hcont". done.
+  - unfold mpmc_producer.
+    subst n_prod.
+    iMod (auth_map_agree γ.(mpmc_sent_name) sent producers with "[$HsentI] [$Hprods]") as "(%Hsent_eq & HsentI & Hprods)".
+    replace (foldr (λ acc y : gmultiset V, acc ⊎ y) ∅ producers) with sent by done.
+    iApply fupd_mask_intro; [solve_ndisj|]. iIntros "Hmask". iNext.
+    iFrame.
+  - unfold mpmc_producer.
+    subst n_prod.
+    iMod (auth_map_agree γ.(mpmc_sent_name) sent producers with "[$HsentI] [$Hprods]") as "(%Hsent_eq & HsentI & Hprods)".
+    replace (foldr (λ acc y : gmultiset V, acc ⊎ y) ∅ producers) with sent by done.
+    iApply fupd_mask_intro; [solve_ndisj|]. iIntros "Hmask". iNext.
+    iFrame.
+  - unfold mpmc_producer.
+    subst n_prod.
+    iMod (auth_map_agree γ.(mpmc_sent_name) sent producers with "[$HsentI] [$Hprods]") as "(%Hsent_eq & HsentI & Hprods)".
+    replace (foldr (λ acc y : gmultiset V, acc ⊎ y) ∅ producers) with sent by done.
+    iApply fupd_mask_intro; [solve_ndisj|]. iIntros "Hmask". iNext.
+    iFrame.
+  - unfold mpmc_producer.
+    subst n_prod.
+    iMod (auth_map_agree γ.(mpmc_sent_name) sent producers with "[$HsentI] [$Hprods]") as "(%Hsent_eq & HsentI & Hprods)".
+    replace (foldr (λ acc y : gmultiset V, acc ⊎ y) ∅ producers) with sent by done.
+    iApply fupd_mask_intro; [solve_ndisj|]. iIntros "Hmask". iNext.
+    iFrame.
+  - unfold mpmc_producer.
+    subst n_prod.
+    iMod (auth_map_agree γ.(mpmc_sent_name) sent producers with "[$HsentI] [$Hprods]") as "(%Hsent_eq & HsentI & Hprods)".
+    replace (foldr (λ acc y : gmultiset V, acc ⊎ y) ∅ producers) with sent by done.
+    destruct draining.
+    {
+      iDestruct "Hprods" as "Hprods1".
+      iNamed "Hinv_open". iNamed "Hprods".
+      iDestruct "Hprods" as "[%Hgood H2]".
+      replace (length producers) with (length prods) by done.
+      iMod (auth_map_agree γ.(mpmc_sent_name) sent prods with "[$HsentI] [$H2]") as
+        "(%Hsent_eq1 & HsentI2 & Hprods2)".
+      replace (foldr (λ acc y : gmultiset V, acc ⊎ y) ∅ producers) with sent by done.
+      iMod (bulk_dealloc_all with "HsentI2 Hprods2") as "[Hserver0 _]".
+      destruct producers as [|p ps]; first (simpl in *;lia).
+      iDestruct (big_sepL_cons with "Hprods1") as "[Hp _]".
+      iExFalso.
+      iDestruct (server_agree with "Hserver0 Hp") as %[Hcontra _].
+      lia.
+    }
+    {
+      iDestruct "Hprods" as "Hprods1". iDestruct "HR" as "HR1".
+      iNamed "Hinv_open". iNamed "Hprods".
+      iDestruct "Hprods" as "[%Hgood H2]".
+      replace (length producers) with (length prods) by done.
+      iMod (auth_map_agree γ.(mpmc_sent_name) sent prods with "[$HsentI] [$H2]") as
+        "(%Hsent_eq1 & HsentI2 & Hprods2)".
+      replace (foldr (λ acc y : gmultiset V, acc ⊎ y) ∅ producers) with sent by done.
+      iMod (bulk_dealloc_all with "HsentI2 Hprods2") as "[Hserver0 _]".
+      destruct producers as [|p ps]; first (simpl in *;lia).
+      iDestruct (big_sepL_cons with "Hprods1") as "[Hp _]".
+      iExFalso.
+      iDestruct (server_agree with "Hserver0 Hp") as %[Hcontra _].
+      lia.
+    }
+Qed.
+
+Lemma mpmc_get_final_resource
+  γ ch (n_prod n_cons : nat) P R (consumers : list (gmultiset V)) :
+  length consumers = n_cons →
+  £ 1 -∗
+  is_mpmc γ ch n_prod n_cons P R -∗
+  is_closed γ -∗
+  ([∗ list] r_i ∈ consumers, mpmc_consumer γ r_i)
+  ={⊤}=∗ R (foldr disj_union ∅ consumers).
+Proof.
+  iIntros (Hlen) "Hlc #Hmpmc #Hclosed Hcons".
+  unfold is_mpmc. iDestruct "Hmpmc" as (cap) "[#Hchan #Hinv]".
+  iInv "Hinv" as "Hinv_open" "Hinv_close".
+  iNamed "Hinv_open".
+  iMod (lc_fupd_elim_later with "Hlc Hinv_open") as "Hinv_open".
+  iDestruct "Hclosed" as "#Hclosed1".
+  iNamed "Hinv_open".
+  unfold is_closed.
+  destruct s; try (iExFalso;(iDestruct (ghost_var_agree with "Hclosed1 Hclosed") as %Hbad);done).
+  destruct draining.
+  - iNamed "Hinv_open".
+    iDestruct "HR_or_clients" as "[HR | Hconss]".
+    + unfold mpmc_consumer.
+      subst n_cons.
+      iMod (auth_map_agree γ.(mpmc_recv_name) recv consumers with "HrecvI Hcons") as
+        "(%Hrecv_eq & HrecvI & Hcons)". rewrite Hsent_recv. rewrite Hrecv_eq.
+      iFrame.
+      iMod ("Hinv_close" with "[Hch HsentI HrecvI Hclosed Hprods Hcons]") as "_".
+      {
+        iNext. iFrame "#%". iFrame.
+        rewrite Hsent_recv. rewrite Hrecv_eq.
+        iFrame.
+        iRight.
+        iFrame.
+        done.
+      }
+      iModIntro. done.
+    + unfold mpmc_consumer.
+      subst n_cons.
+      iMod (auth_map_agree γ.(mpmc_recv_name) recv consumers with "HrecvI Hcons") as
+        "(%Hrecv_eq & HrecvI & Hcons)". rewrite Hsent_recv. rewrite Hrecv_eq.
+      iFrame.
+      iExFalso.
+      iDestruct "Hconss" as (conss Hlen_conss) "Hconss_list".
+      iMod (bulk_dealloc_all with "HrecvI Hcons") as "[Hserver0 _]".
+      destruct conss as [|c cs]; first (simpl in *;lia).
+      iDestruct (big_sepL_cons with "Hconss_list") as "[Hc _]".
+      iDestruct (server_agree with "Hserver0 Hc") as %[Hcontra _].
+      lia.
+  - iNamed "Hinv_open".
+    unfold is_mpmc.
+    iDestruct (ghost_var_agree with "Hclosed1 Hclosed") as %Hclosed_eq.
+    done.
+Qed.
+
+End mpmc.


### PR DESCRIPTION
Finish remaining idioms with the exception of DSP:

MPMC - multi producer/consumer, has set instead of list and allows splitting handles for producing/consuming but otherwise similar to SPSC

Done - For using a channel as a close-only broadcast notification, 1 "notifier" and many "notifiees" that get disjoint or duplicable resources on close 

Join - Similar to waitgroup, use as a countdown latch to join 1 or more goroutines 