### PR TITLE
Start dsp example proof

### DIFF
--- a/new/proof/github_com/goose_lang/goose/testdata/examples/channel.v
+++ b/new/proof/github_com/goose_lang/goose/testdata/examples/channel.v
@@ -28,6 +28,23 @@ Proof.
   wp_start. iApply "HΦ". done.
 Qed.
 
+Lemma wp_DSPExample :
+  {{{ is_pkg_init chan_spec_raw_examples ∗ is_pkg_init channel }}}
+    @! chan_spec_raw_examples.DSPExampleX #()
+  {{{ RET #(W64 42); True }}}.
+Proof.
+  wp_start. wp_auto. wp_pures.
+   wp_apply (wp_NewChannelRef (t:=ptrT) 0);first done.
+  iIntros (c). iIntros (γ).
+  iIntros "[#Hic Hoc]".
+  wp_auto.
+   wp_apply (wp_NewChannelRef (t:=(structT [])) 0);first done.
+  iIntros (signal). iIntros (γ').
+  iIntros "[#Hicsignal Hocsignal]".
+  wp_auto.
+Admitted.
+
+
 Lemma wp_HelloWorldAsync :
   {{{ is_pkg_init chan_spec_raw_examples ∗ is_pkg_init channel  }}}
     @! chan_spec_raw_examples.HelloWorldAsyncX #()


### PR DESCRIPTION
Start example proof for this code:

// prog3 from Actris 2.0 intro: https://arxiv.org/pdf/2010.15030
func DSPExampleX() int {
	c := channel.NewChannelRef[*int](0)
	signal := channel.NewChannelRef[struct{}](0)
	go func() {
		ptr := c.ReceiveDiscardOk() // receive pointer ℓ
		*ptr = *ptr + 2             // update *ℓ to *ℓ + 2
		signal.Send(struct{}{})     // send signal ()
	}()
	val := 40
	ptr := &val               // create reference ℓ := ref 40
	c.Send(ptr)               // send pointer ℓ
	signal.ReceiveDiscardOk() // receive signal
	return *ptr               // dereference to get 42
}
