### PR TITLE
Add a wp_end tactic

### DIFF
--- a/new/proof/github_com/goose_lang/goose/model/channel/protocol/dsp/dsp_proofmode.v
+++ b/new/proof/github_com/goose_lang/goose/model/channel/protocol/dsp/dsp_proofmode.v
@@ -210,7 +210,7 @@ Tactic Notation "wp_recv_core" tactic3(tac_intros) "as" tactic3(tac) :=
     |tc_solve
     |pm_reduce; simpl; tac_intros;
      tac Hnew;
-     wp_end]
+     wp_finish]
   | _ => fail "wp_recv: not a 'wp'"
   end.
 
@@ -290,7 +290,7 @@ Tactic Notation "wp_send_core" tactic3(tac_exist) "with" constr(pat) :=
         | |- False => fail "wp_send:" Hs' "not found"
         | _ => notypeclasses refine (conj (eq_refl _) (conj _ _));
                 [iFrame Hs_frame; solve_done d
-                |wp_end]
+                |wp_finish]
         end]
      | _ => fail "wp_send: not a 'wp'"
      end

--- a/src/goose_lang/lib/typed_mem/typed_mem.v
+++ b/src/goose_lang/lib/typed_mem/typed_mem.v
@@ -565,12 +565,12 @@ Tactic Notation "wp_load" :=
         |fail 1 "wp_load: cannot find 'load_ty' in" e];
       [tc_solve
       |solve_pointsto ()
-      |wp_end] ) ||
+      |wp_finish] ) ||
     ( first
         [reshape_expr e ltac:(fun K e' => eapply (tac_wp_load_ty_persistent _ _ _ _ K))
         |fail 1 "wp_load: cannot find 'load_ty' in" e];
       [solve_pointsto ()
-      |wp_end] )
+      |wp_finish] )
   | _ => fail "wp_load: not a 'wp'"
   end.
 
@@ -588,6 +588,6 @@ Tactic Notation "wp_store" :=
     |tc_solve
     |solve_pointsto ()
     |pm_reflexivity
-    |first [wp_pure_filter (Rec BAnon BAnon _); wp_rec |wp_end]]
+    |first [wp_pure_filter (Rec BAnon BAnon _); wp_rec |wp_finish]]
   | _ => fail "wp_store: not a 'wp'"
   end.

--- a/src/goose_lang/lib/wp_store.v
+++ b/src/goose_lang/lib/wp_store.v
@@ -38,6 +38,6 @@ Tactic Notation "wp_untyped_store" :=
     [tc_solve
     |solve_pointsto ()
     |pm_reflexivity
-    |first [wp_pure_filter (Rec BAnon BAnon _); wp_rec|wp_end]]
+    |first [wp_pure_filter (Rec BAnon BAnon _); wp_rec|wp_finish]]
   | _ => fail "wp_untyped_store: not a 'wp'"
   end.

--- a/src/goose_lang/proofmode.v
+++ b/src/goose_lang/proofmode.v
@@ -99,7 +99,7 @@ Ltac solve_bi_true :=
       | |- envs_entails _ (bi_wand (bi_pure True) _)  => apply tac_wp_true_elim
       end.
 
-Ltac wp_end :=
+Ltac wp_finish :=
   wp_expr_simpl;      (* simplify occurences of subst/fill *)
   try wp_value_head;  (* in case we have reached a value, get rid of the WP *)
   pm_prettify.        (* prettify ▷s caused by [MaybeIntoLaterNEnvs] and
@@ -125,7 +125,7 @@ Tactic Notation "wp_pure1_maybe_lc" constr(maybeCredName) tactic3(filter) :=
       [tc_solve                         (* PureExec *)
       |try solve_vals_compare_safe      (* The pure condition for PureExec -- handles trivial goals, including [vals_compare_safe] *)
       |tc_solve                         (* IntoLaters *)
-      | pm_reduce; wp_end  (* new goal *)
+      | pm_reduce; wp_finish  (* new goal *)
       ] | fail "wp_pure: first pattern match is not a redex" ]
           (* "3" is carefully chose to bubble up just enough to not break out of the [repeat] in [wp_pures] *)
    ) || fail "wp_pure: cannot find redex pattern"
@@ -158,7 +158,7 @@ Tactic Notation "wp_pure_filter" open_constr(efoc) :=
 Ltac wp_pures :=
   iStartProof;
   lazymatch goal with
-    | |- envs_entails ?envs (wp ?s ?E (Val ?v) ?Q) => wp_end
+    | |- envs_entails ?envs (wp ?s ?E (Val ?v) ?Q) => wp_finish
     | |- _ =>
       (* The `;[]` makes sure that no side-condition magically spawns. *)
       (* TODO: do this in one go, without [repeat]. *)
@@ -409,12 +409,12 @@ Tactic Notation "wp_untyped_load" :=
         |fail 1 "wp_untyped_load: cannot find 'Load' in" e];
       [tc_solve
       |solve_pointsto ()
-      |wp_end] ) ||
+      |wp_finish] ) ||
     ( first
         [reshape_expr e ltac:(fun K e' => eapply (tac_wp_load_persistent _ _ _ _ K))
         |fail 1 "wp_untyped_load: cannot find 'Load' in" e];
       [solve_pointsto ()
-      |wp_end] )
+      |wp_finish] )
   | _ => fail "wp_untyped_load: not a 'wp'"
   end.
 
@@ -432,8 +432,8 @@ Tactic Notation "wp_cmpxchg" "as" simple_intropattern(H1) "|" simple_intropatter
     |solve_pointsto ()
     |pm_reflexivity
     |try solve_vals_compare_safe
-    |intros H1; wp_end
-    |intros H2; wp_end]
+    |intros H1; wp_finish
+    |intros H2; wp_finish]
   | _ => fail "wp_cmpxchg: not a 'wp'"
   end.
 
@@ -451,7 +451,7 @@ Tactic Notation "wp_cmpxchg_fail" :=
     |solve_pointsto ()
     |try (simpl; congruence) (* value inequality *)
     |try solve_vals_compare_safe
-    |wp_end]
+    |wp_finish]
   | _ => fail "wp_cmpxchg_fail: not a 'wp'"
   end.
 
@@ -470,6 +470,6 @@ Tactic Notation "wp_cmpxchg_suc" :=
     |pm_reflexivity
     |try (simpl; congruence) (* value equality *)
     |try solve_vals_compare_safe
-    |wp_end]
+    |wp_finish]
   | _ => fail "wp_cmpxchg_suc: not a 'wp'"
   end.


### PR DESCRIPTION
This is a simple shorthand that makes a big difference in simple, introductory examples. It also spares typing HΦ.

The tactic is fairly conservative: it does `iApply "HΦ"` and then further automation only to solve the goal. We could add `iFrame "#*"` (which helps in a few cases) and we could consider running `iFrame` even if it doesn't the solve the goal, although technically I think iFrame is unsafe, especially in instantiating evars.