### PR TITLE
Update elimination stack proof to use time.After

### DIFF
--- a/new/generatedproof/github_com/goose_lang/goose/testdata/examples/channel.v
+++ b/new/generatedproof/github_com/goose_lang/goose/testdata/examples/channel.v
@@ -92,7 +92,6 @@ Context `{ffi_syntax}.
 Record t := mk {
   base' : loc;
   exchanger' : loc;
-  timeout' : time.Duration.t;
 }.
 End def.
 End EliminationStack.
@@ -106,19 +105,18 @@ Global Instance EliminationStack_wf : struct.Wf chan_spec_raw_examples.Eliminati
 Proof. apply _. Qed.
 
 Global Instance settable_EliminationStack : Settable EliminationStack.t :=
-  settable! EliminationStack.mk < EliminationStack.base'; EliminationStack.exchanger'; EliminationStack.timeout' >.
+  settable! EliminationStack.mk < EliminationStack.base'; EliminationStack.exchanger' >.
 Global Instance into_val_EliminationStack : IntoVal EliminationStack.t :=
   {| to_val_def v :=
     struct.val_aux chan_spec_raw_examples.EliminationStack [
     "base" ::= #(EliminationStack.base' v);
-    "exchanger" ::= #(EliminationStack.exchanger' v);
-    "timeout" ::= #(EliminationStack.timeout' v)
+    "exchanger" ::= #(EliminationStack.exchanger' v)
     ]%struct
   |}.
 
 Global Program Instance into_val_typed_EliminationStack : IntoValTyped EliminationStack.t chan_spec_raw_examples.EliminationStack :=
 {|
-  default_val := EliminationStack.mk (default_val _) (default_val _) (default_val _);
+  default_val := EliminationStack.mk (default_val _) (default_val _);
 |}.
 Next Obligation. solve_to_val_type. Qed.
 Next Obligation. solve_zero_val. Qed.
@@ -131,27 +129,22 @@ Proof. solve_into_val_struct_field. Qed.
 Global Instance into_val_struct_field_EliminationStack_exchanger : IntoValStructField "exchanger" chan_spec_raw_examples.EliminationStack EliminationStack.exchanger'.
 Proof. solve_into_val_struct_field. Qed.
 
-Global Instance into_val_struct_field_EliminationStack_timeout : IntoValStructField "timeout" chan_spec_raw_examples.EliminationStack EliminationStack.timeout'.
-Proof. solve_into_val_struct_field. Qed.
-
 
 Context `{!ffi_model, !ffi_semantics _ _, !ffi_interp _, !heapGS Σ}.
-Global Instance wp_struct_make_EliminationStack base' exchanger' timeout':
+Global Instance wp_struct_make_EliminationStack base' exchanger':
   PureWp True
     (struct.make #chan_spec_raw_examples.EliminationStack (alist_val [
       "base" ::= #base';
-      "exchanger" ::= #exchanger';
-      "timeout" ::= #timeout'
+      "exchanger" ::= #exchanger'
     ]))%struct
-    #(EliminationStack.mk base' exchanger' timeout').
+    #(EliminationStack.mk base' exchanger').
 Proof. solve_struct_make_pure_wp. Qed.
 
 
 Global Instance EliminationStack_struct_fields_split dq l (v : EliminationStack.t) :
   StructFieldsSplit dq l v (
     "Hbase" ∷ l ↦s[chan_spec_raw_examples.EliminationStack :: "base"]{dq} v.(EliminationStack.base') ∗
-    "Hexchanger" ∷ l ↦s[chan_spec_raw_examples.EliminationStack :: "exchanger"]{dq} v.(EliminationStack.exchanger') ∗
-    "Htimeout" ∷ l ↦s[chan_spec_raw_examples.EliminationStack :: "timeout"]{dq} v.(EliminationStack.timeout')
+    "Hexchanger" ∷ l ↦s[chan_spec_raw_examples.EliminationStack :: "exchanger"]{dq} v.(EliminationStack.exchanger')
   ).
 Proof.
   rewrite /named.
@@ -160,7 +153,6 @@ Proof.
 
   rewrite -!/(typed_pointsto_def _ _ _) -!typed_pointsto_unseal.
   simpl_one_flatten_struct (# (EliminationStack.base' v)) (chan_spec_raw_examples.EliminationStack) "base"%go.
-  simpl_one_flatten_struct (# (EliminationStack.exchanger' v)) (chan_spec_raw_examples.EliminationStack) "exchanger"%go.
 
   solve_field_ref_f.
 Qed.
@@ -353,10 +345,6 @@ Final Obligation. iIntros. iFrame "#%". Qed.
 
 Global Instance wp_func_call_NewLockedStack :
   WpFuncCall chan_spec_raw_examples.NewLockedStack _ (is_pkg_defined chan_spec_raw_examples) :=
-  ltac:(solve_wp_func_call).
-
-Global Instance wp_func_call_after :
-  WpFuncCall chan_spec_raw_examples.after _ (is_pkg_defined chan_spec_raw_examples) :=
   ltac:(solve_wp_func_call).
 
 Global Instance wp_func_call_NewEliminationStack :

--- a/new/proof/github_com/goose_lang/goose/model/channel/protocol/simple/simple.v
+++ b/new/proof/github_com/goose_lang/goose/model/channel/protocol/simple/simple.v
@@ -71,12 +71,12 @@ Proof.
 Qed.
 
 Lemma simple_rcv_au γ ch P Φ  :
-  is_simple γ ch P ∗ £1 ∗ £1 ⊢
-  (▷ ∀ v, P v -∗ Φ v true ) -∗
+  is_simple γ ch P ⊢
   £1 ∗ £1  -∗
-  rcv_au_slow ch γ.(chan_name) (λ (v:V) (ok:bool), Φ v ok).
+  (▷ ∀ v, P v -∗ Φ v true ) -∗
+  rcv_au_slow ch γ.(chan_name) Φ.
 Proof.
-  iIntros "(#Hsimple & ? & ?) HΦ (Hlc1 & Hlc2 )".
+  iIntros "#Hsimple (Hlc1 & Hlc2 ) HΦ".
   iNamed "Hsimple".
   iInv "Hinv" as "Hinv_open" "Hinv_close".
   iMod (lc_fupd_elim_later with "[$] Hinv_open") as "Hinv_open".
@@ -184,7 +184,7 @@ Proof.
   iNamed "Hsimple".
   wp_apply (chan.wp_receive ch γ.(chan_name) with "[$Hch]").
   iIntros "(Hlc1 & Hlc2 & Hlc3 & Hlc4)".
-  iApply (simple_rcv_au with "[$Hlc3 $Hlc4][HΦ][$Hlc1 $Hlc2]").
+  iApply (simple_rcv_au with "[] [$Hlc1 $Hlc2]").
   {
     iFrame "#".
   }
@@ -193,11 +193,11 @@ Proof.
   }
 Qed.
 
-Lemma simple_send_au γ ch P v (Φ: val → iProp Σ) :
+Lemma simple_send_au γ ch P v (Φ: iProp Σ) :
   is_simple γ ch P ∗ £1 ∗ £1 ⊢
   P v -∗
-  (▷ Φ #()) -∗
-  send_au_slow ch v γ.(chan_name) (Φ #()).
+  (▷ Φ) -∗
+  send_au_slow ch v γ.(chan_name) Φ.
 Proof.
   iIntros "(#Hsimple & ? & ?) HP HΦ".
   iNamed "Hsimple".

--- a/new/proof/github_com/goose_lang/goose/testdata/examples/channel.v
+++ b/new/proof/github_com/goose_lang/goose/testdata/examples/channel.v
@@ -127,19 +127,14 @@ Proof using chan_protocolG0 chan_protocolG1.
       iFrame "#".
 
       iApply ((simple_rcv_au  (V:=go_string)  γfuture ch)
-               with " [-HΦ Hlc1 Hlc2][HΦ][$Hlc1 $Hlc2]").
-      {
-        iFrame "#".
-        iFrame.
-      }
-      {
+               with " [$Hfut] [$]").
       iNext. iIntros (v). iIntros "%Hw".
       wp_auto.
       subst v.
       iApply "HΦ".
       iPureIntro.
-      right. done. }
-      }
+      right. done.
+    }
     {
       iFrame "Hdonech".
 

--- a/new/should_build.v
+++ b/new/should_build.v
@@ -7,7 +7,7 @@ From New.proof.github_com.mit_pdos.gokv Require gokv.
 From New.proof.github_com.goose_lang.goose.testdata.examples
   Require unittest unittest.generics.
 From New.proof.github_com.goose_lang.goose.testdata.examples
-  Require channel channel_search_replace.
+  Require channel channel_search_replace elimination_stack.
 
 From New.proof.github_com.goose_lang.goose.model.channel.protocol
   Require protocols.


### PR DESCRIPTION
This commit also cleans up the simple recv and send AUs: they now take just \Phi to have an obviously general conclusion. The simple recv AU also needs only two later credits, not four.

Depends on https://github.com/goose-lang/goose/pull/160 which implements the code change.