### PR TITLE
Translate CmpFunc-based sorting code

### DIFF
--- a/new/code/slices.v
+++ b/new/code/slices.v
@@ -116,9 +116,115 @@ Definition isNaN : go_string := "slices.isNaN"%go.
 
 Definition insertionSortCmpFunc : go_string := "slices.insertionSortCmpFunc"%go.
 
+(* insertionSortCmpFunc sorts data[a:b] using insertion sort.
+
+   go: zsortanyfunc.go:10:6 *)
+Definition insertionSortCmpFuncⁱᵐᵖˡ : val :=
+  λ: "E" "data" "a" "b" "cmp",
+    exception_do (let: "cmp" := (mem.alloc "cmp") in
+    let: "b" := (mem.alloc "b") in
+    let: "a" := (mem.alloc "a") in
+    let: "data" := (mem.alloc "data") in
+    (let: "i" := (mem.alloc (type.zero_val #intT)) in
+    let: "$r0" := ((![#intT] "a") + #(W64 1)) in
+    do:  ("i" <-[#intT] "$r0");;;
+    (for: (λ: <>, int_lt (![#intT] "i") (![#intT] "b")); (λ: <>, do:  ("i" <-[#intT] ((![#intT] "i") + #(W64 1)))) := λ: <>,
+      (let: "j" := (mem.alloc (type.zero_val #intT)) in
+      let: "$r0" := (![#intT] "i") in
+      do:  ("j" <-[#intT] "$r0");;;
+      (for: (λ: <>, (int_gt (![#intT] "j") (![#intT] "a")) && (int_lt (let: "$a0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "j"))) in
+      let: "$a1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "j") - #(W64 1)))) in
+      (![#funcT] "cmp") "$a0" "$a1") #(W64 0))); (λ: <>, do:  ("j" <-[#intT] ((![#intT] "j") - #(W64 1)))) := λ: <>,
+        let: "$r0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "j") - #(W64 1)))) in
+        let: "$r1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "j"))) in
+        do:  ((slice.elem_ref "E" (![#sliceT] "data") (![#intT] "j")) <-["E"] "$r0");;;
+        do:  ((slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "j") - #(W64 1))) <-["E"] "$r1")))));;;
+    return: #()).
+
 Definition siftDownCmpFunc : go_string := "slices.siftDownCmpFunc"%go.
 
+(* siftDownCmpFunc implements the heap property on data[lo:hi].
+   first is an offset into the array where the root of the heap lies.
+
+   go: zsortanyfunc.go:20:6 *)
+Definition siftDownCmpFuncⁱᵐᵖˡ : val :=
+  λ: "E" "data" "lo" "hi" "first" "cmp",
+    exception_do (let: "cmp" := (mem.alloc "cmp") in
+    let: "first" := (mem.alloc "first") in
+    let: "hi" := (mem.alloc "hi") in
+    let: "lo" := (mem.alloc "lo") in
+    let: "data" := (mem.alloc "data") in
+    let: "root" := (mem.alloc (type.zero_val #intT)) in
+    let: "$r0" := (![#intT] "lo") in
+    do:  ("root" <-[#intT] "$r0");;;
+    (for: (λ: <>, #true); (λ: <>, #()) := λ: <>,
+      let: "child" := (mem.alloc (type.zero_val #intT)) in
+      let: "$r0" := ((#(W64 2) * (![#intT] "root")) + #(W64 1)) in
+      do:  ("child" <-[#intT] "$r0");;;
+      (if: int_geq (![#intT] "child") (![#intT] "hi")
+      then break: #()
+      else do:  #());;;
+      (if: (int_lt ((![#intT] "child") + #(W64 1)) (![#intT] "hi")) && (int_lt (let: "$a0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "first") + (![#intT] "child")))) in
+      let: "$a1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (((![#intT] "first") + (![#intT] "child")) + #(W64 1)))) in
+      (![#funcT] "cmp") "$a0" "$a1") #(W64 0))
+      then do:  ("child" <-[#intT] ((![#intT] "child") + #(W64 1)))
+      else do:  #());;;
+      (if: (~ (int_lt (let: "$a0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "first") + (![#intT] "root")))) in
+      let: "$a1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "first") + (![#intT] "child")))) in
+      (![#funcT] "cmp") "$a0" "$a1") #(W64 0)))
+      then return: (#())
+      else do:  #());;;
+      let: "$r0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "first") + (![#intT] "child")))) in
+      let: "$r1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "first") + (![#intT] "root")))) in
+      do:  ((slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "first") + (![#intT] "root"))) <-["E"] "$r0");;;
+      do:  ((slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "first") + (![#intT] "child"))) <-["E"] "$r1");;;
+      let: "$r0" := (![#intT] "child") in
+      do:  ("root" <-[#intT] "$r0"));;;
+    return: #()).
+
 Definition heapSortCmpFunc : go_string := "slices.heapSortCmpFunc"%go.
+
+(* go: zsortanyfunc.go:38:6 *)
+Definition heapSortCmpFuncⁱᵐᵖˡ : val :=
+  λ: "E" "data" "a" "b" "cmp",
+    exception_do (let: "cmp" := (mem.alloc "cmp") in
+    let: "b" := (mem.alloc "b") in
+    let: "a" := (mem.alloc "a") in
+    let: "data" := (mem.alloc "data") in
+    let: "first" := (mem.alloc (type.zero_val #intT)) in
+    let: "$r0" := (![#intT] "a") in
+    do:  ("first" <-[#intT] "$r0");;;
+    let: "lo" := (mem.alloc (type.zero_val #intT)) in
+    let: "$r0" := #(W64 0) in
+    do:  ("lo" <-[#intT] "$r0");;;
+    let: "hi" := (mem.alloc (type.zero_val #intT)) in
+    let: "$r0" := ((![#intT] "b") - (![#intT] "a")) in
+    do:  ("hi" <-[#intT] "$r0");;;
+    (let: "i" := (mem.alloc (type.zero_val #intT)) in
+    let: "$r0" := (((![#intT] "hi") - #(W64 1)) `quots` #(W64 2)) in
+    do:  ("i" <-[#intT] "$r0");;;
+    (for: (λ: <>, int_geq (![#intT] "i") #(W64 0)); (λ: <>, do:  ("i" <-[#intT] ((![#intT] "i") - #(W64 1)))) := λ: <>,
+      do:  (let: "$a0" := (![#sliceT] "data") in
+      let: "$a1" := (![#intT] "i") in
+      let: "$a2" := (![#intT] "hi") in
+      let: "$a3" := (![#intT] "first") in
+      let: "$a4" := (![#funcT] "cmp") in
+      ((func_call #siftDownCmpFunc) "E") "$a0" "$a1" "$a2" "$a3" "$a4")));;;
+    (let: "i" := (mem.alloc (type.zero_val #intT)) in
+    let: "$r0" := ((![#intT] "hi") - #(W64 1)) in
+    do:  ("i" <-[#intT] "$r0");;;
+    (for: (λ: <>, int_geq (![#intT] "i") #(W64 0)); (λ: <>, do:  ("i" <-[#intT] ((![#intT] "i") - #(W64 1)))) := λ: <>,
+      let: "$r0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "first") + (![#intT] "i")))) in
+      let: "$r1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "first"))) in
+      do:  ((slice.elem_ref "E" (![#sliceT] "data") (![#intT] "first")) <-["E"] "$r0");;;
+      do:  ((slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "first") + (![#intT] "i"))) <-["E"] "$r1");;;
+      do:  (let: "$a0" := (![#sliceT] "data") in
+      let: "$a1" := (![#intT] "lo") in
+      let: "$a2" := (![#intT] "i") in
+      let: "$a3" := (![#intT] "first") in
+      let: "$a4" := (![#funcT] "cmp") in
+      ((func_call #siftDownCmpFunc) "E") "$a0" "$a1" "$a2" "$a3" "$a4")));;;
+    return: #()).
 
 Definition pdqsortCmpFunc : go_string := "slices.pdqsortCmpFunc"%go.
 
@@ -128,25 +234,843 @@ Definition partitionEqualCmpFunc : go_string := "slices.partitionEqualCmpFunc"%g
 
 Definition partialInsertionSortCmpFunc : go_string := "slices.partialInsertionSortCmpFunc"%go.
 
-Definition breakPatternsCmpFunc : go_string := "slices.breakPatternsCmpFunc"%go.
+Definition reverseRangeCmpFunc : go_string := "slices.reverseRangeCmpFunc"%go.
 
 Definition choosePivotCmpFunc : go_string := "slices.choosePivotCmpFunc"%go.
 
-Definition order2CmpFunc : go_string := "slices.order2CmpFunc"%go.
+Definition breakPatternsCmpFunc : go_string := "slices.breakPatternsCmpFunc"%go.
+
+(* pdqsortCmpFunc sorts data[a:b].
+   The algorithm based on pattern-defeating quicksort(pdqsort), but without the optimizations from BlockQuicksort.
+   pdqsort paper: https://arxiv.org/pdf/2106.05123.pdf
+   C++ implementation: https://github.com/orlp/pdqsort
+   Rust implementation: https://docs.rs/pdqsort/latest/pdqsort/
+   limit is the number of allowed bad (very unbalanced) pivots before falling back to heapsort.
+
+   go: zsortanyfunc.go:61:6 *)
+Definition pdqsortCmpFuncⁱᵐᵖˡ : val :=
+  λ: "E" "data" "a" "b" "limit" "cmp",
+    exception_do (let: "cmp" := (mem.alloc "cmp") in
+    let: "limit" := (mem.alloc "limit") in
+    let: "b" := (mem.alloc "b") in
+    let: "a" := (mem.alloc "a") in
+    let: "data" := (mem.alloc "data") in
+    let maxInsertion := 12 in
+    let: "wasPartitioned" := (mem.alloc (type.zero_val #boolT)) in
+    let: "$r0" := #true in
+    do:  ("wasPartitioned" <-[#boolT] "$r0");;;
+    let: "wasBalanced" := (mem.alloc (type.zero_val #boolT)) in
+    let: "$r0" := #true in
+    do:  ("wasBalanced" <-[#boolT] "$r0");;;
+    (for: (λ: <>, #true); (λ: <>, #()) := λ: <>,
+      let: "length" := (mem.alloc (type.zero_val #intT)) in
+      let: "$r0" := ((![#intT] "b") - (![#intT] "a")) in
+      do:  ("length" <-[#intT] "$r0");;;
+      (if: int_leq (![#intT] "length") #(W64 maxInsertion)
+      then
+        do:  (let: "$a0" := (![#sliceT] "data") in
+        let: "$a1" := (![#intT] "a") in
+        let: "$a2" := (![#intT] "b") in
+        let: "$a3" := (![#funcT] "cmp") in
+        ((func_call #insertionSortCmpFunc) "E") "$a0" "$a1" "$a2" "$a3");;;
+        return: (#())
+      else do:  #());;;
+      (if: (![#intT] "limit") = #(W64 0)
+      then
+        do:  (let: "$a0" := (![#sliceT] "data") in
+        let: "$a1" := (![#intT] "a") in
+        let: "$a2" := (![#intT] "b") in
+        let: "$a3" := (![#funcT] "cmp") in
+        ((func_call #heapSortCmpFunc) "E") "$a0" "$a1" "$a2" "$a3");;;
+        return: (#())
+      else do:  #());;;
+      (if: (~ (![#boolT] "wasBalanced"))
+      then
+        do:  (let: "$a0" := (![#sliceT] "data") in
+        let: "$a1" := (![#intT] "a") in
+        let: "$a2" := (![#intT] "b") in
+        let: "$a3" := (![#funcT] "cmp") in
+        ((func_call #breakPatternsCmpFunc) "E") "$a0" "$a1" "$a2" "$a3");;;
+        do:  ("limit" <-[#intT] ((![#intT] "limit") - #(W64 1)))
+      else do:  #());;;
+      let: "hint" := (mem.alloc (type.zero_val #sortedHint)) in
+      let: "pivot" := (mem.alloc (type.zero_val #intT)) in
+      let: ("$ret0", "$ret1") := (let: "$a0" := (![#sliceT] "data") in
+      let: "$a1" := (![#intT] "a") in
+      let: "$a2" := (![#intT] "b") in
+      let: "$a3" := (![#funcT] "cmp") in
+      ((func_call #choosePivotCmpFunc) "E") "$a0" "$a1" "$a2" "$a3") in
+      let: "$r0" := "$ret0" in
+      let: "$r1" := "$ret1" in
+      do:  ("pivot" <-[#intT] "$r0");;;
+      do:  ("hint" <-[#sortedHint] "$r1");;;
+      (if: (![#sortedHint] "hint") = decreasingHint
+      then
+        do:  (let: "$a0" := (![#sliceT] "data") in
+        let: "$a1" := (![#intT] "a") in
+        let: "$a2" := (![#intT] "b") in
+        let: "$a3" := (![#funcT] "cmp") in
+        ((func_call #reverseRangeCmpFunc) "E") "$a0" "$a1" "$a2" "$a3");;;
+        let: "$r0" := (((![#intT] "b") - #(W64 1)) - ((![#intT] "pivot") - (![#intT] "a"))) in
+        do:  ("pivot" <-[#intT] "$r0");;;
+        let: "$r0" := increasingHint in
+        do:  ("hint" <-[#sortedHint] "$r0")
+      else do:  #());;;
+      (if: ((![#boolT] "wasBalanced") && (![#boolT] "wasPartitioned")) && ((![#sortedHint] "hint") = increasingHint)
+      then
+        (if: let: "$a0" := (![#sliceT] "data") in
+        let: "$a1" := (![#intT] "a") in
+        let: "$a2" := (![#intT] "b") in
+        let: "$a3" := (![#funcT] "cmp") in
+        ((func_call #partialInsertionSortCmpFunc) "E") "$a0" "$a1" "$a2" "$a3"
+        then return: (#())
+        else do:  #())
+      else do:  #());;;
+      (if: (int_gt (![#intT] "a") #(W64 0)) && (~ (int_lt (let: "$a0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "a") - #(W64 1)))) in
+      let: "$a1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "pivot"))) in
+      (![#funcT] "cmp") "$a0" "$a1") #(W64 0)))
+      then
+        let: "mid" := (mem.alloc (type.zero_val #intT)) in
+        let: "$r0" := (let: "$a0" := (![#sliceT] "data") in
+        let: "$a1" := (![#intT] "a") in
+        let: "$a2" := (![#intT] "b") in
+        let: "$a3" := (![#intT] "pivot") in
+        let: "$a4" := (![#funcT] "cmp") in
+        ((func_call #partitionEqualCmpFunc) "E") "$a0" "$a1" "$a2" "$a3" "$a4") in
+        do:  ("mid" <-[#intT] "$r0");;;
+        let: "$r0" := (![#intT] "mid") in
+        do:  ("a" <-[#intT] "$r0");;;
+        continue: #()
+      else do:  #());;;
+      let: "alreadyPartitioned" := (mem.alloc (type.zero_val #boolT)) in
+      let: "mid" := (mem.alloc (type.zero_val #intT)) in
+      let: ("$ret0", "$ret1") := (let: "$a0" := (![#sliceT] "data") in
+      let: "$a1" := (![#intT] "a") in
+      let: "$a2" := (![#intT] "b") in
+      let: "$a3" := (![#intT] "pivot") in
+      let: "$a4" := (![#funcT] "cmp") in
+      ((func_call #partitionCmpFunc) "E") "$a0" "$a1" "$a2" "$a3" "$a4") in
+      let: "$r0" := "$ret0" in
+      let: "$r1" := "$ret1" in
+      do:  ("mid" <-[#intT] "$r0");;;
+      do:  ("alreadyPartitioned" <-[#boolT] "$r1");;;
+      let: "$r0" := (![#boolT] "alreadyPartitioned") in
+      do:  ("wasPartitioned" <-[#boolT] "$r0");;;
+      let: "rightLen" := (mem.alloc (type.zero_val #intT)) in
+      let: "leftLen" := (mem.alloc (type.zero_val #intT)) in
+      let: "$r0" := ((![#intT] "mid") - (![#intT] "a")) in
+      let: "$r1" := ((![#intT] "b") - (![#intT] "mid")) in
+      do:  ("leftLen" <-[#intT] "$r0");;;
+      do:  ("rightLen" <-[#intT] "$r1");;;
+      let: "balanceThreshold" := (mem.alloc (type.zero_val #intT)) in
+      let: "$r0" := ((![#intT] "length") `quots` #(W64 8)) in
+      do:  ("balanceThreshold" <-[#intT] "$r0");;;
+      (if: int_lt (![#intT] "leftLen") (![#intT] "rightLen")
+      then
+        let: "$r0" := (int_geq (![#intT] "leftLen") (![#intT] "balanceThreshold")) in
+        do:  ("wasBalanced" <-[#boolT] "$r0");;;
+        do:  (let: "$a0" := (![#sliceT] "data") in
+        let: "$a1" := (![#intT] "a") in
+        let: "$a2" := (![#intT] "mid") in
+        let: "$a3" := (![#intT] "limit") in
+        let: "$a4" := (![#funcT] "cmp") in
+        ((func_call #pdqsortCmpFunc) "E") "$a0" "$a1" "$a2" "$a3" "$a4");;;
+        let: "$r0" := ((![#intT] "mid") + #(W64 1)) in
+        do:  ("a" <-[#intT] "$r0")
+      else
+        let: "$r0" := (int_geq (![#intT] "rightLen") (![#intT] "balanceThreshold")) in
+        do:  ("wasBalanced" <-[#boolT] "$r0");;;
+        do:  (let: "$a0" := (![#sliceT] "data") in
+        let: "$a1" := ((![#intT] "mid") + #(W64 1)) in
+        let: "$a2" := (![#intT] "b") in
+        let: "$a3" := (![#intT] "limit") in
+        let: "$a4" := (![#funcT] "cmp") in
+        ((func_call #pdqsortCmpFunc) "E") "$a0" "$a1" "$a2" "$a3" "$a4");;;
+        let: "$r0" := (![#intT] "mid") in
+        do:  ("b" <-[#intT] "$r0")));;;
+    return: #()).
+
+(* partitionCmpFunc does one quicksort partition.
+   Let p = data[pivot]
+   Moves elements in data[a:b] around, so that data[i]<p and data[j]>=p for i<newpivot and j>newpivot.
+   On return, data[newpivot] = p
+
+   go: zsortanyfunc.go:135:6 *)
+Definition partitionCmpFuncⁱᵐᵖˡ : val :=
+  λ: "E" "data" "a" "b" "pivot" "cmp",
+    exception_do (let: "alreadyPartitioned" := (mem.alloc (type.zero_val #boolT)) in
+    let: "newpivot" := (mem.alloc (type.zero_val #intT)) in
+    let: "cmp" := (mem.alloc "cmp") in
+    let: "pivot" := (mem.alloc "pivot") in
+    let: "b" := (mem.alloc "b") in
+    let: "a" := (mem.alloc "a") in
+    let: "data" := (mem.alloc "data") in
+    let: "$r0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "pivot"))) in
+    let: "$r1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "a"))) in
+    do:  ((slice.elem_ref "E" (![#sliceT] "data") (![#intT] "a")) <-["E"] "$r0");;;
+    do:  ((slice.elem_ref "E" (![#sliceT] "data") (![#intT] "pivot")) <-["E"] "$r1");;;
+    let: "j" := (mem.alloc (type.zero_val #intT)) in
+    let: "i" := (mem.alloc (type.zero_val #intT)) in
+    let: "$r0" := ((![#intT] "a") + #(W64 1)) in
+    let: "$r1" := ((![#intT] "b") - #(W64 1)) in
+    do:  ("i" <-[#intT] "$r0");;;
+    do:  ("j" <-[#intT] "$r1");;;
+    (for: (λ: <>, (int_leq (![#intT] "i") (![#intT] "j")) && (int_lt (let: "$a0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "i"))) in
+    let: "$a1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "a"))) in
+    (![#funcT] "cmp") "$a0" "$a1") #(W64 0))); (λ: <>, #()) := λ: <>,
+      do:  ("i" <-[#intT] ((![#intT] "i") + #(W64 1))));;;
+    (for: (λ: <>, (int_leq (![#intT] "i") (![#intT] "j")) && (~ (int_lt (let: "$a0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "j"))) in
+    let: "$a1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "a"))) in
+    (![#funcT] "cmp") "$a0" "$a1") #(W64 0)))); (λ: <>, #()) := λ: <>,
+      do:  ("j" <-[#intT] ((![#intT] "j") - #(W64 1))));;;
+    (if: int_gt (![#intT] "i") (![#intT] "j")
+    then
+      let: "$r0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "a"))) in
+      let: "$r1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "j"))) in
+      do:  ((slice.elem_ref "E" (![#sliceT] "data") (![#intT] "j")) <-["E"] "$r0");;;
+      do:  ((slice.elem_ref "E" (![#sliceT] "data") (![#intT] "a")) <-["E"] "$r1");;;
+      return: (![#intT] "j", #true)
+    else do:  #());;;
+    let: "$r0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "j"))) in
+    let: "$r1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "i"))) in
+    do:  ((slice.elem_ref "E" (![#sliceT] "data") (![#intT] "i")) <-["E"] "$r0");;;
+    do:  ((slice.elem_ref "E" (![#sliceT] "data") (![#intT] "j")) <-["E"] "$r1");;;
+    do:  ("i" <-[#intT] ((![#intT] "i") + #(W64 1)));;;
+    do:  ("j" <-[#intT] ((![#intT] "j") - #(W64 1)));;;
+    (for: (λ: <>, #true); (λ: <>, #()) := λ: <>,
+      (for: (λ: <>, (int_leq (![#intT] "i") (![#intT] "j")) && (int_lt (let: "$a0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "i"))) in
+      let: "$a1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "a"))) in
+      (![#funcT] "cmp") "$a0" "$a1") #(W64 0))); (λ: <>, #()) := λ: <>,
+        do:  ("i" <-[#intT] ((![#intT] "i") + #(W64 1))));;;
+      (for: (λ: <>, (int_leq (![#intT] "i") (![#intT] "j")) && (~ (int_lt (let: "$a0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "j"))) in
+      let: "$a1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "a"))) in
+      (![#funcT] "cmp") "$a0" "$a1") #(W64 0)))); (λ: <>, #()) := λ: <>,
+        do:  ("j" <-[#intT] ((![#intT] "j") - #(W64 1))));;;
+      (if: int_gt (![#intT] "i") (![#intT] "j")
+      then break: #()
+      else do:  #());;;
+      let: "$r0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "j"))) in
+      let: "$r1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "i"))) in
+      do:  ((slice.elem_ref "E" (![#sliceT] "data") (![#intT] "i")) <-["E"] "$r0");;;
+      do:  ((slice.elem_ref "E" (![#sliceT] "data") (![#intT] "j")) <-["E"] "$r1");;;
+      do:  ("i" <-[#intT] ((![#intT] "i") + #(W64 1)));;;
+      do:  ("j" <-[#intT] ((![#intT] "j") - #(W64 1))));;;
+    let: "$r0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "a"))) in
+    let: "$r1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "j"))) in
+    do:  ((slice.elem_ref "E" (![#sliceT] "data") (![#intT] "j")) <-["E"] "$r0");;;
+    do:  ((slice.elem_ref "E" (![#sliceT] "data") (![#intT] "a")) <-["E"] "$r1");;;
+    return: (![#intT] "j", #false)).
+
+(* partitionEqualCmpFunc partitions data[a:b] into elements equal to data[pivot] followed by elements greater than data[pivot].
+   It assumed that data[a:b] does not contain elements smaller than the data[pivot].
+
+   go: zsortanyfunc.go:173:6 *)
+Definition partitionEqualCmpFuncⁱᵐᵖˡ : val :=
+  λ: "E" "data" "a" "b" "pivot" "cmp",
+    exception_do (let: "newpivot" := (mem.alloc (type.zero_val #intT)) in
+    let: "cmp" := (mem.alloc "cmp") in
+    let: "pivot" := (mem.alloc "pivot") in
+    let: "b" := (mem.alloc "b") in
+    let: "a" := (mem.alloc "a") in
+    let: "data" := (mem.alloc "data") in
+    let: "$r0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "pivot"))) in
+    let: "$r1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "a"))) in
+    do:  ((slice.elem_ref "E" (![#sliceT] "data") (![#intT] "a")) <-["E"] "$r0");;;
+    do:  ((slice.elem_ref "E" (![#sliceT] "data") (![#intT] "pivot")) <-["E"] "$r1");;;
+    let: "j" := (mem.alloc (type.zero_val #intT)) in
+    let: "i" := (mem.alloc (type.zero_val #intT)) in
+    let: "$r0" := ((![#intT] "a") + #(W64 1)) in
+    let: "$r1" := ((![#intT] "b") - #(W64 1)) in
+    do:  ("i" <-[#intT] "$r0");;;
+    do:  ("j" <-[#intT] "$r1");;;
+    (for: (λ: <>, #true); (λ: <>, #()) := λ: <>,
+      (for: (λ: <>, (int_leq (![#intT] "i") (![#intT] "j")) && (~ (int_lt (let: "$a0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "a"))) in
+      let: "$a1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "i"))) in
+      (![#funcT] "cmp") "$a0" "$a1") #(W64 0)))); (λ: <>, #()) := λ: <>,
+        do:  ("i" <-[#intT] ((![#intT] "i") + #(W64 1))));;;
+      (for: (λ: <>, (int_leq (![#intT] "i") (![#intT] "j")) && (int_lt (let: "$a0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "a"))) in
+      let: "$a1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "j"))) in
+      (![#funcT] "cmp") "$a0" "$a1") #(W64 0))); (λ: <>, #()) := λ: <>,
+        do:  ("j" <-[#intT] ((![#intT] "j") - #(W64 1))));;;
+      (if: int_gt (![#intT] "i") (![#intT] "j")
+      then break: #()
+      else do:  #());;;
+      let: "$r0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "j"))) in
+      let: "$r1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "i"))) in
+      do:  ((slice.elem_ref "E" (![#sliceT] "data") (![#intT] "i")) <-["E"] "$r0");;;
+      do:  ((slice.elem_ref "E" (![#sliceT] "data") (![#intT] "j")) <-["E"] "$r1");;;
+      do:  ("i" <-[#intT] ((![#intT] "i") + #(W64 1)));;;
+      do:  ("j" <-[#intT] ((![#intT] "j") - #(W64 1))));;;
+    return: (![#intT] "i")).
+
+(* partialInsertionSortCmpFunc partially sorts a slice, returns true if the slice is sorted at the end.
+
+   go: zsortanyfunc.go:195:6 *)
+Definition partialInsertionSortCmpFuncⁱᵐᵖˡ : val :=
+  λ: "E" "data" "a" "b" "cmp",
+    exception_do (let: "cmp" := (mem.alloc "cmp") in
+    let: "b" := (mem.alloc "b") in
+    let: "a" := (mem.alloc "a") in
+    let: "data" := (mem.alloc "data") in
+    let maxSteps := 5 in
+    let shortestShifting := 50 in
+    let: "i" := (mem.alloc (type.zero_val #intT)) in
+    let: "$r0" := ((![#intT] "a") + #(W64 1)) in
+    do:  ("i" <-[#intT] "$r0");;;
+    (let: "j" := (mem.alloc (type.zero_val #intT)) in
+    let: "$r0" := #(W64 0) in
+    do:  ("j" <-[#intT] "$r0");;;
+    (for: (λ: <>, int_lt (![#intT] "j") #(W64 maxSteps)); (λ: <>, do:  ("j" <-[#intT] ((![#intT] "j") + #(W64 1)))) := λ: <>,
+      (for: (λ: <>, (int_lt (![#intT] "i") (![#intT] "b")) && (~ (int_lt (let: "$a0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "i"))) in
+      let: "$a1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "i") - #(W64 1)))) in
+      (![#funcT] "cmp") "$a0" "$a1") #(W64 0)))); (λ: <>, #()) := λ: <>,
+        do:  ("i" <-[#intT] ((![#intT] "i") + #(W64 1))));;;
+      (if: (![#intT] "i") = (![#intT] "b")
+      then return: (#true)
+      else do:  #());;;
+      (if: int_lt ((![#intT] "b") - (![#intT] "a")) #(W64 shortestShifting)
+      then return: (#false)
+      else do:  #());;;
+      let: "$r0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "i") - #(W64 1)))) in
+      let: "$r1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "i"))) in
+      do:  ((slice.elem_ref "E" (![#sliceT] "data") (![#intT] "i")) <-["E"] "$r0");;;
+      do:  ((slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "i") - #(W64 1))) <-["E"] "$r1");;;
+      (if: int_geq ((![#intT] "i") - (![#intT] "a")) #(W64 2)
+      then
+        (let: "j" := (mem.alloc (type.zero_val #intT)) in
+        let: "$r0" := ((![#intT] "i") - #(W64 1)) in
+        do:  ("j" <-[#intT] "$r0");;;
+        (for: (λ: <>, int_geq (![#intT] "j") #(W64 1)); (λ: <>, do:  ("j" <-[#intT] ((![#intT] "j") - #(W64 1)))) := λ: <>,
+          (if: (~ (int_lt (let: "$a0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "j"))) in
+          let: "$a1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "j") - #(W64 1)))) in
+          (![#funcT] "cmp") "$a0" "$a1") #(W64 0)))
+          then break: #()
+          else do:  #());;;
+          let: "$r0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "j") - #(W64 1)))) in
+          let: "$r1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "j"))) in
+          do:  ((slice.elem_ref "E" (![#sliceT] "data") (![#intT] "j")) <-["E"] "$r0");;;
+          do:  ((slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "j") - #(W64 1))) <-["E"] "$r1")))
+      else do:  #());;;
+      (if: int_geq ((![#intT] "b") - (![#intT] "i")) #(W64 2)
+      then
+        (let: "j" := (mem.alloc (type.zero_val #intT)) in
+        let: "$r0" := ((![#intT] "i") + #(W64 1)) in
+        do:  ("j" <-[#intT] "$r0");;;
+        (for: (λ: <>, int_lt (![#intT] "j") (![#intT] "b")); (λ: <>, do:  ("j" <-[#intT] ((![#intT] "j") + #(W64 1)))) := λ: <>,
+          (if: (~ (int_lt (let: "$a0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "j"))) in
+          let: "$a1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "j") - #(W64 1)))) in
+          (![#funcT] "cmp") "$a0" "$a1") #(W64 0)))
+          then break: #()
+          else do:  #());;;
+          let: "$r0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "j") - #(W64 1)))) in
+          let: "$r1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "j"))) in
+          do:  ((slice.elem_ref "E" (![#sliceT] "data") (![#intT] "j")) <-["E"] "$r0");;;
+          do:  ((slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "j") - #(W64 1))) <-["E"] "$r1")))
+      else do:  #())));;;
+    return: (#false)).
+
+(* breakPatternsCmpFunc scatters some elements around in an attempt to break some patterns
+   that might cause imbalanced partitions in quicksort.
+
+   go: zsortanyfunc.go:240:6 *)
+Definition breakPatternsCmpFuncⁱᵐᵖˡ : val :=
+  λ: "E" "data" "a" "b" "cmp",
+    exception_do (let: "cmp" := (mem.alloc "cmp") in
+    let: "b" := (mem.alloc "b") in
+    let: "a" := (mem.alloc "a") in
+    let: "data" := (mem.alloc "data") in
+    let: "length" := (mem.alloc (type.zero_val #intT)) in
+    let: "$r0" := ((![#intT] "b") - (![#intT] "a")) in
+    do:  ("length" <-[#intT] "$r0");;;
+    (if: int_geq (![#intT] "length") #(W64 8)
+    then
+      let: "random" := (mem.alloc (type.zero_val #xorshift)) in
+      let: "$r0" := (s_to_w64 (![#intT] "length")) in
+      do:  ("random" <-[#xorshift] "$r0");;;
+      let: "modulus" := (mem.alloc (type.zero_val #uintT)) in
+      let: "$r0" := (let: "$a0" := (![#intT] "length") in
+      (func_call #nextPowerOfTwo) "$a0") in
+      do:  ("modulus" <-[#uintT] "$r0");;;
+      (let: "idx" := (mem.alloc (type.zero_val #intT)) in
+      let: "$r0" := (((![#intT] "a") + (((![#intT] "length") `quots` #(W64 4)) * #(W64 2))) - #(W64 1)) in
+      do:  ("idx" <-[#intT] "$r0");;;
+      (for: (λ: <>, int_leq (![#intT] "idx") (((![#intT] "a") + (((![#intT] "length") `quots` #(W64 4)) * #(W64 2))) + #(W64 1))); (λ: <>, do:  ("idx" <-[#intT] ((![#intT] "idx") + #(W64 1)))) := λ: <>,
+        let: "other" := (mem.alloc (type.zero_val #intT)) in
+        let: "$r0" := (u_to_w64 ((u_to_w64 ((method_call #(ptrT.id xorshift.id) #"Next"%go "random") #())) `and` ((![#uintT] "modulus") - #(W64 1)))) in
+        do:  ("other" <-[#intT] "$r0");;;
+        (if: int_geq (![#intT] "other") (![#intT] "length")
+        then do:  ("other" <-[#intT] ((![#intT] "other") - (![#intT] "length")))
+        else do:  #());;;
+        let: "$r0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "a") + (![#intT] "other")))) in
+        let: "$r1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "idx"))) in
+        do:  ((slice.elem_ref "E" (![#sliceT] "data") (![#intT] "idx")) <-["E"] "$r0");;;
+        do:  ((slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "a") + (![#intT] "other"))) <-["E"] "$r1")))
+    else do:  #());;;
+    return: #()).
 
 Definition medianCmpFunc : go_string := "slices.medianCmpFunc"%go.
 
 Definition medianAdjacentCmpFunc : go_string := "slices.medianAdjacentCmpFunc"%go.
 
-Definition reverseRangeCmpFunc : go_string := "slices.reverseRangeCmpFunc"%go.
+(* choosePivotCmpFunc chooses a pivot in data[a:b].
+
+   [0,8): chooses a static pivot.
+   [8,shortestNinther): uses the simple median-of-three method.
+   [shortestNinther,∞): uses the Tukey ninther method.
+
+   go: zsortanyfunc.go:261:6 *)
+Definition choosePivotCmpFuncⁱᵐᵖˡ : val :=
+  λ: "E" "data" "a" "b" "cmp",
+    exception_do (let: "hint" := (mem.alloc (type.zero_val #sortedHint)) in
+    let: "pivot" := (mem.alloc (type.zero_val #intT)) in
+    let: "cmp" := (mem.alloc "cmp") in
+    let: "b" := (mem.alloc "b") in
+    let: "a" := (mem.alloc "a") in
+    let: "data" := (mem.alloc "data") in
+    let shortestNinther := 50 in
+    let maxSwaps := 12 in
+    let: "l" := (mem.alloc (type.zero_val #intT)) in
+    let: "$r0" := ((![#intT] "b") - (![#intT] "a")) in
+    do:  ("l" <-[#intT] "$r0");;;
+    let: "k" := (mem.alloc (type.zero_val #intT)) in
+    let: "$r0" := ((![#intT] "a") + (((![#intT] "l") `quots` #(W64 4)) * #(W64 3))) in
+    do:  ("k" <-[#intT] "$r0");;;
+    let: "j" := (mem.alloc (type.zero_val #intT)) in
+    let: "$r0" := ((![#intT] "a") + (((![#intT] "l") `quots` #(W64 4)) * #(W64 2))) in
+    do:  ("j" <-[#intT] "$r0");;;
+    let: "i" := (mem.alloc (type.zero_val #intT)) in
+    let: "$r0" := ((![#intT] "a") + (((![#intT] "l") `quots` #(W64 4)) * #(W64 1))) in
+    do:  ("i" <-[#intT] "$r0");;;
+    let: "swaps" := (mem.alloc (type.zero_val #intT)) in
+    (if: int_geq (![#intT] "l") #(W64 8)
+    then
+      (if: int_geq (![#intT] "l") #(W64 shortestNinther)
+      then
+        let: "$r0" := (let: "$a0" := (![#sliceT] "data") in
+        let: "$a1" := (![#intT] "i") in
+        let: "$a2" := "swaps" in
+        let: "$a3" := (![#funcT] "cmp") in
+        ((func_call #medianAdjacentCmpFunc) "E") "$a0" "$a1" "$a2" "$a3") in
+        do:  ("i" <-[#intT] "$r0");;;
+        let: "$r0" := (let: "$a0" := (![#sliceT] "data") in
+        let: "$a1" := (![#intT] "j") in
+        let: "$a2" := "swaps" in
+        let: "$a3" := (![#funcT] "cmp") in
+        ((func_call #medianAdjacentCmpFunc) "E") "$a0" "$a1" "$a2" "$a3") in
+        do:  ("j" <-[#intT] "$r0");;;
+        let: "$r0" := (let: "$a0" := (![#sliceT] "data") in
+        let: "$a1" := (![#intT] "k") in
+        let: "$a2" := "swaps" in
+        let: "$a3" := (![#funcT] "cmp") in
+        ((func_call #medianAdjacentCmpFunc) "E") "$a0" "$a1" "$a2" "$a3") in
+        do:  ("k" <-[#intT] "$r0")
+      else do:  #());;;
+      let: "$r0" := (let: "$a0" := (![#sliceT] "data") in
+      let: "$a1" := (![#intT] "i") in
+      let: "$a2" := (![#intT] "j") in
+      let: "$a3" := (![#intT] "k") in
+      let: "$a4" := "swaps" in
+      let: "$a5" := (![#funcT] "cmp") in
+      ((func_call #medianCmpFunc) "E") "$a0" "$a1" "$a2" "$a3" "$a4" "$a5") in
+      do:  ("j" <-[#intT] "$r0")
+    else do:  #());;;
+    let: "$sw" := (![#intT] "swaps") in
+    (if: "$sw" = #(W64 0)
+    then return: (![#intT] "j", increasingHint)
+    else
+      (if: "$sw" = #(W64 maxSwaps)
+      then return: (![#intT] "j", decreasingHint)
+      else return: (![#intT] "j", unknownHint)))).
+
+Definition order2CmpFunc : go_string := "slices.order2CmpFunc"%go.
+
+(* order2CmpFunc returns x,y where data[x] <= data[y], where x,y=a,b or x,y=b,a.
+
+   go: zsortanyfunc.go:298:6 *)
+Definition order2CmpFuncⁱᵐᵖˡ : val :=
+  λ: "E" "data" "a" "b" "swaps" "cmp",
+    exception_do (let: "cmp" := (mem.alloc "cmp") in
+    let: "swaps" := (mem.alloc "swaps") in
+    let: "b" := (mem.alloc "b") in
+    let: "a" := (mem.alloc "a") in
+    let: "data" := (mem.alloc "data") in
+    (if: int_lt (let: "$a0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "b"))) in
+    let: "$a1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "a"))) in
+    (![#funcT] "cmp") "$a0" "$a1") #(W64 0)
+    then
+      do:  ((![#ptrT] "swaps") <-[#intT] ((![#intT] (![#ptrT] "swaps")) + #(W64 1)));;;
+      return: (![#intT] "b", ![#intT] "a")
+    else do:  #());;;
+    return: (![#intT] "a", ![#intT] "b")).
+
+(* medianCmpFunc returns x where data[x] is the median of data[a],data[b],data[c], where x is a, b, or c.
+
+   go: zsortanyfunc.go:307:6 *)
+Definition medianCmpFuncⁱᵐᵖˡ : val :=
+  λ: "E" "data" "a" "b" "c" "swaps" "cmp",
+    exception_do (let: "cmp" := (mem.alloc "cmp") in
+    let: "swaps" := (mem.alloc "swaps") in
+    let: "c" := (mem.alloc "c") in
+    let: "b" := (mem.alloc "b") in
+    let: "a" := (mem.alloc "a") in
+    let: "data" := (mem.alloc "data") in
+    let: ("$ret0", "$ret1") := (let: "$a0" := (![#sliceT] "data") in
+    let: "$a1" := (![#intT] "a") in
+    let: "$a2" := (![#intT] "b") in
+    let: "$a3" := (![#ptrT] "swaps") in
+    let: "$a4" := (![#funcT] "cmp") in
+    ((func_call #order2CmpFunc) "E") "$a0" "$a1" "$a2" "$a3" "$a4") in
+    let: "$r0" := "$ret0" in
+    let: "$r1" := "$ret1" in
+    do:  ("a" <-[#intT] "$r0");;;
+    do:  ("b" <-[#intT] "$r1");;;
+    let: ("$ret0", "$ret1") := (let: "$a0" := (![#sliceT] "data") in
+    let: "$a1" := (![#intT] "b") in
+    let: "$a2" := (![#intT] "c") in
+    let: "$a3" := (![#ptrT] "swaps") in
+    let: "$a4" := (![#funcT] "cmp") in
+    ((func_call #order2CmpFunc) "E") "$a0" "$a1" "$a2" "$a3" "$a4") in
+    let: "$r0" := "$ret0" in
+    let: "$r1" := "$ret1" in
+    do:  ("b" <-[#intT] "$r0");;;
+    do:  ("c" <-[#intT] "$r1");;;
+    let: ("$ret0", "$ret1") := (let: "$a0" := (![#sliceT] "data") in
+    let: "$a1" := (![#intT] "a") in
+    let: "$a2" := (![#intT] "b") in
+    let: "$a3" := (![#ptrT] "swaps") in
+    let: "$a4" := (![#funcT] "cmp") in
+    ((func_call #order2CmpFunc) "E") "$a0" "$a1" "$a2" "$a3" "$a4") in
+    let: "$r0" := "$ret0" in
+    let: "$r1" := "$ret1" in
+    do:  ("a" <-[#intT] "$r0");;;
+    do:  ("b" <-[#intT] "$r1");;;
+    return: (![#intT] "b")).
+
+(* medianAdjacentCmpFunc finds the median of data[a - 1], data[a], data[a + 1] and stores the index into a.
+
+   go: zsortanyfunc.go:315:6 *)
+Definition medianAdjacentCmpFuncⁱᵐᵖˡ : val :=
+  λ: "E" "data" "a" "swaps" "cmp",
+    exception_do (let: "cmp" := (mem.alloc "cmp") in
+    let: "swaps" := (mem.alloc "swaps") in
+    let: "a" := (mem.alloc "a") in
+    let: "data" := (mem.alloc "data") in
+    return: (let: "$a0" := (![#sliceT] "data") in
+     let: "$a1" := ((![#intT] "a") - #(W64 1)) in
+     let: "$a2" := (![#intT] "a") in
+     let: "$a3" := ((![#intT] "a") + #(W64 1)) in
+     let: "$a4" := (![#ptrT] "swaps") in
+     let: "$a5" := (![#funcT] "cmp") in
+     ((func_call #medianCmpFunc) "E") "$a0" "$a1" "$a2" "$a3" "$a4" "$a5")).
+
+(* go: zsortanyfunc.go:319:6 *)
+Definition reverseRangeCmpFuncⁱᵐᵖˡ : val :=
+  λ: "E" "data" "a" "b" "cmp",
+    exception_do (let: "cmp" := (mem.alloc "cmp") in
+    let: "b" := (mem.alloc "b") in
+    let: "a" := (mem.alloc "a") in
+    let: "data" := (mem.alloc "data") in
+    let: "i" := (mem.alloc (type.zero_val #intT)) in
+    let: "$r0" := (![#intT] "a") in
+    do:  ("i" <-[#intT] "$r0");;;
+    let: "j" := (mem.alloc (type.zero_val #intT)) in
+    let: "$r0" := ((![#intT] "b") - #(W64 1)) in
+    do:  ("j" <-[#intT] "$r0");;;
+    (for: (λ: <>, int_lt (![#intT] "i") (![#intT] "j")); (λ: <>, #()) := λ: <>,
+      let: "$r0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "j"))) in
+      let: "$r1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "i"))) in
+      do:  ((slice.elem_ref "E" (![#sliceT] "data") (![#intT] "i")) <-["E"] "$r0");;;
+      do:  ((slice.elem_ref "E" (![#sliceT] "data") (![#intT] "j")) <-["E"] "$r1");;;
+      do:  ("i" <-[#intT] ((![#intT] "i") + #(W64 1)));;;
+      do:  ("j" <-[#intT] ((![#intT] "j") - #(W64 1))));;;
+    return: #()).
 
 Definition swapRangeCmpFunc : go_string := "slices.swapRangeCmpFunc"%go.
+
+(* go: zsortanyfunc.go:329:6 *)
+Definition swapRangeCmpFuncⁱᵐᵖˡ : val :=
+  λ: "E" "data" "a" "b" "n" "cmp",
+    exception_do (let: "cmp" := (mem.alloc "cmp") in
+    let: "n" := (mem.alloc "n") in
+    let: "b" := (mem.alloc "b") in
+    let: "a" := (mem.alloc "a") in
+    let: "data" := (mem.alloc "data") in
+    (let: "i" := (mem.alloc (type.zero_val #intT)) in
+    let: "$r0" := #(W64 0) in
+    do:  ("i" <-[#intT] "$r0");;;
+    (for: (λ: <>, int_lt (![#intT] "i") (![#intT] "n")); (λ: <>, do:  ("i" <-[#intT] ((![#intT] "i") + #(W64 1)))) := λ: <>,
+      let: "$r0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "b") + (![#intT] "i")))) in
+      let: "$r1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "a") + (![#intT] "i")))) in
+      do:  ((slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "a") + (![#intT] "i"))) <-["E"] "$r0");;;
+      do:  ((slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "b") + (![#intT] "i"))) <-["E"] "$r1")));;;
+    return: #()).
 
 Definition stableCmpFunc : go_string := "slices.stableCmpFunc"%go.
 
 Definition symMergeCmpFunc : go_string := "slices.symMergeCmpFunc"%go.
 
+(* go: zsortanyfunc.go:335:6 *)
+Definition stableCmpFuncⁱᵐᵖˡ : val :=
+  λ: "E" "data" "n" "cmp",
+    exception_do (let: "cmp" := (mem.alloc "cmp") in
+    let: "n" := (mem.alloc "n") in
+    let: "data" := (mem.alloc "data") in
+    let: "blockSize" := (mem.alloc (type.zero_val #intT)) in
+    let: "$r0" := #(W64 20) in
+    do:  ("blockSize" <-[#intT] "$r0");;;
+    let: "b" := (mem.alloc (type.zero_val #intT)) in
+    let: "a" := (mem.alloc (type.zero_val #intT)) in
+    let: "$r0" := #(W64 0) in
+    let: "$r1" := (![#intT] "blockSize") in
+    do:  ("a" <-[#intT] "$r0");;;
+    do:  ("b" <-[#intT] "$r1");;;
+    (for: (λ: <>, int_leq (![#intT] "b") (![#intT] "n")); (λ: <>, #()) := λ: <>,
+      do:  (let: "$a0" := (![#sliceT] "data") in
+      let: "$a1" := (![#intT] "a") in
+      let: "$a2" := (![#intT] "b") in
+      let: "$a3" := (![#funcT] "cmp") in
+      ((func_call #insertionSortCmpFunc) "E") "$a0" "$a1" "$a2" "$a3");;;
+      let: "$r0" := (![#intT] "b") in
+      do:  ("a" <-[#intT] "$r0");;;
+      do:  ("b" <-[#intT] ((![#intT] "b") + (![#intT] "blockSize"))));;;
+    do:  (let: "$a0" := (![#sliceT] "data") in
+    let: "$a1" := (![#intT] "a") in
+    let: "$a2" := (![#intT] "n") in
+    let: "$a3" := (![#funcT] "cmp") in
+    ((func_call #insertionSortCmpFunc) "E") "$a0" "$a1" "$a2" "$a3");;;
+    (for: (λ: <>, int_lt (![#intT] "blockSize") (![#intT] "n")); (λ: <>, #()) := λ: <>,
+      let: "$r0" := #(W64 0) in
+      let: "$r1" := (#(W64 2) * (![#intT] "blockSize")) in
+      do:  ("a" <-[#intT] "$r0");;;
+      do:  ("b" <-[#intT] "$r1");;;
+      (for: (λ: <>, int_leq (![#intT] "b") (![#intT] "n")); (λ: <>, #()) := λ: <>,
+        do:  (let: "$a0" := (![#sliceT] "data") in
+        let: "$a1" := (![#intT] "a") in
+        let: "$a2" := ((![#intT] "a") + (![#intT] "blockSize")) in
+        let: "$a3" := (![#intT] "b") in
+        let: "$a4" := (![#funcT] "cmp") in
+        ((func_call #symMergeCmpFunc) "E") "$a0" "$a1" "$a2" "$a3" "$a4");;;
+        let: "$r0" := (![#intT] "b") in
+        do:  ("a" <-[#intT] "$r0");;;
+        do:  ("b" <-[#intT] ((![#intT] "b") + (#(W64 2) * (![#intT] "blockSize")))));;;
+      (let: "m" := (mem.alloc (type.zero_val #intT)) in
+      let: "$r0" := ((![#intT] "a") + (![#intT] "blockSize")) in
+      do:  ("m" <-[#intT] "$r0");;;
+      (if: int_lt (![#intT] "m") (![#intT] "n")
+      then
+        do:  (let: "$a0" := (![#sliceT] "data") in
+        let: "$a1" := (![#intT] "a") in
+        let: "$a2" := (![#intT] "m") in
+        let: "$a3" := (![#intT] "n") in
+        let: "$a4" := (![#funcT] "cmp") in
+        ((func_call #symMergeCmpFunc) "E") "$a0" "$a1" "$a2" "$a3" "$a4")
+      else do:  #()));;;
+      do:  ("blockSize" <-[#intT] ((![#intT] "blockSize") * #(W64 2))));;;
+    return: #()).
+
 Definition rotateCmpFunc : go_string := "slices.rotateCmpFunc"%go.
+
+(* symMergeCmpFunc merges the two sorted subsequences data[a:m] and data[m:b] using
+   the SymMerge algorithm from Pok-Son Kim and Arne Kutzner, "Stable Minimum
+   Storage Merging by Symmetric Comparisons", in Susanne Albers and Tomasz
+   Radzik, editors, Algorithms - ESA 2004, volume 3221 of Lecture Notes in
+   Computer Science, pages 714-723. Springer, 2004.
+
+   Let M = m-a and N = b-n. Wolog M < N.
+   The recursion depth is bound by ceil(log(N+M)).
+   The algorithm needs O(M*log(N/M + 1)) calls to data.Less.
+   The algorithm needs O((M+N)*log(M)) calls to data.Swap.
+
+   The paper gives O((M+N)*log(M)) as the number of assignments assuming a
+   rotation algorithm which uses O(M+N+gcd(M+N)) assignments. The argumentation
+   in the paper carries through for Swap operations, especially as the block
+   swapping rotate uses only O(M+N) Swaps.
+
+   symMerge assumes non-degenerate arguments: a < m && m < b.
+   Having the caller check this condition eliminates many leaf recursion calls,
+   which improves performance.
+
+   go: zsortanyfunc.go:378:6 *)
+Definition symMergeCmpFuncⁱᵐᵖˡ : val :=
+  λ: "E" "data" "a" "m" "b" "cmp",
+    exception_do (let: "cmp" := (mem.alloc "cmp") in
+    let: "b" := (mem.alloc "b") in
+    let: "m" := (mem.alloc "m") in
+    let: "a" := (mem.alloc "a") in
+    let: "data" := (mem.alloc "data") in
+    (if: ((![#intT] "m") - (![#intT] "a")) = #(W64 1)
+    then
+      let: "i" := (mem.alloc (type.zero_val #intT)) in
+      let: "$r0" := (![#intT] "m") in
+      do:  ("i" <-[#intT] "$r0");;;
+      let: "j" := (mem.alloc (type.zero_val #intT)) in
+      let: "$r0" := (![#intT] "b") in
+      do:  ("j" <-[#intT] "$r0");;;
+      (for: (λ: <>, int_lt (![#intT] "i") (![#intT] "j")); (λ: <>, #()) := λ: <>,
+        let: "h" := (mem.alloc (type.zero_val #intT)) in
+        let: "$r0" := (u_to_w64 ((s_to_w64 ((![#intT] "i") + (![#intT] "j"))) ≫ #(W64 1))) in
+        do:  ("h" <-[#intT] "$r0");;;
+        (if: int_lt (let: "$a0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "h"))) in
+        let: "$a1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "a"))) in
+        (![#funcT] "cmp") "$a0" "$a1") #(W64 0)
+        then
+          let: "$r0" := ((![#intT] "h") + #(W64 1)) in
+          do:  ("i" <-[#intT] "$r0")
+        else
+          let: "$r0" := (![#intT] "h") in
+          do:  ("j" <-[#intT] "$r0")));;;
+      (let: "k" := (mem.alloc (type.zero_val #intT)) in
+      let: "$r0" := (![#intT] "a") in
+      do:  ("k" <-[#intT] "$r0");;;
+      (for: (λ: <>, int_lt (![#intT] "k") ((![#intT] "i") - #(W64 1))); (λ: <>, do:  ("k" <-[#intT] ((![#intT] "k") + #(W64 1)))) := λ: <>,
+        let: "$r0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "k") + #(W64 1)))) in
+        let: "$r1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "k"))) in
+        do:  ((slice.elem_ref "E" (![#sliceT] "data") (![#intT] "k")) <-["E"] "$r0");;;
+        do:  ((slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "k") + #(W64 1))) <-["E"] "$r1")));;;
+      return: (#())
+    else do:  #());;;
+    (if: ((![#intT] "b") - (![#intT] "m")) = #(W64 1)
+    then
+      let: "i" := (mem.alloc (type.zero_val #intT)) in
+      let: "$r0" := (![#intT] "a") in
+      do:  ("i" <-[#intT] "$r0");;;
+      let: "j" := (mem.alloc (type.zero_val #intT)) in
+      let: "$r0" := (![#intT] "m") in
+      do:  ("j" <-[#intT] "$r0");;;
+      (for: (λ: <>, int_lt (![#intT] "i") (![#intT] "j")); (λ: <>, #()) := λ: <>,
+        let: "h" := (mem.alloc (type.zero_val #intT)) in
+        let: "$r0" := (u_to_w64 ((s_to_w64 ((![#intT] "i") + (![#intT] "j"))) ≫ #(W64 1))) in
+        do:  ("h" <-[#intT] "$r0");;;
+        (if: (~ (int_lt (let: "$a0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "m"))) in
+        let: "$a1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "h"))) in
+        (![#funcT] "cmp") "$a0" "$a1") #(W64 0)))
+        then
+          let: "$r0" := ((![#intT] "h") + #(W64 1)) in
+          do:  ("i" <-[#intT] "$r0")
+        else
+          let: "$r0" := (![#intT] "h") in
+          do:  ("j" <-[#intT] "$r0")));;;
+      (let: "k" := (mem.alloc (type.zero_val #intT)) in
+      let: "$r0" := (![#intT] "m") in
+      do:  ("k" <-[#intT] "$r0");;;
+      (for: (λ: <>, int_gt (![#intT] "k") (![#intT] "i")); (λ: <>, do:  ("k" <-[#intT] ((![#intT] "k") - #(W64 1)))) := λ: <>,
+        let: "$r0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "k") - #(W64 1)))) in
+        let: "$r1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "k"))) in
+        do:  ((slice.elem_ref "E" (![#sliceT] "data") (![#intT] "k")) <-["E"] "$r0");;;
+        do:  ((slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "k") - #(W64 1))) <-["E"] "$r1")));;;
+      return: (#())
+    else do:  #());;;
+    let: "mid" := (mem.alloc (type.zero_val #intT)) in
+    let: "$r0" := (u_to_w64 ((s_to_w64 ((![#intT] "a") + (![#intT] "b"))) ≫ #(W64 1))) in
+    do:  ("mid" <-[#intT] "$r0");;;
+    let: "n" := (mem.alloc (type.zero_val #intT)) in
+    let: "$r0" := ((![#intT] "mid") + (![#intT] "m")) in
+    do:  ("n" <-[#intT] "$r0");;;
+    let: "r" := (mem.alloc (type.zero_val #intT)) in
+    let: "start" := (mem.alloc (type.zero_val #intT)) in
+    (if: int_gt (![#intT] "m") (![#intT] "mid")
+    then
+      let: "$r0" := ((![#intT] "n") - (![#intT] "b")) in
+      do:  ("start" <-[#intT] "$r0");;;
+      let: "$r0" := (![#intT] "mid") in
+      do:  ("r" <-[#intT] "$r0")
+    else
+      let: "$r0" := (![#intT] "a") in
+      do:  ("start" <-[#intT] "$r0");;;
+      let: "$r0" := (![#intT] "m") in
+      do:  ("r" <-[#intT] "$r0"));;;
+    let: "p" := (mem.alloc (type.zero_val #intT)) in
+    let: "$r0" := ((![#intT] "n") - #(W64 1)) in
+    do:  ("p" <-[#intT] "$r0");;;
+    (for: (λ: <>, int_lt (![#intT] "start") (![#intT] "r")); (λ: <>, #()) := λ: <>,
+      let: "c" := (mem.alloc (type.zero_val #intT)) in
+      let: "$r0" := (u_to_w64 ((s_to_w64 ((![#intT] "start") + (![#intT] "r"))) ≫ #(W64 1))) in
+      do:  ("c" <-[#intT] "$r0");;;
+      (if: (~ (int_lt (let: "$a0" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") ((![#intT] "p") - (![#intT] "c")))) in
+      let: "$a1" := (!["E"] (slice.elem_ref "E" (![#sliceT] "data") (![#intT] "c"))) in
+      (![#funcT] "cmp") "$a0" "$a1") #(W64 0)))
+      then
+        let: "$r0" := ((![#intT] "c") + #(W64 1)) in
+        do:  ("start" <-[#intT] "$r0")
+      else
+        let: "$r0" := (![#intT] "c") in
+        do:  ("r" <-[#intT] "$r0")));;;
+    let: "end" := (mem.alloc (type.zero_val #intT)) in
+    let: "$r0" := ((![#intT] "n") - (![#intT] "start")) in
+    do:  ("end" <-[#intT] "$r0");;;
+    (if: (int_lt (![#intT] "start") (![#intT] "m")) && (int_lt (![#intT] "m") (![#intT] "end"))
+    then
+      do:  (let: "$a0" := (![#sliceT] "data") in
+      let: "$a1" := (![#intT] "start") in
+      let: "$a2" := (![#intT] "m") in
+      let: "$a3" := (![#intT] "end") in
+      let: "$a4" := (![#funcT] "cmp") in
+      ((func_call #rotateCmpFunc) "E") "$a0" "$a1" "$a2" "$a3" "$a4")
+    else do:  #());;;
+    (if: (int_lt (![#intT] "a") (![#intT] "start")) && (int_lt (![#intT] "start") (![#intT] "mid"))
+    then
+      do:  (let: "$a0" := (![#sliceT] "data") in
+      let: "$a1" := (![#intT] "a") in
+      let: "$a2" := (![#intT] "start") in
+      let: "$a3" := (![#intT] "mid") in
+      let: "$a4" := (![#funcT] "cmp") in
+      ((func_call #symMergeCmpFunc) "E") "$a0" "$a1" "$a2" "$a3" "$a4")
+    else do:  #());;;
+    (if: (int_lt (![#intT] "mid") (![#intT] "end")) && (int_lt (![#intT] "end") (![#intT] "b"))
+    then
+      do:  (let: "$a0" := (![#sliceT] "data") in
+      let: "$a1" := (![#intT] "mid") in
+      let: "$a2" := (![#intT] "end") in
+      let: "$a3" := (![#intT] "b") in
+      let: "$a4" := (![#funcT] "cmp") in
+      ((func_call #symMergeCmpFunc) "E") "$a0" "$a1" "$a2" "$a3" "$a4")
+    else do:  #());;;
+    return: #()).
+
+(* rotateCmpFunc rotates two consecutive blocks u = data[a:m] and v = data[m:b] in data:
+   Data of the form 'x u v y' is changed to 'x v u y'.
+   rotate performs at most b-a many calls to data.Swap,
+   and it assumes non-degenerate arguments: a < m && m < b.
+
+   go: zsortanyfunc.go:464:6 *)
+Definition rotateCmpFuncⁱᵐᵖˡ : val :=
+  λ: "E" "data" "a" "m" "b" "cmp",
+    exception_do (let: "cmp" := (mem.alloc "cmp") in
+    let: "b" := (mem.alloc "b") in
+    let: "m" := (mem.alloc "m") in
+    let: "a" := (mem.alloc "a") in
+    let: "data" := (mem.alloc "data") in
+    let: "i" := (mem.alloc (type.zero_val #intT)) in
+    let: "$r0" := ((![#intT] "m") - (![#intT] "a")) in
+    do:  ("i" <-[#intT] "$r0");;;
+    let: "j" := (mem.alloc (type.zero_val #intT)) in
+    let: "$r0" := ((![#intT] "b") - (![#intT] "m")) in
+    do:  ("j" <-[#intT] "$r0");;;
+    (for: (λ: <>, (![#intT] "i") ≠ (![#intT] "j")); (λ: <>, #()) := λ: <>,
+      (if: int_gt (![#intT] "i") (![#intT] "j")
+      then
+        do:  (let: "$a0" := (![#sliceT] "data") in
+        let: "$a1" := ((![#intT] "m") - (![#intT] "i")) in
+        let: "$a2" := (![#intT] "m") in
+        let: "$a3" := (![#intT] "j") in
+        let: "$a4" := (![#funcT] "cmp") in
+        ((func_call #swapRangeCmpFunc) "E") "$a0" "$a1" "$a2" "$a3" "$a4");;;
+        do:  ("i" <-[#intT] ((![#intT] "i") - (![#intT] "j")))
+      else
+        do:  (let: "$a0" := (![#sliceT] "data") in
+        let: "$a1" := ((![#intT] "m") - (![#intT] "i")) in
+        let: "$a2" := (((![#intT] "m") + (![#intT] "j")) - (![#intT] "i")) in
+        let: "$a3" := (![#intT] "i") in
+        let: "$a4" := (![#funcT] "cmp") in
+        ((func_call #swapRangeCmpFunc) "E") "$a0" "$a1" "$a2" "$a3" "$a4");;;
+        do:  ("j" <-[#intT] ((![#intT] "j") - (![#intT] "i")))));;;
+    do:  (let: "$a0" := (![#sliceT] "data") in
+    let: "$a1" := ((![#intT] "m") - (![#intT] "i")) in
+    let: "$a2" := (![#intT] "m") in
+    let: "$a3" := (![#intT] "i") in
+    let: "$a4" := (![#funcT] "cmp") in
+    ((func_call #swapRangeCmpFunc) "E") "$a0" "$a1" "$a2" "$a3" "$a4");;;
+    return: #()).
 
 Definition insertionSortOrdered : go_string := "slices.insertionSortOrdered"%go.
 
@@ -275,40 +1199,6 @@ Axiom BinarySearchFuncⁱᵐᵖˡ : val.
 Axiom nextPowerOfTwoⁱᵐᵖˡ : val.
 
 Axiom isNaNⁱᵐᵖˡ : val.
-
-Axiom insertionSortCmpFuncⁱᵐᵖˡ : val.
-
-Axiom siftDownCmpFuncⁱᵐᵖˡ : val.
-
-Axiom heapSortCmpFuncⁱᵐᵖˡ : val.
-
-Axiom pdqsortCmpFuncⁱᵐᵖˡ : val.
-
-Axiom partitionCmpFuncⁱᵐᵖˡ : val.
-
-Axiom partitionEqualCmpFuncⁱᵐᵖˡ : val.
-
-Axiom partialInsertionSortCmpFuncⁱᵐᵖˡ : val.
-
-Axiom breakPatternsCmpFuncⁱᵐᵖˡ : val.
-
-Axiom choosePivotCmpFuncⁱᵐᵖˡ : val.
-
-Axiom order2CmpFuncⁱᵐᵖˡ : val.
-
-Axiom medianCmpFuncⁱᵐᵖˡ : val.
-
-Axiom medianAdjacentCmpFuncⁱᵐᵖˡ : val.
-
-Axiom reverseRangeCmpFuncⁱᵐᵖˡ : val.
-
-Axiom swapRangeCmpFuncⁱᵐᵖˡ : val.
-
-Axiom stableCmpFuncⁱᵐᵖˡ : val.
-
-Axiom symMergeCmpFuncⁱᵐᵖˡ : val.
-
-Axiom rotateCmpFuncⁱᵐᵖˡ : val.
 
 Axiom insertionSortOrderedⁱᵐᵖˡ : val.
 

--- a/new/code/slices.v.toml
+++ b/new/code/slices.v.toml
@@ -1,2 +1,2 @@
-translate = ["!*"]
+translate = ["*CmpFunc"]
 imports = ["!*"]

--- a/new/generatedproof/slices.v
+++ b/new/generatedproof/slices.v
@@ -64,5 +64,73 @@ Global Program Instance is_pkg_defined_slices : IsPkgDefined slices :=
 Final Obligation. iIntros. iFrame "#%". Qed.
 #[local] Opaque is_pkg_defined_single is_pkg_defined_pure_single.
 
+Global Instance wp_func_call_insertionSortCmpFunc :
+  WpFuncCall slices.insertionSortCmpFunc _ (is_pkg_defined slices) :=
+  ltac:(solve_wp_func_call).
+
+Global Instance wp_func_call_siftDownCmpFunc :
+  WpFuncCall slices.siftDownCmpFunc _ (is_pkg_defined slices) :=
+  ltac:(solve_wp_func_call).
+
+Global Instance wp_func_call_heapSortCmpFunc :
+  WpFuncCall slices.heapSortCmpFunc _ (is_pkg_defined slices) :=
+  ltac:(solve_wp_func_call).
+
+Global Instance wp_func_call_pdqsortCmpFunc :
+  WpFuncCall slices.pdqsortCmpFunc _ (is_pkg_defined slices) :=
+  ltac:(solve_wp_func_call).
+
+Global Instance wp_func_call_partitionCmpFunc :
+  WpFuncCall slices.partitionCmpFunc _ (is_pkg_defined slices) :=
+  ltac:(solve_wp_func_call).
+
+Global Instance wp_func_call_partitionEqualCmpFunc :
+  WpFuncCall slices.partitionEqualCmpFunc _ (is_pkg_defined slices) :=
+  ltac:(solve_wp_func_call).
+
+Global Instance wp_func_call_partialInsertionSortCmpFunc :
+  WpFuncCall slices.partialInsertionSortCmpFunc _ (is_pkg_defined slices) :=
+  ltac:(solve_wp_func_call).
+
+Global Instance wp_func_call_breakPatternsCmpFunc :
+  WpFuncCall slices.breakPatternsCmpFunc _ (is_pkg_defined slices) :=
+  ltac:(solve_wp_func_call).
+
+Global Instance wp_func_call_choosePivotCmpFunc :
+  WpFuncCall slices.choosePivotCmpFunc _ (is_pkg_defined slices) :=
+  ltac:(solve_wp_func_call).
+
+Global Instance wp_func_call_order2CmpFunc :
+  WpFuncCall slices.order2CmpFunc _ (is_pkg_defined slices) :=
+  ltac:(solve_wp_func_call).
+
+Global Instance wp_func_call_medianCmpFunc :
+  WpFuncCall slices.medianCmpFunc _ (is_pkg_defined slices) :=
+  ltac:(solve_wp_func_call).
+
+Global Instance wp_func_call_medianAdjacentCmpFunc :
+  WpFuncCall slices.medianAdjacentCmpFunc _ (is_pkg_defined slices) :=
+  ltac:(solve_wp_func_call).
+
+Global Instance wp_func_call_reverseRangeCmpFunc :
+  WpFuncCall slices.reverseRangeCmpFunc _ (is_pkg_defined slices) :=
+  ltac:(solve_wp_func_call).
+
+Global Instance wp_func_call_swapRangeCmpFunc :
+  WpFuncCall slices.swapRangeCmpFunc _ (is_pkg_defined slices) :=
+  ltac:(solve_wp_func_call).
+
+Global Instance wp_func_call_stableCmpFunc :
+  WpFuncCall slices.stableCmpFunc _ (is_pkg_defined slices) :=
+  ltac:(solve_wp_func_call).
+
+Global Instance wp_func_call_symMergeCmpFunc :
+  WpFuncCall slices.symMergeCmpFunc _ (is_pkg_defined slices) :=
+  ltac:(solve_wp_func_call).
+
+Global Instance wp_func_call_rotateCmpFunc :
+  WpFuncCall slices.rotateCmpFunc _ (is_pkg_defined slices) :=
+  ltac:(solve_wp_func_call).
+
 End names.
 End slices.

--- a/new/proof/slices.v
+++ b/new/proof/slices.v
@@ -1,0 +1,1 @@
+From New.proof.slices_proof Require Export sort.

--- a/new/proof/slices_proof/slices_init.v
+++ b/new/proof/slices_proof/slices_init.v
@@ -1,0 +1,10 @@
+From New.generatedproof Require Import slices.
+From New.proof Require Import proof_prelude.
+
+Section proof.
+Context  `{hG: heapGS Σ, !ffi_semantics _ _} `{!globalsGS Σ} {go_ctx : GoContext}.
+
+#[global] Instance : IsPkgInit slices := define_is_pkg_init True%I.
+#[global] Instance : GetIsPkgInitWf slices := build_get_is_pkg_init_wf.
+
+End proof.

--- a/new/proof/slices_proof/sort.v
+++ b/new/proof/slices_proof/sort.v
@@ -1,0 +1,8 @@
+From New.generatedproof Require Import slices.
+From New.proof Require Import proof_prelude.
+From New.proof.slices_proof Require Import slices_init.
+
+Section proof.
+Context  `{hG: heapGS Σ, !ffi_semantics _ _} `{!globalsGS Σ} {go_ctx : GoContext}.
+
+End proof.

--- a/new/should_build.v
+++ b/new/should_build.v
@@ -13,7 +13,7 @@ From New.proof.github_com.goose_lang.goose.model.channel.protocol
   Require protocols.
 
 From New.proof Require go_etcd_io.etcd.client.v3.leasing.
-From New.proof Require Import bytes chan context sort.
+From New.proof Require Import bytes chan context sort slices.
 
 Require New.generatedproof.github_com.mit_pdos.gokv.vrsm.apps.closed.
 


### PR DESCRIPTION
Translate the sorting implementation that underlies `slices.SortFunc`.

Translating `slices.SortFunc` itself is just a bit painful because it relies on `bits.Len`, which does not currently translate. Other than that `slices.SortFunc` is essentially just `pdqsortCmpFunc`.