### PR TITLE
Avoid setup-rocq scanning Perennial opam pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
         uses: tchajed/setup-rocq@v1
         with:
           rocq-version: "${{ matrix.rocq-version }}"
+          cache-key-opam-files: ""
       - name: Install build dependencies
         run: |
           opam install --deps-only ./perennial.opam


### PR DESCRIPTION
This fixes CI failing in the Rocq setup step when `setup-rocq` sees the `rocq-stdpp.dev` and `rocq-iris.dev` pins in `perennial.opam`. Those pins are for Perennial’s library dependencies and are installed later by `opam install --deps-only ./perennial.opam`; they should not be used by `setup-rocq` to infer which Rocq package to install. Disabling opam-file scanning keeps the CI matrix `rocq-version` as the source of truth for the Rocq version, while leaving dependency installation to the existing opam step.