### PR TITLE
Fix proofgen typeparam name collision

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -12,6 +12,7 @@ github.com/goose-lang/std v0.5.0/go.mod h1:bnKHDHwU0lHf99eMI5PVM77UweRyu6qgM/h43
 github.com/kr/pty v1.1.1 h1:VkoXIwSboBpnk99O/KFauAEILuNHv5DVFKZMBN/gUgw=
 github.com/mit-pdos/gokv v0.0.0-20240710184135-76e2d6393889 h1:GjAmEiCKVc1yAEFb3ZyeaRfT6rzxZiJTSaI10p0sy7Q=
 github.com/mit-pdos/gokv v0.0.0-20240710184135-76e2d6393889/go.mod h1:LXcj7Z77EPHRIhK2Vv7+6PFi/3Okj36Qm5kQ7gq9NDk=
+github.com/mit-pdos/gokv v0.1.1/go.mod h1:ZLlOibv49aW6WzNYy/kyew+xwSOLk94LY8qYjheZHJ8=
 github.com/mit-pdos/vmvcc v0.0.0-20230715174658-6a95955d9979 h1:uCgx7zbcx6jUUHMwaBDEilJ1YHApLdhrJOh1NJ1fOvc=
 github.com/mit-pdos/vmvcc v0.0.0-20230715174658-6a95955d9979/go.mod h1:fzuSriWmRv/JeMdRV0W7dgKlRmWXuHoWhycaT2vQLbs=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=

--- a/goose/proofgen/tmpl/_typeparams.tmpl
+++ b/goose/proofgen/tmpl/_typeparams.tmpl
@@ -1,5 +1,5 @@
 {{/* partial that takes a list of type parameters (a []string) and emits the
      binders for their Gallina/go.type parameters */}}
 {{- range $T_param := . -}}
-`{!IntoVal {{$T_param}}'} `{!IntoValTyped {{$T_param}}' {{$T_param}}}{{" "}}
+({{$T_param}} : go.type) `{!IntoVal {{$T_param}}'} `{!IntoValTyped {{$T_param}}' {{$T_param}}}{{" "}}
 {{- end -}}

--- a/goose/proofgen/tmpl/types.tmpl
+++ b/goose/proofgen/tmpl/types.tmpl
@@ -16,7 +16,7 @@
 
 {{ define "IntoValParams" -}}
 {{- range $p:= . -}}
-`{!ZeroVal {{$p}}'} `{!TypedPointsto (Σ:=Σ) {{$p}}'} `{!IntoValTyped {{$p}}' {{$p}}} {{ end -}}
+({{$p}} : go.type) `{!ZeroVal {{$p}}'} `{!TypedPointsto (Σ:=Σ) {{$p}}'} `{!IntoValTyped {{$p}}' {{$p}}} {{ end -}}
 {{- end -}}
 
 {{- range $t := .Types -}}

--- a/goose/testdata/examples/unittest/generics/generics.go
+++ b/goose/testdata/examples/unittest/generics/generics.go
@@ -72,6 +72,11 @@ type MultiParam[A any, B any] struct {
 	X A
 }
 
+type TypeParamCollision[T any, C any] struct {
+	X T
+	Y C
+}
+
 func useMultiParam() {
 	mp := MultiParam[uint64, bool]{Y: true, X: 1}
 	mp.X = 2

--- a/goose/testdata/examples/unittest/generics/generics.gold.v
+++ b/goose/testdata/examples/unittest/generics/generics.gold.v
@@ -28,6 +28,10 @@ Definition MultiParam {ext : ffi_syntax} {go_gctx : GoGlobalContext} (A : go.typ
 
 #[global] Opaque MultiParam.
 
+Definition TypeParamCollision {ext : ffi_syntax} {go_gctx : GoGlobalContext} (T : go.type) (C : go.type) : go.type := go.Named "github.com/mit-pdos/perennial/goose/testdata/examples/unittest/generics.TypeParamCollision"%go [T; C].
+
+#[global] Opaque TypeParamCollision.
+
 Definition nonStructGeneric {ext : ffi_syntax} {go_gctx : GoGlobalContext} (T : go.type) : go.type := go.Named "github.com/mit-pdos/perennial/goose/testdata/examples/unittest/generics.nonStructGeneric"%go [T].
 
 #[global] Opaque nonStructGeneric.
@@ -145,7 +149,7 @@ Definition useContainerⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext
     do:  ((StructFieldRef (Container go.uint64) "W"%go "container") <-[go.uint64] "$r0");;;
     return: #()).
 
-(* go: generics.go:75:6 *)
+(* go: generics.go:80:6 *)
 Definition useMultiParamⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} : val :=
   λ: <>,
     exception_do (let: "mp" := (GoAlloc (MultiParam go.uint64 go.bool) (GoZeroVal (MultiParam go.uint64 go.bool) #())) in
@@ -157,7 +161,7 @@ Definition useMultiParamⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContex
     do:  ((StructFieldRef (MultiParam go.uint64 go.bool) "X"%go "mp") <-[go.uint64] "$r0");;;
     return: #()).
 
-(* go: generics.go:80:6 *)
+(* go: generics.go:85:6 *)
 Definition swapMultiParamⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} (A : go.type) : val :=
   λ: "p",
     exception_do (let: "p" := (GoAlloc (go.PointerType (MultiParam A A)) "p") in
@@ -170,7 +174,7 @@ Definition swapMultiParamⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalConte
     do:  ((StructFieldRef (MultiParam A A) "Y"%go (![go.PointerType (MultiParam A A)] "p")) <-[A] "$r0");;;
     return: #()).
 
-(* go: generics.go:86:6 *)
+(* go: generics.go:91:6 *)
 Definition multiParamFuncⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} (A B : go.type) : val :=
   λ: "x" "b",
     exception_do (let: "b" := (GoAlloc B "b") in
@@ -178,7 +182,7 @@ Definition multiParamFuncⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalConte
     return: (let: "$v0" := (![B] "b") in
      CompositeLiteral (go.SliceType B) (LiteralValue [KeyedElement None (ElementExpression B "$v0")]))).
 
-(* go: generics.go:90:6 *)
+(* go: generics.go:95:6 *)
 Definition useMultiParamFuncⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} : val :=
   λ: <>,
     exception_do (do:  (let: "$a0" := #(W64 1) in
@@ -187,7 +191,7 @@ Definition useMultiParamFuncⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalCo
     return: (#());;;
     return: #()).
 
-(* go: generics.go:96:6 *)
+(* go: generics.go:101:6 *)
 Definition useAnyPointerⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} : val :=
   λ: <>,
     exception_do (let: "x" := (GoAlloc go.uint64 (GoZeroVal go.uint64 #())) in
@@ -383,6 +387,41 @@ Class MultiParam_Assumptions {ext : ffi_syntax} `{!GoGlobalContext} `{!GoLocalCo
   #[global] MultiParam_set_X A B A' B' (x : MultiParam.t A' B') y :: ⟦StructFieldSet (MultiParamⁱᵐᵖˡ A B) "X", (#x, #y)⟧ ⤳[under] #(x <|MultiParam.X' := y|>);
 }.
 
+Module TypeParamCollision.
+Section def.
+Context {ext : ffi_syntax} {go_gctx : GoGlobalContext}.
+Record t {T C : Type} :=
+mk {
+  X' : T;
+  Y' : C;
+}.
+
+#[global] Instance zero_val `{!ZeroVal T} `{!ZeroVal C} : ZeroVal t := {| zero_val := mk T C (zero_val _) (zero_val _)|}.
+#[global] Arguments mk : clear implicits.
+#[global] Arguments t : clear implicits.
+End def.
+End TypeParamCollision.
+
+Definition TypeParamCollision'fds_unsealed (T : go.type) (C : go.type) {ext : ffi_syntax} {go_gctx : GoGlobalContext} : list go.field_decl := [
+  (go.FieldDecl "X"%go T);
+  (go.FieldDecl "Y"%go C)
+].
+Program Definition TypeParamCollision'fds (T : go.type) (C : go.type) {ext : ffi_syntax} {go_gctx : GoGlobalContext} := sealed (TypeParamCollision'fds_unsealed T C).
+Global Instance equals_unfold_TypeParamCollision T C {ext : ffi_syntax} {go_gctx : GoGlobalContext} : TypeParamCollision'fds T C =→ TypeParamCollision'fds_unsealed T C.
+Proof. rewrite /TypeParamCollision'fds seal_eq //. Qed.
+
+Definition TypeParamCollisionⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} (T : go.type) (C : go.type) : go.type := go.StructType (TypeParamCollision'fds T C).
+
+Class TypeParamCollision_Assumptions {ext : ffi_syntax} `{!GoGlobalContext} `{!GoLocalContext} `{!GoSemanticsFunctions} : Prop :=
+{
+  #[global] TypeParamCollision_type_repr T T' `{!ZeroVal T'} `{!TypeRepr T T'}C C' `{!ZeroVal C'} `{!TypeRepr C C'} :: go.TypeReprUnderlying (TypeParamCollisionⁱᵐᵖˡ T C) (TypeParamCollision.t T' C');
+  #[global] TypeParamCollision_underlying T C :: (TypeParamCollision T C) <u (TypeParamCollisionⁱᵐᵖˡ T C);
+  #[global] TypeParamCollision_get_X T C T' C' (x : TypeParamCollision.t T' C') :: ⟦StructFieldGet (TypeParamCollisionⁱᵐᵖˡ T C) "X", #x⟧ ⤳[under] #x.(TypeParamCollision.X');
+  #[global] TypeParamCollision_set_X T C T' C' (x : TypeParamCollision.t T' C') y :: ⟦StructFieldSet (TypeParamCollisionⁱᵐᵖˡ T C) "X", (#x, #y)⟧ ⤳[under] #(x <|TypeParamCollision.X' := y|>);
+  #[global] TypeParamCollision_get_Y T C T' C' (x : TypeParamCollision.t T' C') :: ⟦StructFieldGet (TypeParamCollisionⁱᵐᵖˡ T C) "Y", #x⟧ ⤳[under] #x.(TypeParamCollision.Y');
+  #[global] TypeParamCollision_set_Y T C T' C' (x : TypeParamCollision.t T' C') y :: ⟦StructFieldSet (TypeParamCollisionⁱᵐᵖˡ T C) "Y", (#x, #y)⟧ ⤳[under] #(x <|TypeParamCollision.Y' := y|>);
+}.
+
 Module nonStructGeneric.
 Section def.
 Context {ext : ffi_syntax} {go_gctx : GoGlobalContext}.
@@ -436,6 +475,7 @@ Class Assumptions {ext : ffi_syntax} `{!GoGlobalContext} `{!GoLocalContext} `{!G
   #[global] UseContainer_instance :: UseContainer_Assumptions;
   #[global] OnlyIndirect_instance :: OnlyIndirect_Assumptions;
   #[global] MultiParam_instance :: MultiParam_Assumptions;
+  #[global] TypeParamCollision_instance :: TypeParamCollision_Assumptions;
   #[global] nonStructGeneric_instance :: nonStructGeneric_Assumptions;
   #[global] useNonStructGeneric_instance :: useNonStructGeneric_Assumptions;
   #[global] UnderlyingSlice_unfold T :: FuncUnfold UnderlyingSlice [T] (UnderlyingSliceⁱᵐᵖˡ T);

--- a/new/code/github_com/mit_pdos/perennial/goose/testdata/examples/unittest/generics.v
+++ b/new/code/github_com/mit_pdos/perennial/goose/testdata/examples/unittest/generics.v
@@ -28,6 +28,10 @@ Definition MultiParam {ext : ffi_syntax} {go_gctx : GoGlobalContext} (A : go.typ
 
 #[global] Opaque MultiParam.
 
+Definition TypeParamCollision {ext : ffi_syntax} {go_gctx : GoGlobalContext} (T : go.type) (C : go.type) : go.type := go.Named "github.com/mit-pdos/perennial/goose/testdata/examples/unittest/generics.TypeParamCollision"%go [T; C].
+
+#[global] Opaque TypeParamCollision.
+
 Definition nonStructGeneric {ext : ffi_syntax} {go_gctx : GoGlobalContext} (T : go.type) : go.type := go.Named "github.com/mit-pdos/perennial/goose/testdata/examples/unittest/generics.nonStructGeneric"%go [T].
 
 #[global] Opaque nonStructGeneric.
@@ -145,7 +149,7 @@ Definition useContainerⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext
     do:  ((StructFieldRef (Container go.uint64) "W"%go "container") <-[go.uint64] "$r0");;;
     return: #()).
 
-(* go: generics.go:75:6 *)
+(* go: generics.go:80:6 *)
 Definition useMultiParamⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} : val :=
   λ: <>,
     exception_do (let: "mp" := (GoAlloc (MultiParam go.uint64 go.bool) (GoZeroVal (MultiParam go.uint64 go.bool) #())) in
@@ -157,7 +161,7 @@ Definition useMultiParamⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContex
     do:  ((StructFieldRef (MultiParam go.uint64 go.bool) "X"%go "mp") <-[go.uint64] "$r0");;;
     return: #()).
 
-(* go: generics.go:80:6 *)
+(* go: generics.go:85:6 *)
 Definition swapMultiParamⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} (A : go.type) : val :=
   λ: "p",
     exception_do (let: "p" := (GoAlloc (go.PointerType (MultiParam A A)) "p") in
@@ -170,7 +174,7 @@ Definition swapMultiParamⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalConte
     do:  ((StructFieldRef (MultiParam A A) "Y"%go (![go.PointerType (MultiParam A A)] "p")) <-[A] "$r0");;;
     return: #()).
 
-(* go: generics.go:86:6 *)
+(* go: generics.go:91:6 *)
 Definition multiParamFuncⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} (A B : go.type) : val :=
   λ: "x" "b",
     exception_do (let: "b" := (GoAlloc B "b") in
@@ -178,7 +182,7 @@ Definition multiParamFuncⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalConte
     return: (let: "$v0" := (![B] "b") in
      CompositeLiteral (go.SliceType B) (LiteralValue [KeyedElement None (ElementExpression B "$v0")]))).
 
-(* go: generics.go:90:6 *)
+(* go: generics.go:95:6 *)
 Definition useMultiParamFuncⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} : val :=
   λ: <>,
     exception_do (do:  (let: "$a0" := #(W64 1) in
@@ -187,7 +191,7 @@ Definition useMultiParamFuncⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalCo
     return: (#());;;
     return: #()).
 
-(* go: generics.go:96:6 *)
+(* go: generics.go:101:6 *)
 Definition useAnyPointerⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} : val :=
   λ: <>,
     exception_do (let: "x" := (GoAlloc go.uint64 (GoZeroVal go.uint64 #())) in
@@ -383,6 +387,41 @@ Class MultiParam_Assumptions {ext : ffi_syntax} `{!GoGlobalContext} `{!GoLocalCo
   #[global] MultiParam_set_X A B A' B' (x : MultiParam.t A' B') y :: ⟦StructFieldSet (MultiParamⁱᵐᵖˡ A B) "X", (#x, #y)⟧ ⤳[under] #(x <|MultiParam.X' := y|>);
 }.
 
+Module TypeParamCollision.
+Section def.
+Context {ext : ffi_syntax} {go_gctx : GoGlobalContext}.
+Record t {T C : Type} :=
+mk {
+  X' : T;
+  Y' : C;
+}.
+
+#[global] Instance zero_val `{!ZeroVal T} `{!ZeroVal C} : ZeroVal t := {| zero_val := mk T C (zero_val _) (zero_val _)|}.
+#[global] Arguments mk : clear implicits.
+#[global] Arguments t : clear implicits.
+End def.
+End TypeParamCollision.
+
+Definition TypeParamCollision'fds_unsealed (T : go.type) (C : go.type) {ext : ffi_syntax} {go_gctx : GoGlobalContext} : list go.field_decl := [
+  (go.FieldDecl "X"%go T);
+  (go.FieldDecl "Y"%go C)
+].
+Program Definition TypeParamCollision'fds (T : go.type) (C : go.type) {ext : ffi_syntax} {go_gctx : GoGlobalContext} := sealed (TypeParamCollision'fds_unsealed T C).
+Global Instance equals_unfold_TypeParamCollision T C {ext : ffi_syntax} {go_gctx : GoGlobalContext} : TypeParamCollision'fds T C =→ TypeParamCollision'fds_unsealed T C.
+Proof. rewrite /TypeParamCollision'fds seal_eq //. Qed.
+
+Definition TypeParamCollisionⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} (T : go.type) (C : go.type) : go.type := go.StructType (TypeParamCollision'fds T C).
+
+Class TypeParamCollision_Assumptions {ext : ffi_syntax} `{!GoGlobalContext} `{!GoLocalContext} `{!GoSemanticsFunctions} : Prop :=
+{
+  #[global] TypeParamCollision_type_repr T T' `{!ZeroVal T'} `{!TypeRepr T T'}C C' `{!ZeroVal C'} `{!TypeRepr C C'} :: go.TypeReprUnderlying (TypeParamCollisionⁱᵐᵖˡ T C) (TypeParamCollision.t T' C');
+  #[global] TypeParamCollision_underlying T C :: (TypeParamCollision T C) <u (TypeParamCollisionⁱᵐᵖˡ T C);
+  #[global] TypeParamCollision_get_X T C T' C' (x : TypeParamCollision.t T' C') :: ⟦StructFieldGet (TypeParamCollisionⁱᵐᵖˡ T C) "X", #x⟧ ⤳[under] #x.(TypeParamCollision.X');
+  #[global] TypeParamCollision_set_X T C T' C' (x : TypeParamCollision.t T' C') y :: ⟦StructFieldSet (TypeParamCollisionⁱᵐᵖˡ T C) "X", (#x, #y)⟧ ⤳[under] #(x <|TypeParamCollision.X' := y|>);
+  #[global] TypeParamCollision_get_Y T C T' C' (x : TypeParamCollision.t T' C') :: ⟦StructFieldGet (TypeParamCollisionⁱᵐᵖˡ T C) "Y", #x⟧ ⤳[under] #x.(TypeParamCollision.Y');
+  #[global] TypeParamCollision_set_Y T C T' C' (x : TypeParamCollision.t T' C') y :: ⟦StructFieldSet (TypeParamCollisionⁱᵐᵖˡ T C) "Y", (#x, #y)⟧ ⤳[under] #(x <|TypeParamCollision.Y' := y|>);
+}.
+
 Module nonStructGeneric.
 Section def.
 Context {ext : ffi_syntax} {go_gctx : GoGlobalContext}.
@@ -436,6 +475,7 @@ Class Assumptions {ext : ffi_syntax} `{!GoGlobalContext} `{!GoLocalContext} `{!G
   #[global] UseContainer_instance :: UseContainer_Assumptions;
   #[global] OnlyIndirect_instance :: OnlyIndirect_Assumptions;
   #[global] MultiParam_instance :: MultiParam_Assumptions;
+  #[global] TypeParamCollision_instance :: TypeParamCollision_Assumptions;
   #[global] nonStructGeneric_instance :: nonStructGeneric_Assumptions;
   #[global] useNonStructGeneric_instance :: useNonStructGeneric_Assumptions;
   #[global] UnderlyingSlice_unfold T :: FuncUnfold UnderlyingSlice [T] (UnderlyingSliceⁱᵐᵖˡ T);

--- a/new/generatedproof/github_com/mit_pdos/perennial/goose/model/channel.v
+++ b/new/generatedproof/github_com/mit_pdos/perennial/goose/model/channel.v
@@ -32,7 +32,7 @@ Local Set Default Proof Using "All".
 Final Obligation. solve_typed_pointsto_agree. Qed.
 
 #[global] Instance Channel_into_val_typed
-  `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
+  (T : go.type) `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
   IntoValTypedUnderlying (channel.Channel.t T') (channel.Channelⁱᵐᵖˡ T).
 Proof. solve_into_val_typed_struct. Qed.
 #[global] Instance Channel_access_load_cap `{!TypedPointsto (Σ:=Σ) T'} l (v : (channel.Channel.t T')) dq :

--- a/new/generatedproof/github_com/mit_pdos/perennial/goose/testdata/examples/semantics.v
+++ b/new/generatedproof/github_com/mit_pdos/perennial/goose/testdata/examples/semantics.v
@@ -977,7 +977,7 @@ Local Set Default Proof Using "All".
 Final Obligation. solve_typed_pointsto_agree. Qed.
 
 #[global] Instance List_into_val_typed
-  `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
+  (T : go.type) `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
   IntoValTypedUnderlying (semantics.List.t T') (semantics.Listⁱᵐᵖˡ T).
 Proof. solve_into_val_typed_struct. Qed.
 #[global] Instance List_access_load_X `{!TypedPointsto (Σ:=Σ) T'} l (v : (semantics.List.t T')) dq :

--- a/new/generatedproof/github_com/mit_pdos/perennial/goose/testdata/examples/unittest/generics.v
+++ b/new/generatedproof/github_com/mit_pdos/perennial/goose/testdata/examples/unittest/generics.v
@@ -28,7 +28,7 @@ Local Set Default Proof Using "All".
 Final Obligation. solve_typed_pointsto_agree. Qed.
 
 #[global] Instance Box_into_val_typed
-  `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
+  (T : go.type) `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
   IntoValTypedUnderlying (generics.Box.t T') (generics.Boxⁱᵐᵖˡ T).
 Proof. solve_into_val_typed_struct. Qed.
 #[global] Instance Box_access_load_Value `{!TypedPointsto (Σ:=Σ) T'} l (v : (generics.Box.t T')) dq :
@@ -72,7 +72,7 @@ Local Set Default Proof Using "All".
 Final Obligation. solve_typed_pointsto_agree. Qed.
 
 #[global] Instance Container_into_val_typed
-  `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
+  (T : go.type) `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
   IntoValTypedUnderlying (generics.Container.t T') (generics.Containerⁱᵐᵖˡ T).
 Proof. solve_into_val_typed_struct. Qed.
 #[global] Instance Container_access_load_X `{!TypedPointsto (Σ:=Σ) T'} l (v : (generics.Container.t T')) dq :
@@ -194,7 +194,7 @@ Local Set Default Proof Using "All".
 Final Obligation. solve_typed_pointsto_agree. Qed.
 
 #[global] Instance OnlyIndirect_into_val_typed
-  `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
+  (T : go.type) `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
   IntoValTypedUnderlying (generics.OnlyIndirect.t T') (generics.OnlyIndirectⁱᵐᵖˡ T).
 Proof. solve_into_val_typed_struct. Qed.
 #[global] Instance OnlyIndirect_access_load_X `{!TypedPointsto (Σ:=Σ) T'} l (v : (generics.OnlyIndirect.t T')) dq :
@@ -249,7 +249,7 @@ Local Set Default Proof Using "All".
 Final Obligation. solve_typed_pointsto_agree. Qed.
 
 #[global] Instance MultiParam_into_val_typed
-  `{!ZeroVal A'} `{!TypedPointsto (Σ:=Σ) A'} `{!IntoValTyped A' A} `{!ZeroVal B'} `{!TypedPointsto (Σ:=Σ) B'} `{!IntoValTyped B' B}  :
+  (A : go.type) `{!ZeroVal A'} `{!TypedPointsto (Σ:=Σ) A'} `{!IntoValTyped A' A} (B : go.type) `{!ZeroVal B'} `{!TypedPointsto (Σ:=Σ) B'} `{!IntoValTyped B' B}  :
   IntoValTypedUnderlying (generics.MultiParam.t A' B') (generics.MultiParamⁱᵐᵖˡ A B).
 Proof. solve_into_val_typed_struct. Qed.
 #[global] Instance MultiParam_access_load_Y `{!TypedPointsto (Σ:=Σ) A'} `{!TypedPointsto (Σ:=Σ) B'} l (v : (generics.MultiParam.t A' B')) dq :
@@ -282,6 +282,61 @@ Proof. solve_pointsto_access_struct. Qed.
 End def.
 End MultiParam.
 
+Module TypeParamCollision.
+Section def.
+
+Context `{hG: heapGS Σ, !ffi_semantics _ _}.
+Context {sem : go.Semantics}.
+Context {package_sem' : generics.Assumptions}.
+
+Local Set Default Proof Using "All".
+
+#[global]Program Instance TypeParamCollision_typed_pointsto `{!TypedPointsto (Σ:=Σ) T'} `{!TypedPointsto (Σ:=Σ) C'}  :
+  TypedPointsto (Σ:=Σ) (generics.TypeParamCollision.t T' C') :=
+  {|
+    typed_pointsto_def l v dq :=
+      (
+      "X" ∷ l.[(generics.TypeParamCollision.t T' C'), "X"] ↦{dq} v.(generics.TypeParamCollision.X') ∗
+      "Y" ∷ l.[(generics.TypeParamCollision.t T' C'), "Y"] ↦{dq} v.(generics.TypeParamCollision.Y') ∗
+      "_" ∷ True
+      )%I
+  |}.
+Final Obligation. solve_typed_pointsto_agree. Qed.
+
+#[global] Instance TypeParamCollision_into_val_typed
+  (T : go.type) `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T} (C : go.type) `{!ZeroVal C'} `{!TypedPointsto (Σ:=Σ) C'} `{!IntoValTyped C' C}  :
+  IntoValTypedUnderlying (generics.TypeParamCollision.t T' C') (generics.TypeParamCollisionⁱᵐᵖˡ T C).
+Proof. solve_into_val_typed_struct. Qed.
+#[global] Instance TypeParamCollision_access_load_X `{!TypedPointsto (Σ:=Σ) T'} `{!TypedPointsto (Σ:=Σ) C'} l (v : (generics.TypeParamCollision.t T' C')) dq :
+  AccessStrict
+    (l.[(generics.TypeParamCollision.t T' C'), "X"] ↦{dq} (v.(generics.TypeParamCollision.X')))
+    (l.[(generics.TypeParamCollision.t T' C'), "X"] ↦{dq} (v.(generics.TypeParamCollision.X')))
+    (l ↦{dq} v) (l ↦{dq} v)%I.
+Proof. solve_pointsto_access_struct. Qed.
+
+#[global] Instance TypeParamCollision_access_store_X `{!TypedPointsto (Σ:=Σ) T'} `{!TypedPointsto (Σ:=Σ) C'} l (v : (generics.TypeParamCollision.t T' C')) X' :
+  AccessStrict
+    (l.[(generics.TypeParamCollision.t T' C'), "X"] ↦ (v.(generics.TypeParamCollision.X')))
+    (l.[(generics.TypeParamCollision.t T' C'), "X"] ↦ X')
+    (l ↦ v) (l ↦ (v <|(generics.TypeParamCollision.X') := X'|>))%I.
+Proof. solve_pointsto_access_struct. Qed.
+#[global] Instance TypeParamCollision_access_load_Y `{!TypedPointsto (Σ:=Σ) T'} `{!TypedPointsto (Σ:=Σ) C'} l (v : (generics.TypeParamCollision.t T' C')) dq :
+  AccessStrict
+    (l.[(generics.TypeParamCollision.t T' C'), "Y"] ↦{dq} (v.(generics.TypeParamCollision.Y')))
+    (l.[(generics.TypeParamCollision.t T' C'), "Y"] ↦{dq} (v.(generics.TypeParamCollision.Y')))
+    (l ↦{dq} v) (l ↦{dq} v)%I.
+Proof. solve_pointsto_access_struct. Qed.
+
+#[global] Instance TypeParamCollision_access_store_Y `{!TypedPointsto (Σ:=Σ) T'} `{!TypedPointsto (Σ:=Σ) C'} l (v : (generics.TypeParamCollision.t T' C')) Y' :
+  AccessStrict
+    (l.[(generics.TypeParamCollision.t T' C'), "Y"] ↦ (v.(generics.TypeParamCollision.Y')))
+    (l.[(generics.TypeParamCollision.t T' C'), "Y"] ↦ Y')
+    (l ↦ v) (l ↦ (v <|(generics.TypeParamCollision.Y') := Y'|>))%I.
+Proof. solve_pointsto_access_struct. Qed.
+
+End def.
+End TypeParamCollision.
+
 Module useNonStructGeneric.
 Section def.
 
@@ -303,7 +358,7 @@ Local Set Default Proof Using "All".
 Final Obligation. solve_typed_pointsto_agree. Qed.
 
 #[global] Instance useNonStructGeneric_into_val_typed
-  `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
+  (T : go.type) `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
   IntoValTypedUnderlying (generics.useNonStructGeneric.t T') (generics.useNonStructGenericⁱᵐᵖˡ T).
 Proof. solve_into_val_typed_struct. Qed.
 #[global] Instance useNonStructGeneric_access_load_x `{!TypedPointsto (Σ:=Σ) T'} l (v : (generics.useNonStructGeneric.t T')) dq :

--- a/new/generatedproof/go_etcd_io/etcd/cache/v3.v
+++ b/new/generatedproof/go_etcd_io/etcd/cache/v3.v
@@ -465,7 +465,7 @@ Local Set Default Proof Using "All".
   TypedPointsto (Σ:=Σ) (cache.ringBuffer.t T'). Admitted.
 
 #[global] Instance ringBuffer_into_val_typed
-  `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
+  (T : go.type) `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
   IntoValTypedUnderlying (cache.ringBuffer.t T') (cache.ringBufferⁱᵐᵖˡ T).
 Proof. Admitted.
 
@@ -485,7 +485,7 @@ Local Set Default Proof Using "All".
   TypedPointsto (Σ:=Σ) (cache.entry.t T'). Admitted.
 
 #[global] Instance entry_into_val_typed
-  `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
+  (T : go.type) `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
   IntoValTypedUnderlying (cache.entry.t T') (cache.entryⁱᵐᵖˡ T).
 Proof. Admitted.
 
@@ -505,7 +505,7 @@ Local Set Default Proof Using "All".
   TypedPointsto (Σ:=Σ) (cache.RevisionOf.t T'). Admitted.
 
 #[global] Instance RevisionOf_into_val_typed
-  `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
+  (T : go.type) `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
   IntoValTypedUnderlying (cache.RevisionOf.t T') (cache.RevisionOfⁱᵐᵖˡ T).
 Proof. Admitted.
 
@@ -525,7 +525,7 @@ Local Set Default Proof Using "All".
   TypedPointsto (Σ:=Σ) (cache.IterFunc.t T'). Admitted.
 
 #[global] Instance IterFunc_into_val_typed
-  `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
+  (T : go.type) `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
   IntoValTypedUnderlying (cache.IterFunc.t T') (cache.IterFuncⁱᵐᵖˡ T).
 Proof. Admitted.
 

--- a/new/generatedproof/go_uber_org/zap.v
+++ b/new/generatedproof/go_uber_org/zap.v
@@ -20,7 +20,7 @@ Local Set Default Proof Using "All".
   TypedPointsto (Σ:=Σ) (zap.objects.t T'). Admitted.
 
 #[global] Instance objects_into_val_typed
-  `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
+  (T : go.type) `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
   IntoValTypedUnderlying (zap.objects.t T') (zap.objectsⁱᵐᵖˡ T).
 Proof. Admitted.
 
@@ -40,7 +40,7 @@ Local Set Default Proof Using "All".
   TypedPointsto (Σ:=Σ) (zap.ObjectMarshalerPtr.t T'). Admitted.
 
 #[global] Instance ObjectMarshalerPtr_into_val_typed
-  `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
+  (T : go.type) `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
   IntoValTypedUnderlying (zap.ObjectMarshalerPtr.t T') (zap.ObjectMarshalerPtrⁱᵐᵖˡ T).
 Proof. Admitted.
 
@@ -60,7 +60,7 @@ Local Set Default Proof Using "All".
   TypedPointsto (Σ:=Σ) (zap.objectValues.t T' P'). Admitted.
 
 #[global] Instance objectValues_into_val_typed
-  `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T} `{!ZeroVal P'} `{!TypedPointsto (Σ:=Σ) P'} `{!IntoValTyped P' P}  :
+  (T : go.type) `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T} (P : go.type) `{!ZeroVal P'} `{!TypedPointsto (Σ:=Σ) P'} `{!IntoValTyped P' P}  :
   IntoValTypedUnderlying (zap.objectValues.t T' P') (zap.objectValuesⁱᵐᵖˡ T P).
 Proof. Admitted.
 
@@ -80,7 +80,7 @@ Local Set Default Proof Using "All".
   TypedPointsto (Σ:=Σ) (zap.stringers.t T'). Admitted.
 
 #[global] Instance stringers_into_val_typed
-  `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
+  (T : go.type) `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
   IntoValTypedUnderlying (zap.stringers.t T') (zap.stringersⁱᵐᵖˡ T).
 Proof. Admitted.
 
@@ -600,7 +600,7 @@ Local Set Default Proof Using "All".
   TypedPointsto (Σ:=Σ) (zap.anyFieldC.t T'). Admitted.
 
 #[global] Instance anyFieldC_into_val_typed
-  `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
+  (T : go.type) `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
   IntoValTypedUnderlying (zap.anyFieldC.t T') (zap.anyFieldCⁱᵐᵖˡ T).
 Proof. Admitted.
 

--- a/new/generatedproof/google_golang_org/grpc.v
+++ b/new/generatedproof/google_golang_org/grpc.v
@@ -2219,7 +2219,7 @@ Local Set Default Proof Using "All".
   TypedPointsto (Σ:=Σ) (grpc.ServerStreamingClient.t Res'). Admitted.
 
 #[global] Instance ServerStreamingClient_into_val_typed
-  `{!ZeroVal Res'} `{!TypedPointsto (Σ:=Σ) Res'} `{!IntoValTyped Res' Res}  :
+  (Res : go.type) `{!ZeroVal Res'} `{!TypedPointsto (Σ:=Σ) Res'} `{!IntoValTyped Res' Res}  :
   IntoValTypedUnderlying (grpc.ServerStreamingClient.t Res') (grpc.ServerStreamingClientⁱᵐᵖˡ Res).
 Proof. Admitted.
 
@@ -2239,7 +2239,7 @@ Local Set Default Proof Using "All".
   TypedPointsto (Σ:=Σ) (grpc.ServerStreamingServer.t Res'). Admitted.
 
 #[global] Instance ServerStreamingServer_into_val_typed
-  `{!ZeroVal Res'} `{!TypedPointsto (Σ:=Σ) Res'} `{!IntoValTyped Res' Res}  :
+  (Res : go.type) `{!ZeroVal Res'} `{!TypedPointsto (Σ:=Σ) Res'} `{!IntoValTyped Res' Res}  :
   IntoValTypedUnderlying (grpc.ServerStreamingServer.t Res') (grpc.ServerStreamingServerⁱᵐᵖˡ Res).
 Proof. Admitted.
 
@@ -2259,7 +2259,7 @@ Local Set Default Proof Using "All".
   TypedPointsto (Σ:=Σ) (grpc.ClientStreamingClient.t Req' Res'). Admitted.
 
 #[global] Instance ClientStreamingClient_into_val_typed
-  `{!ZeroVal Req'} `{!TypedPointsto (Σ:=Σ) Req'} `{!IntoValTyped Req' Req} `{!ZeroVal Res'} `{!TypedPointsto (Σ:=Σ) Res'} `{!IntoValTyped Res' Res}  :
+  (Req : go.type) `{!ZeroVal Req'} `{!TypedPointsto (Σ:=Σ) Req'} `{!IntoValTyped Req' Req} (Res : go.type) `{!ZeroVal Res'} `{!TypedPointsto (Σ:=Σ) Res'} `{!IntoValTyped Res' Res}  :
   IntoValTypedUnderlying (grpc.ClientStreamingClient.t Req' Res') (grpc.ClientStreamingClientⁱᵐᵖˡ Req Res).
 Proof. Admitted.
 
@@ -2279,7 +2279,7 @@ Local Set Default Proof Using "All".
   TypedPointsto (Σ:=Σ) (grpc.ClientStreamingServer.t Req' Res'). Admitted.
 
 #[global] Instance ClientStreamingServer_into_val_typed
-  `{!ZeroVal Req'} `{!TypedPointsto (Σ:=Σ) Req'} `{!IntoValTyped Req' Req} `{!ZeroVal Res'} `{!TypedPointsto (Σ:=Σ) Res'} `{!IntoValTyped Res' Res}  :
+  (Req : go.type) `{!ZeroVal Req'} `{!TypedPointsto (Σ:=Σ) Req'} `{!IntoValTyped Req' Req} (Res : go.type) `{!ZeroVal Res'} `{!TypedPointsto (Σ:=Σ) Res'} `{!IntoValTyped Res' Res}  :
   IntoValTypedUnderlying (grpc.ClientStreamingServer.t Req' Res') (grpc.ClientStreamingServerⁱᵐᵖˡ Req Res).
 Proof. Admitted.
 
@@ -2299,7 +2299,7 @@ Local Set Default Proof Using "All".
   TypedPointsto (Σ:=Σ) (grpc.BidiStreamingClient.t Req' Res'). Admitted.
 
 #[global] Instance BidiStreamingClient_into_val_typed
-  `{!ZeroVal Req'} `{!TypedPointsto (Σ:=Σ) Req'} `{!IntoValTyped Req' Req} `{!ZeroVal Res'} `{!TypedPointsto (Σ:=Σ) Res'} `{!IntoValTyped Res' Res}  :
+  (Req : go.type) `{!ZeroVal Req'} `{!TypedPointsto (Σ:=Σ) Req'} `{!IntoValTyped Req' Req} (Res : go.type) `{!ZeroVal Res'} `{!TypedPointsto (Σ:=Σ) Res'} `{!IntoValTyped Res' Res}  :
   IntoValTypedUnderlying (grpc.BidiStreamingClient.t Req' Res') (grpc.BidiStreamingClientⁱᵐᵖˡ Req Res).
 Proof. Admitted.
 
@@ -2319,7 +2319,7 @@ Local Set Default Proof Using "All".
   TypedPointsto (Σ:=Σ) (grpc.BidiStreamingServer.t Req' Res'). Admitted.
 
 #[global] Instance BidiStreamingServer_into_val_typed
-  `{!ZeroVal Req'} `{!TypedPointsto (Σ:=Σ) Req'} `{!IntoValTyped Req' Req} `{!ZeroVal Res'} `{!TypedPointsto (Σ:=Σ) Res'} `{!IntoValTyped Res' Res}  :
+  (Req : go.type) `{!ZeroVal Req'} `{!TypedPointsto (Σ:=Σ) Req'} `{!IntoValTyped Req' Req} (Res : go.type) `{!ZeroVal Res'} `{!TypedPointsto (Σ:=Σ) Res'} `{!IntoValTyped Res' Res}  :
   IntoValTypedUnderlying (grpc.BidiStreamingServer.t Req' Res') (grpc.BidiStreamingServerⁱᵐᵖˡ Req Res).
 Proof. Admitted.
 
@@ -2339,7 +2339,7 @@ Local Set Default Proof Using "All".
   TypedPointsto (Σ:=Σ) (grpc.GenericClientStream.t Req' Res'). Admitted.
 
 #[global] Instance GenericClientStream_into_val_typed
-  `{!ZeroVal Req'} `{!TypedPointsto (Σ:=Σ) Req'} `{!IntoValTyped Req' Req} `{!ZeroVal Res'} `{!TypedPointsto (Σ:=Σ) Res'} `{!IntoValTyped Res' Res}  :
+  (Req : go.type) `{!ZeroVal Req'} `{!TypedPointsto (Σ:=Σ) Req'} `{!IntoValTyped Req' Req} (Res : go.type) `{!ZeroVal Res'} `{!TypedPointsto (Σ:=Σ) Res'} `{!IntoValTyped Res' Res}  :
   IntoValTypedUnderlying (grpc.GenericClientStream.t Req' Res') (grpc.GenericClientStreamⁱᵐᵖˡ Req Res).
 Proof. Admitted.
 
@@ -2359,7 +2359,7 @@ Local Set Default Proof Using "All".
   TypedPointsto (Σ:=Σ) (grpc.GenericServerStream.t Req' Res'). Admitted.
 
 #[global] Instance GenericServerStream_into_val_typed
-  `{!ZeroVal Req'} `{!TypedPointsto (Σ:=Σ) Req'} `{!IntoValTyped Req' Req} `{!ZeroVal Res'} `{!TypedPointsto (Σ:=Σ) Res'} `{!IntoValTyped Res' Res}  :
+  (Req : go.type) `{!ZeroVal Req'} `{!TypedPointsto (Σ:=Σ) Req'} `{!IntoValTyped Req' Req} (Res : go.type) `{!ZeroVal Res'} `{!TypedPointsto (Σ:=Σ) Res'} `{!IntoValTyped Res' Res}  :
   IntoValTypedUnderlying (grpc.GenericServerStream.t Req' Res') (grpc.GenericServerStreamⁱᵐᵖˡ Req Res).
 Proof. Admitted.
 

--- a/new/generatedproof/k8s_io/utils/third_party/forked/golang/btree.v
+++ b/new/generatedproof/k8s_io/utils/third_party/forked/golang/btree.v
@@ -31,7 +31,7 @@ Local Set Default Proof Using "All".
 Final Obligation. solve_typed_pointsto_agree. Qed.
 
 #[global] Instance FreeList_into_val_typed
-  `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
+  (T : go.type) `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
   IntoValTypedUnderlying (btree.FreeList.t T') (btree.FreeListⁱᵐᵖˡ T).
 Proof. solve_into_val_typed_struct. Qed.
 #[global] Instance FreeList_access_load_mu `{!TypedPointsto (Σ:=Σ) T'} l (v : (btree.FreeList.t T')) dq :
@@ -87,7 +87,7 @@ Local Set Default Proof Using "All".
 Final Obligation. solve_typed_pointsto_agree. Qed.
 
 #[global] Instance node_into_val_typed
-  `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
+  (T : go.type) `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
   IntoValTypedUnderlying (btree.node.t T') (btree.nodeⁱᵐᵖˡ T).
 Proof. solve_into_val_typed_struct. Qed.
 #[global] Instance node_access_load_items `{!TypedPointsto (Σ:=Σ) T'} l (v : (btree.node.t T')) dq :
@@ -155,7 +155,7 @@ Local Set Default Proof Using "All".
 Final Obligation. solve_typed_pointsto_agree. Qed.
 
 #[global] Instance optionalItem_into_val_typed
-  `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
+  (T : go.type) `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
   IntoValTypedUnderlying (btree.optionalItem.t T') (btree.optionalItemⁱᵐᵖˡ T).
 Proof. solve_into_val_typed_struct. Qed.
 #[global] Instance optionalItem_access_load_item `{!TypedPointsto (Σ:=Σ) T'} l (v : (btree.optionalItem.t T')) dq :
@@ -212,7 +212,7 @@ Local Set Default Proof Using "All".
 Final Obligation. solve_typed_pointsto_agree. Qed.
 
 #[global] Instance BTree_into_val_typed
-  `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
+  (T : go.type) `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
   IntoValTypedUnderlying (btree.BTree.t T') (btree.BTreeⁱᵐᵖˡ T).
 Proof. solve_into_val_typed_struct. Qed.
 #[global] Instance BTree_access_load_degree `{!TypedPointsto (Σ:=Σ) T'} l (v : (btree.BTree.t T')) dq :
@@ -293,7 +293,7 @@ Local Set Default Proof Using "All".
 Final Obligation. solve_typed_pointsto_agree. Qed.
 
 #[global] Instance copyOnWriteContext_into_val_typed
-  `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
+  (T : go.type) `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
   IntoValTypedUnderlying (btree.copyOnWriteContext.t T') (btree.copyOnWriteContextⁱᵐᵖˡ T).
 Proof. solve_into_val_typed_struct. Qed.
 #[global] Instance copyOnWriteContext_access_load_freelist `{!TypedPointsto (Σ:=Σ) T'} l (v : (btree.copyOnWriteContext.t T')) dq :

--- a/new/generatedproof/sync/atomic.v
+++ b/new/generatedproof/sync/atomic.v
@@ -112,7 +112,7 @@ Local Set Default Proof Using "All".
 Final Obligation. solve_typed_pointsto_agree. Qed.
 
 #[global] Instance Pointer_into_val_typed
-  `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
+  (T : go.type) `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}  :
   IntoValTypedUnderlying (atomic.Pointer.t T') (atomic.Pointerⁱᵐᵖˡ T).
 Proof. solve_into_val_typed_struct. Qed.
 #[global] Instance Pointer_access_load__0 `{!TypedPointsto (Σ:=Σ) T'} l (v : (atomic.Pointer.t T')) dq :


### PR DESCRIPTION
This PR fixes the type param name collision. For example, before the fix, when translating https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/gentype/fake.go#L50
```go
type FakeClientWithApply[T objectWithMeta, C namedObject] struct {
    *FakeClient[T]
    alsoFakeApplier[T, C]
}
```
proofgen generates
```coq
#[global] Instance FakeClientWithApply_into_val_typed
  `{!ZeroVal T'} `{!TypedPointsto (Σ:=Σ) T'} `{!IntoValTyped T' T}
  `{!ZeroVal C'} `{!TypedPointsto (Σ:=Σ) C'} `{!IntoValTyped C' C} :
  IntoValTypedUnderlying
    (gentype.FakeClientWithApply.t T' C')
    (gentype.FakeClientWithApplyⁱᵐᵖˡ T C).
Proof. Admitted.
```
which fails compilation
```text
File "./src/generatedproof/k8s_io/client_go/gentype.v", line 66, characters 133-134:
Error:
In environment
...
T' : Type
ZeroVal0 : ZeroVal T'
TypedPointsto0 : TypedPointsto T'
T : go.type
IntoValTyped0 : IntoValTyped T' T
C' : Type
ZeroVal1 : ZeroVal C'
TypedPointsto1 : TypedPointsto C'
The term "C" has type "iProp ?Σ0" while it is expected to have type
 "go.type".
```
because "C" conflicts with the crash token "C".

This PR fixes this issue by adding proofgen binders. It also adds a regression generic type with a "C" parameter and regenerates the affected Goose/proofgen outputs.

This PR is mainly implemented by Codex.
