### PR TITLE
add support for [wp_apply (foo) as (x y z) "ipat"]

### DIFF
--- a/new/golang/theory/auto.v
+++ b/new/golang/theory/auto.v
@@ -109,8 +109,8 @@ Ltac2 Type wp_param := [
   | RunAuto(bool)
   (* generate later credits *)
   | GenLc(int)
-  (* intro pattern to run afterward *)
-  | AsClause(Ltac1.t)
+  (* deferred introduction to run afterward (Coq binders + intro pattern) *)
+  | AsClause(unit -> unit)
 ].
 
 Ltac2 Type exn ::= [ WpParamExn(wp_param) ].
@@ -128,13 +128,91 @@ Tactic Notation "--lc" int(n) :=
     let n := Option.get (Ltac1.to_int n') in
     Control.zero (WpParamExn (GenLc n))) in
   f n.
-(* NOTE: does not support other variants of [iIntros] from
-   [iris/iris/proofmode/ltac_tactics.v] to make intro patterns more canonical.
- *)
+(* The [as] clause runs [iIntros] after the [wp_apply]. The bare form [as
+   "ipat"] introduces just the spatial intro pattern; the forms [as (x1 ... xn)
+   "ipat"] additionally introduce up to 8 leading Coq-level binders (e.g. the
+   existentially-quantified return values), exactly as if one had written
+   [iIntros (x1 ... xn) "ipat"] by hand.
+
+   Coq's [Tactic Notation] cannot take a variadic number of [simple_intropattern]
+   arguments in a single rule, so we enumerate the arities (matching the
+   convention used by Iris's own [wp_apply ... as] notation). Each rule packages
+   the introduction as a deferred thunk carried by [AsClause]; [wp_apply] forces
+   it on the last goal after running the lemma. *)
 Tactic Notation "as" constr(ipat) :=
   let f := ltac2:(ipat' |-
-      Control.zero (WpParamExn (AsClause ipat'))) in
+      Control.zero (WpParamExn (AsClause (fun () =>
+        ltac1:(ip |- iIntros ip) ipat')))) in
   f ipat.
+Tactic Notation "as" "(" simple_intropattern(x1) ")" constr(ipat) :=
+  let f := ltac2:(x1 ipat' |-
+      Control.zero (WpParamExn (AsClause (fun () =>
+        ltac1:(a1 ip |- iIntros (a1); iIntros ip) x1 ipat')))) in
+  f x1 ipat.
+Tactic Notation "as" "(" simple_intropattern(x1) simple_intropattern(x2) ")"
+    constr(ipat) :=
+  let f := ltac2:(x1 x2 ipat' |-
+      Control.zero (WpParamExn (AsClause (fun () =>
+        ltac1:(a1 a2 ip |- iIntros (a1); iIntros (a2); iIntros ip)
+          x1 x2 ipat')))) in
+  f x1 x2 ipat.
+Tactic Notation "as" "(" simple_intropattern(x1) simple_intropattern(x2)
+    simple_intropattern(x3) ")" constr(ipat) :=
+  let f := ltac2:(x1 x2 x3 ipat' |-
+      Control.zero (WpParamExn (AsClause (fun () =>
+        ltac1:(a1 a2 a3 ip |-
+          iIntros (a1); iIntros (a2); iIntros (a3); iIntros ip)
+          x1 x2 x3 ipat')))) in
+  f x1 x2 x3 ipat.
+Tactic Notation "as" "(" simple_intropattern(x1) simple_intropattern(x2)
+    simple_intropattern(x3) simple_intropattern(x4) ")" constr(ipat) :=
+  let f := ltac2:(x1 x2 x3 x4 ipat' |-
+      Control.zero (WpParamExn (AsClause (fun () =>
+        ltac1:(a1 a2 a3 a4 ip |-
+          iIntros (a1); iIntros (a2); iIntros (a3); iIntros (a4); iIntros ip)
+          x1 x2 x3 x4 ipat')))) in
+  f x1 x2 x3 x4 ipat.
+Tactic Notation "as" "(" simple_intropattern(x1) simple_intropattern(x2)
+    simple_intropattern(x3) simple_intropattern(x4) simple_intropattern(x5) ")"
+    constr(ipat) :=
+  let f := ltac2:(x1 x2 x3 x4 x5 ipat' |-
+      Control.zero (WpParamExn (AsClause (fun () =>
+        ltac1:(a1 a2 a3 a4 a5 ip |-
+          iIntros (a1); iIntros (a2); iIntros (a3); iIntros (a4); iIntros (a5);
+          iIntros ip)
+          x1 x2 x3 x4 x5 ipat')))) in
+  f x1 x2 x3 x4 x5 ipat.
+Tactic Notation "as" "(" simple_intropattern(x1) simple_intropattern(x2)
+    simple_intropattern(x3) simple_intropattern(x4) simple_intropattern(x5)
+    simple_intropattern(x6) ")" constr(ipat) :=
+  let f := ltac2:(x1 x2 x3 x4 x5 x6 ipat' |-
+      Control.zero (WpParamExn (AsClause (fun () =>
+        ltac1:(a1 a2 a3 a4 a5 a6 ip |-
+          iIntros (a1); iIntros (a2); iIntros (a3); iIntros (a4); iIntros (a5);
+          iIntros (a6); iIntros ip)
+          x1 x2 x3 x4 x5 x6 ipat')))) in
+  f x1 x2 x3 x4 x5 x6 ipat.
+Tactic Notation "as" "(" simple_intropattern(x1) simple_intropattern(x2)
+    simple_intropattern(x3) simple_intropattern(x4) simple_intropattern(x5)
+    simple_intropattern(x6) simple_intropattern(x7) ")" constr(ipat) :=
+  let f := ltac2:(x1 x2 x3 x4 x5 x6 x7 ipat' |-
+      Control.zero (WpParamExn (AsClause (fun () =>
+        ltac1:(a1 a2 a3 a4 a5 a6 a7 ip |-
+          iIntros (a1); iIntros (a2); iIntros (a3); iIntros (a4); iIntros (a5);
+          iIntros (a6); iIntros (a7); iIntros ip)
+          x1 x2 x3 x4 x5 x6 x7 ipat')))) in
+  f x1 x2 x3 x4 x5 x6 x7 ipat.
+Tactic Notation "as" "(" simple_intropattern(x1) simple_intropattern(x2)
+    simple_intropattern(x3) simple_intropattern(x4) simple_intropattern(x5)
+    simple_intropattern(x6) simple_intropattern(x7) simple_intropattern(x8) ")"
+    constr(ipat) :=
+  let f := ltac2:(x1 x2 x3 x4 x5 x6 x7 x8 ipat' |-
+      Control.zero (WpParamExn (AsClause (fun () =>
+        ltac1:(a1 a2 a3 a4 a5 a6 a7 a8 ip |-
+          iIntros (a1); iIntros (a2); iIntros (a3); iIntros (a4); iIntros (a5);
+          iIntros (a6); iIntros (a7); iIntros (a8); iIntros ip)
+          x1 x2 x3 x4 x5 x6 x7 x8 ipat')))) in
+  f x1 x2 x3 x4 x5 x6 x7 x8 ipat.
 
 Ltac2 Type exn ::= [WrappedExn(message option, exn)].
 Ltac2 catch_wp_param (thunk : unit -> 'a) : wp_param :=
@@ -185,10 +263,11 @@ Ltac2 wp_apply_core (lem: Ltac1.t) : unit :=
 Ltac2 iIntros (ipat: Ltac1.t) : unit :=
   ltac1:(ipat |- iIntros ipat) ipat.
 
-Ltac2 wp_apply (lem: Ltac1.t) (do_auto: bool) (lc: int) (as_clause: Ltac1.t option) :=
+Ltac2 wp_apply (lem: Ltac1.t) (do_auto: bool) (lc: int)
+    (as_clause: (unit -> unit) option) :=
     wp_apply_core lem; try ltac1:(iPkgInit);
     match as_clause with
-    | Some ipat => focus_last (iIntros ipat)
+    | Some cl => focus_last (cl ())
     | None => ()
     end;
     if do_auto then
@@ -199,13 +278,13 @@ Tactic Notation "wp_apply" open_constr(lem) tactic1_list(ps) :=
   let f := ltac2:(lem ps_raw |-
     let r_auto := Ref.ref wp_apply_auto_default in
     let r_lc := Ref.ref 0 in
-    let r_as: (Ltac1.t option) Ref.ref := Ref.ref None in
+    let r_as: ((unit -> unit) option) Ref.ref := Ref.ref None in
     let ps : Ltac1.t list := Option.get (Ltac1.to_list ps_raw) in
     List.iter (fun p =>
       let param := catch_wp_param (fun () => Ltac1.run p) in
       match param with
       | GenLc n => Ref.set r_lc n
-      | AsClause ipat => Ref.set r_as (Some ipat)
+      | AsClause cl => Ref.set r_as (Some cl)
       | RunAuto b => Ref.set r_auto b
       end
     ) ps;

--- a/new/golang/theory/chan.v
+++ b/new/golang/theory/chan.v
@@ -163,13 +163,11 @@ Proof.
       iMod "Hau". iModIntro. iNext. iNamed "Hau".
       iFrame. destruct s.
       * iIntros "H". iSpecialize ("Hcont" with "[$]").
-        iMod "Hcont". iModIntro. wp_auto. wp_apply (wp_wand with "Hcont").
-        iIntros (?) "HΦ". wp_auto. iApply "Hwand". iFrame.
+        iMod "Hcont". iModIntro. wp_auto. wp_apply (wp_wand with "Hcont") as (?) "HΦ". iApply "Hwand". iFrame.
       * iIntros "H". iSpecialize ("Hcont" with "[$]"). iMod "Hcont". iModIntro.
         iMod "Hcont". iModIntro. iNext. iNamed "Hcont". iFrame.
         destruct s; try iFrame. iIntros "H". iSpecialize ("Hcontinner" with "[$]").
-        iMod "Hcontinner". iModIntro. wp_auto. wp_apply (wp_wand with "Hcontinner").
-        iIntros (v) "HΦ". wp_auto. iApply "Hwand". iFrame.
+        iMod "Hcontinner". iModIntro. wp_auto. wp_apply (wp_wand with "Hcontinner") as (v) "HΦ". iApply "Hwand". iFrame.
       * iFrame.
       * iIntros "H". iSpecialize ("Hcont" with "[$]"). iMod "Hcont". iModIntro.
         wp_auto. wp_apply (wp_wand with "Hcont"). iIntros (v) "HΦ".
@@ -332,8 +330,7 @@ Proof.
       iLeft in "Hau". iMod "Hau". iModIntro. iNext. iNamed "Hau".
       iFrame. destruct s.
       * iIntros "H". iSpecialize ("Hcont" with "[$]").
-        iMod "Hcont". iModIntro. wp_auto. wp_apply (wp_wand with "Hcont").
-        iIntros (?) "HΦ". wp_auto. iApply "Hwand". iFrame.
+        iMod "Hcont". iModIntro. wp_auto. wp_apply (wp_wand with "Hcont") as (?) "HΦ". iApply "Hwand". iFrame.
       * done.
       * done.
       * iIntros "H". iSpecialize ("Hcont" with "[$]"). iMod "Hcont". iModIntro.

--- a/new/golang/theory/chan/au_spec/chan_au_new.v
+++ b/new/golang/theory/chan/au_spec/chan_au_new.v
@@ -87,8 +87,7 @@ Proof using W.
     rewrite -wp_fupd.
     wp_alloc mu as "mu".
     wp_auto.
-    wp_apply (wp_slice_make2 (V:=V)); first done.
-    iIntros (sl) ("Hsl"). wp_auto.
+    wp_apply (wp_slice_make2 (V:=V)) as (sl) "Hsl"; first done.
     wp_alloc ch as "Hch".
     wp_auto.
     iDestruct (typed_pointsto_not_null with "Hch") as "%Hnot_null".

--- a/new/golang/theory/chan/au_spec/chan_au_send.v
+++ b/new/golang/theory/chan/au_spec/chan_au_send.v
@@ -159,8 +159,7 @@ Proof using W.
       iDestruct (own_slice_len with "slice") as "[%Hl %Hcap2]".
       iDestruct (slice.own_slice_len with "slice") as "[%Hlen_slice %Hslgtz]".
       iDestruct (own_slice_wf with "slice") as "%Hwf".
-      wp_apply (wp_slice_append with "[$slice $Hsl $slice_cap]").
-      iIntros (fr) "(Hfr & Hfrsl & Hsl)". wp_auto_lc 1.
+      wp_apply (wp_slice_append with "[$slice $Hsl $slice_cap]") as (fr) "(Hfr & Hfrsl & Hsl)" --lc 1.
 
       iApply fupd_wp. iLeft in "HΦ". iMod "HΦ".
       iMod (lc_fupd_elim_later with "[$] HΦ") as "Hlogatom".
@@ -397,8 +396,7 @@ Proof using W.
       { simpl in *. len. }
       iMod ("Hcont" with "Hchanrepfrag") as "Hstep". iModIntro.
       wp_apply wp_slice_literal. iSplitR; first done. iIntros "%sl [Hsl _]". wp_auto.
-      wp_apply (wp_slice_append with "[$slice_inv $Hsl $slice_cap_inv]").
-      iIntros (fr) "(slice_inv & slice_cap_inv & Hsl)". wp_auto.
+      wp_apply (wp_slice_append with "[$slice_inv $Hsl $slice_cap_inv]") as (fr) "(slice_inv & slice_cap_inv & Hsl)".
       iCombineNamed "*_inv" as "Hi".
       wp_apply (wp_Mutex__Unlock with "[$lock $Hlock Hi]").
       { iNamed "Hi". unfold chan_inv_inner. iExists (Buffered (buffer ++ [v])). iFrame. }
@@ -510,8 +508,7 @@ Proof using W.
       2:{ exfalso. word. }
       iMod ("Hcont" with "Hchanrepfrag") as "Hstep". iModIntro.
       wp_apply wp_slice_literal. iSplitR; first done. iIntros "%sl [Hsl _]". wp_auto.
-      wp_apply (wp_slice_append with "[$slice_inv $Hsl $slice_cap_inv]").
-      iIntros (fr) "(slice_inv & slice_cap_inv & Hsl)". wp_auto.
+      wp_apply (wp_slice_append with "[$slice_inv $Hsl $slice_cap_inv]") as (fr) "(slice_inv & slice_cap_inv & Hsl)".
       iCombineNamed "*_inv" as "Hi".
       wp_apply (wp_Mutex__Unlock with "[$lock $Hlock Hi]").
       { iNamed "Hi". unfold chan_inv_inner. iExists (Buffered (buffer ++ [v])). iFrame. }

--- a/new/golang/theory/map.v
+++ b/new/golang/theory/map.v
@@ -283,8 +283,7 @@ Proof.
   }
   iSpecialize ("Hiter" $! i key v with "[//] HP").
   erewrite drop_S; last done. rewrite fmap_cons foldr_cons.
-  rewrite Hagree Hlookup /=. wp_apply (wp_wand with "Hiter").
-  iIntros (execv) "Hpost".
+  rewrite Hagree Hlookup /=. wp_apply (wp_wand with "Hiter") as (execv) "Hpost" --no-auto.
   rewrite -Z2Nat.inj_succ; last lia.
   iDestruct "Hpost" as "[[-> H]|Hpost]".
   { wp_auto. rewrite continue_val_unseal. wp_auto.

--- a/new/golang/theory/slice.v
+++ b/new/golang/theory/slice.v
@@ -886,9 +886,8 @@ Proof.
   iDestruct (own_slice_wf with "Hs") as %Hwf.
   wp_apply wp_slice_make2; first word.
   iIntros (zero_sl) "[? _]". wp_auto.
-  wp_apply (wp_slice_copy with "[-HΦ]"); first iFrame.
-  iIntros (?) "(%Hlen' & Hsl & _)".
-  wp_auto. iApply "HΦ".
+  wp_apply (wp_slice_copy with "[-HΦ]") as (?) "(%Hlen' & Hsl & _)"; first iFrame.
+  iApply "HΦ".
   rewrite drop_ge; last len.
   rewrite take_ge; last len. rewrite app_nil_r.
   replace (sint.nat _) with (length vs) by word.

--- a/new/proof/github_com/goose_lang/std/std_core.v
+++ b/new/proof/github_com/goose_lang/std/std_core.v
@@ -221,9 +221,7 @@ Proof.
       repeat f_equal.
       word.
     + f_equal; word.
-  - wp_apply (wp_Shuffle with "[$Hs]").
-    iIntros (xs') "[%Hperm Hs]".
-    wp_auto.
+  - wp_apply (wp_Shuffle with "[$Hs]") as (xs') "[%Hperm Hs]".
     iApply "HΦ".
     iFrame.
     iPureIntro.

--- a/new/proof/github_com/mit_pdos/perennial/goose/testdata/examples/channel.v
+++ b/new/proof/github_com/mit_pdos/perennial/goose/testdata/examples/channel.v
@@ -178,8 +178,7 @@ Lemma wp_HelloWorldSync :
 Proof.
   wp_start. wp_apply wp_HelloWorldAsync.
   iIntros (ch γfuture) "[#Hchan #Hfut]".
-  wp_apply (wp_bag_receive with "Hfut").
-  iIntros (v) "%Hv". wp_auto. subst v.
+  wp_apply (wp_bag_receive with "Hfut") as (v) "%Hv". subst v.
   iApply "HΦ". done.
 Qed.
 
@@ -248,8 +247,7 @@ Proof.
     iIntros "_". wp_auto. done.
   }
 
-  wp_apply (wp_HelloWorldCancellable with "[$Hdone_broadcast]").
-  iIntros (result) "%Hres". wp_auto. iApply "HΦ".
+  wp_apply (wp_HelloWorldCancellable with "[$Hdone_broadcast]") as (result) "%Hres". iApply "HΦ".
   iPureIntro. destruct Hres; auto.
 Qed.
 
@@ -281,8 +279,7 @@ Proof.
     wp_apply (wp_future_fulfill (V:=unit) (t:=go.StructType []) with "[$Hisfut $Hpromise $message]").
     done.
   }
-  wp_apply (wp_future_await (V:=unit) (t:=go.StructType []) with "[$Hisfut $HAwait]").
-  iIntros (v P pre post) "(%Hsplit & HP & _)".
+  wp_apply (wp_future_await (V:=unit) (t:=go.StructType []) with "[$Hisfut $HAwait]") as (v P pre post) "(%Hsplit & HP & _)" --no-auto.
   destruct pre; simpl in Hsplit; [injection Hsplit as <- | exfalso; by destruct pre].
   destruct post; [|done].
   wp_auto.
@@ -322,8 +319,7 @@ Proof.
     wp_apply (wp_future_fulfill (V:=unit) (t:=go.StructType []) with "[$Hisfut $Hpromise2 $world]").
     done.
   }
-  wp_apply (wp_future_await (V:=unit) (t:=go.StructType []) with "[$Hisfut $HAwait]").
-  iIntros (v1 P1 pre1 post1) "(%Hsplit1 & HP1 & HAwait)".
+  wp_apply (wp_future_await (V:=unit) (t:=go.StructType []) with "[$Hisfut $HAwait]") as (v1 P1 pre1 post1) "(%Hsplit1 & HP1 & HAwait)" --no-auto.
   (* Resolve which contract was fulfilled first *)
   destruct pre1 as [|? pre1']; simpl in Hsplit1;
     [ injection Hsplit1 as ? Hpost1; subst P1 post1; simpl in *
@@ -368,12 +364,9 @@ Lemma wp_BroadcastExample :
   {{{ RET #(); True }}}.
 Proof.
   wp_start. wp_auto.
-  wp_apply (chan.wp_make1).
-  iIntros (done_ch γdone) "(#Hdone_is_chan & _ & Hdone_own)". wp_auto. simpl.
-  wp_apply (chan.wp_make1).
-  iIntros (result1_ch γr1) "(#Hr1_is_chan & _ & Hr1_own)". wp_auto. simpl.
-  wp_apply (chan.wp_make1).
-  iIntros (result2_ch γr2) "(#Hr2_is_chan & _ & Hr2_own)". wp_auto. simpl.
+  wp_apply (chan.wp_make1) as (done_ch γdone) "(#Hdone_is_chan & _ & Hdone_own)". simpl.
+  wp_apply (chan.wp_make1) as (result1_ch γr1) "(#Hr1_is_chan & _ & Hr1_own)". simpl.
+  wp_apply (chan.wp_make1) as (result2_ch γr2) "(#Hr2_is_chan & _ & Hr2_own)". simpl.
   iMod (start_bag (λ v, ⌜v = W64 6⌝)%I with "Hr1_is_chan Hr1_own")
     as "#Hbag1".
   { done. }
@@ -405,9 +398,8 @@ Proof.
   iPersist "sharedValue".
   wp_apply (wp_broadcast_chan_close (ty:=go.ChannelType go.sendrecv (go.StructType [])) with "[$Hown_done $sharedValue]").
   iIntros "_". wp_auto.
-  wp_apply (wp_bag_receive with "Hbag1").
-  iIntros (v1) "%Hv1". subst v1. wp_auto.
-  wp_apply (wp_bag_receive with "Hbag2"). iIntros (v2) "%Hv2".
+  wp_apply (wp_bag_receive with "Hbag1") as (v1) "%Hv1" --no-auto. subst v1. wp_auto.
+  wp_apply (wp_bag_receive with "Hbag2") as (v2) "%Hv2" --no-auto.
   subst v2. wp_auto. by iApply "HΦ".
   Unshelve. all: try apply _. all: try exact sem.
 Qed.

--- a/new/proof/github_com/mit_pdos/perennial/goose/testdata/examples/channel_fibonacci.v
+++ b/new/proof/github_com/mit_pdos/perennial/goose/testdata/examples/channel_fibonacci.v
@@ -182,8 +182,7 @@ Proof.
     wp_apply wp_slice_literal. iSplitR; first done. iIntros "%sl0 [Hsl0 _]". wp_auto.
     iDestruct (slice.own_slice_len with "Hsl0") as "[%Hl0 %Hcap0]".
     iDestruct (slice.own_slice_len with "Hsl0") as "[%Hlen_slice0 %Hslgtz0]".
-    wp_apply (wp_slice_append with "[$Hsl $Hsl0 $oslc ]").
-    iIntros (sl') "Hsl'". wp_auto. wp_for_post. iFrame.
+    wp_apply (wp_slice_append with "[$Hsl $Hsl0 $oslc ]") as (sl') "Hsl'". wp_for_post. iFrame.
     iExists (S i). iDestruct "Hsl'" as "(Hsl & Hcap3 & Hsl0)".
     rewrite Hfib.
     rewrite fib_list_length. rewrite Nat2Z.id. do 2 rewrite <- fib_list_succ.

--- a/new/proof/github_com/mit_pdos/perennial/goose/testdata/examples/channel_google.v
+++ b/new/proof/github_com/mit_pdos/perennial/goose/testdata/examples/channel_google.v
@@ -169,8 +169,7 @@ Lemma wp_Google (q : go_string) :
       ∃ xs, sl ↦* xs ∗ ⌜xs ≡ₚ google_expected q⌝ }}}.
 Proof using All.
   wp_start. wp_auto.
-  wp_apply (chan.wp_make2 (W64 3)); first done.
-  iIntros (c γch) "(#Hchan & %Hcap3 & Hown)".
+  wp_apply (chan.wp_make2 (W64 3)) as (c γch) "(#Hchan & %Hcap3 & Hown)" --no-auto; first done.
   simpl in *.
   iMod (start_future
           (V:=go_string)
@@ -218,9 +217,7 @@ Proof using All.
               with "[$Hmf $Hprom_vid]");done.
   }
 
-  wp_apply (wp_slice_make3 (V:=go_string) (t:=go.string));first word.
-  iIntros (sl) "[Hsl [Hcap_sl %Hcap]]".
-  wp_auto.
+  wp_apply (wp_slice_make3 (V:=go_string) (t:=go.string)) as (sl) "[Hsl [Hcap_sl %Hcap]]";first word.
 
   iAssert (∃ (i : Z) (xs : list go_string)
                   (donek remk : list kind) (sl0 : slice.t),
@@ -262,9 +259,8 @@ Proof using All.
     iDestruct (contract_of_sound q k v with "HPv") as %->.
     wp_auto.
     wp_apply wp_slice_literal. iSplitR; first done. iIntros "% [Hsl1 _]". wp_auto.
-    wp_apply (wp_slice_append with "[$Hsl $Hcap $Hsl1]").
-    iIntros (sl') "[Hsl' Hcap']".
-    wp_auto. set j := length pre. set remk' := delete j remk.
+    wp_apply (wp_slice_append with "[$Hsl $Hcap $Hsl1]") as (sl') "[Hsl' Hcap']".
+    set j := length pre. set remk' := delete j remk.
     have Hj_lt_map : j < length (map (contract_of q) remk).
     {
       subst j. rewrite HsplitP. rewrite app_length /=.

--- a/new/proof/github_com/mit_pdos/perennial/goose/testdata/examples/channel_higher_order.v
+++ b/new/proof/github_com/mit_pdos/perennial/goose/testdata/examples/channel_higher_order.v
@@ -49,8 +49,7 @@ Qed.
   Proof using All.
 
   wp_start as "Hawait". iNamed "Hawait".
-  wp_apply (wp_future_await with "[$Hfut $HAwait]").
-  iIntros (v P pre post) "(%Hsplit & HP & _HAwait)".
+  wp_apply (wp_future_await with "[$Hfut $HAwait]") as (v P pre post) "(%Hsplit & HP & _HAwait)" --no-auto.
   destruct pre as [|? pre']; simpl in Hsplit.
   - injection Hsplit as <-.
     destruct post as [|? post']; last done.

--- a/new/proof/github_com/mit_pdos/perennial/goose/testdata/examples/channel_search_replace.v
+++ b/new/proof/github_com/mit_pdos/perennial/goose/testdata/examples/channel_search_replace.v
@@ -43,9 +43,8 @@ Lemma wp_worker (γs: chan_names) (ch: loc) (wg: loc) (x y: w64) :
 Proof.
   wp_start. iNamed "Hpre".
   wp_auto.
-  wp_apply (wp_bag_receive with "[$Hchan]").
-  iIntros (s) "Hrcv".
-  wp_auto. iPersist "y x".
+  wp_apply (wp_bag_receive with "[$Hchan]") as (s) "Hrcv".
+  iPersist "y x".
   iAssert (∃ s,
       "s" ∷ s_ptr ↦ s ∗
       "Hrcv" ∷ chanP wg x y s
@@ -69,9 +68,8 @@ Proof.
     { rewrite take_ge; last word. rewrite drop_ge; last word.
       rewrite app_nil_r. iFrame. }
     wp_for_post.
-    wp_apply (wp_bag_receive with "[$Hchan]").
-    iIntros (s') "Hrcv".
-    wp_auto. iFrame.
+    wp_apply (wp_bag_receive with "[$Hchan]") as (s') "Hrcv".
+    iFrame.
   - rewrite -> decide_True; last done. wp_auto.
     rewrite -> decide_True; last word.
     assert (sint.nat i < length xs)%nat as Hlt by word.

--- a/new/proof/github_com/mit_pdos/perennial/goose/testdata/examples/channel_select_tricky_examples.v
+++ b/new/proof/github_com/mit_pdos/perennial/goose/testdata/examples/channel_select_tricky_examples.v
@@ -223,9 +223,7 @@ Lemma wp_select_nb_full_buffer_not_ready :
 Proof.
   wp_start. wp_auto_lc 2.
 
-  wp_apply (chan.wp_make2); first done.
-  iIntros (ch γ) "(#His_chan & %Hcap & Hown)".
-  wp_auto.
+  wp_apply (chan.wp_make2) as (ch γ) "(#His_chan & %Hcap & Hown)"; first done.
 
   (* First send: use the empty-buffer AU to fill buffer to [0]. *)
   wp_apply (chan.wp_send ch (W64 0) γ with "[$His_chan]").

--- a/new/proof/github_com/mit_pdos/perennial/goose/testdata/examples/elimination_stack.v
+++ b/new/proof/github_com/mit_pdos/perennial/goose/testdata/examples/elimination_stack.v
@@ -61,8 +61,7 @@ Proof.
   wp_apply (wp_Mutex__Lock with "[$Hmu]"). iIntros "[Hlocked Hi]".
   iNamedSuffix "Hi" "_inv". wp_auto.
   wp_apply wp_slice_literal. iSplitR; first done. iIntros "% [Htmp _]". wp_auto.
-  wp_apply (wp_slice_append with "[$Hsl_inv $Hcap_inv $Htmp]").
-  iIntros (stack_sl') "(Hsl_inv & Hcap_inv & _)". wp_auto.
+  wp_apply (wp_slice_append with "[$Hsl_inv $Hcap_inv $Htmp]") as (stack_sl') "(Hsl_inv & Hcap_inv & _)".
   iApply fupd_wp. iMod "HΦ" as "(% & Hl & HΦ)". iCombine "Hl Hauth_inv" gives %[_ ->].
   iMod (ghost_var_update_2 with "Hl Hauth_inv") as "[Hl Hauth_inv]".
   { compute_done. }

--- a/new/proof/github_com/mit_pdos/perennial/goose/testdata/examples/lock.v
+++ b/new/proof/github_com/mit_pdos/perennial/goose/testdata/examples/lock.v
@@ -100,9 +100,7 @@ Proof.
   wp_start as "#HisLock".
   iNamed "HisLock".
   wp_auto.
-  wp_apply (wp_After).
-  iIntros (after_ch γafter_ch) "#Hafter_chan".
-  wp_auto_lc 2.
+  wp_apply (wp_After) as (after_ch γafter_ch) "#Hafter_chan" --lc 2.
   wp_apply chan.wp_select_blocking. simpl.
    iSplit.
   - simpl. iExists unit, l.(Lock.ch'), γ.(lchan_name), tt, _, _, _.

--- a/new/proof/github_com/tchajed/marshal.v
+++ b/new/proof/github_com/tchajed/marshal.v
@@ -148,8 +148,7 @@ Proof.
   assert (Hb: 0 ≤ sint.Z len ≤ sint.Z s.(slice.len) ≤ sint.Z s.(slice.len)) by word.
   iEval (rewrite (own_slice_slice len s.(slice.len) s q (head ++ tail) Hb)) in "Hs".
   iDestruct "Hs" as "(Hhead & Htail & _)".
-  wp_apply (wp_slice_copy with "[$Hsl $Hhead]").
-  iIntros (n) "(%Hn & Hsl & Hhead)". wp_auto.
+  wp_apply (wp_slice_copy with "[$Hsl $Hhead]") as (n) "(%Hn & Hsl & Hhead)".
   rewrite -> decide_True by word. wp_auto.
   iApply "HΦ".
   iSplitL "Hsl".
@@ -180,10 +179,8 @@ Theorem wp_ReadLenPrefixedBytes s q (len: u64) (head tail : list u8):
 Proof.
   iIntros (Hlen).
   wp_start as "Hs". wp_auto.
-  wp_apply (wp_ReadInt with "[$Hs]").
-  iIntros (?) "Hs". wp_auto.
-  wp_apply (wp_ReadBytes with "[$]"); first trivial.
-  iIntros (??) "[Hb Hs]". wp_auto.
+  wp_apply (wp_ReadInt with "[$Hs]") as (?) "Hs".
+  wp_apply (wp_ReadBytes with "[$]") as (? ?) "[Hb Hs]"; first trivial.
   iApply "HΦ". iFrame.
 Qed.
 
@@ -391,8 +388,7 @@ Theorem wp_WriteBytes s (vs : list u8) data_sl q (data : list u8) :
   }}}.
 Proof.
   wp_start as "(Hs & Hcap & Hdata)". wp_auto.
-  wp_apply (wp_slice_append with "[$Hs $Hdata $Hcap]").
-  iIntros (s') "(Hs' & Hcap' & Hdata')". wp_auto.
+  wp_apply (wp_slice_append with "[$Hs $Hdata $Hcap]") as (s') "(Hs' & Hcap' & Hdata')".
   iApply "HΦ". iFrame.
 Qed.
 
@@ -412,10 +408,8 @@ Theorem wp_WriteLenPrefixedBytes s (vs : list u8) data_sl q (data : list u8) :
   }}}.
 Proof.
   wp_start as "(Hs & Hdata & Hscap)". wp_auto.
-  wp_apply (wp_WriteInt with "[$Hs $Hscap]").
-  iIntros (s') "[Hs' Hscap]". wp_auto.
-  wp_apply (wp_WriteBytes with "[$Hs' $Hdata $Hscap]").
-  iIntros (s'0) "(Hs & Hscap & Hdata)". wp_auto.
+  wp_apply (wp_WriteInt with "[$Hs $Hscap]") as (s') "[Hs' Hscap]".
+  wp_apply (wp_WriteBytes with "[$Hs' $Hdata $Hscap]") as (s'0) "(Hs & Hscap & Hdata)".
   iApply "HΦ".
   rewrite -app_assoc.
   iDestruct (own_slice_len with "Hdata") as "[%Hdlen %]".
@@ -436,12 +430,10 @@ Proof.
   wp_start as "[Hs Hcap]". wp_auto.
   destruct b; wp_auto.
   - wp_apply wp_slice_literal. iSplitR; first done. iIntros "% [Hsl _]". wp_auto.
-    wp_apply (wp_slice_append with "[$Hs $Hcap $Hsl]").
-    iIntros (s') "(Hs' & Hcap' & _)". wp_auto.
+    wp_apply (wp_slice_append with "[$Hs $Hcap $Hsl]") as (s') "(Hs' & Hcap' & _)".
     iApply "HΦ". iFrame.
   - wp_apply wp_slice_literal. iSplitR; first done. iIntros "% [Hsl _]". wp_auto.
-    wp_apply (wp_slice_append with "[$Hs $Hcap $Hsl]").
-    iIntros (s') "(Hs' & Hcap' & _)". wp_auto.
+    wp_apply (wp_slice_append with "[$Hs $Hcap $Hsl]") as (s') "(Hs' & Hcap' & _)".
     iApply "HΦ". iFrame.
 Qed.
 

--- a/new/proof/go_etcd_io/raft/v3.v
+++ b/new/proof/go_etcd_io/raft/v3.v
@@ -25,8 +25,7 @@ Lemma wp_Node__Propose  ctx ctx_desc n γraft data_sl data :
   {{{ (err : error.t), RET #err; True }}}.
 Proof.
   wp_start. iNamed "Hpre". iNamed "Hnode". subst. simpl.
-  wp_apply (wp_node__Propose with "[$]").
-  iIntros (?) "_". by iApply "HΦ".
+  wp_apply (wp_node__Propose with "[$]") as (?) "_" --no-auto. by iApply "HΦ".
 Qed.
 
 End proof.

--- a/new/proof/strings.v
+++ b/new/proof/strings.v
@@ -109,8 +109,7 @@ Example wp_Fields_mixed_ws :
       sl ↦* ["hello"%go; "there"%go; "general"%go; "kenobi"%go] ∗ own_slice_cap w8 sl (DfracOwn 1) }}}.
 Proof.
   iIntros (Φ) "#Hinit HΦ".
-  wp_apply (wp_Fields).
-  iIntros (sl) "(Hsl & Hcap)".
+  wp_apply (wp_Fields) as (sl) "(Hsl & Hcap)" --no-auto.
   iApply "HΦ". iFrame.
 Qed.
 
@@ -124,8 +123,7 @@ Example wp_Fields_two_words:
   }}}.
 Proof.
   iIntros (Φ) "#Hinit HΦ".
-  wp_apply (wp_Fields "hello world"%go).
-  iIntros (sl) "(Hsl & Hcap)".
+  wp_apply (wp_Fields "hello world"%go) as (sl) "(Hsl & Hcap)" --no-auto.
   iApply "HΦ". iFrame.
 Qed.
 

--- a/new/proof/sync_proof/mutex.v
+++ b/new/proof/sync_proof/mutex.v
@@ -47,8 +47,7 @@ Lemma wp_Mutex__TryLock m R :
   {{{ (locked : bool), RET #locked; if locked then own_Mutex m ∗ R else True }}}.
 Proof.
   wp_start as "#His".
-  wp_apply (wp_lock_trylock with "[$His]").
-  iIntros (locked) "H".
+  wp_apply (wp_lock_trylock with "[$His]") as (locked) "H" --no-auto.
   iApply "HΦ".
   done.
 Qed.


### PR DESCRIPTION
Support introducing Coq-level binders in the wp_apply tactic, similar to other IPM tactics.

The motivation is that, when using Claude to do other Perennial proofs, it kept wanting to write wp_apply in this style.

These proofs themselves were also largely done using Claude.